### PR TITLE
Fix for NegativeArraySizeException when deserializing RoaringArray

### DIFF
--- a/src/main/java/org/roaringbitmap/RoaringArray.java
+++ b/src/main/java/org/roaringbitmap/RoaringArray.java
@@ -299,7 +299,7 @@ public final class RoaringArray implements Cloneable, Externalizable {
         final byte[] buffer = new byte[2];
         // little endian
         in.readFully(buffer4);
-        final int cookie = buffer4[0] | ((buffer4[1] & 0xFF) << 8)
+        final int cookie = (buffer4[0] & 0xFF) | ((buffer4[1] & 0xFF) << 8)
                 | ((buffer4[2] & 0xFF) << 16)
                 | ((buffer4[3] & 0xFF) << 24);
         if (cookie != serialCookie)
@@ -307,7 +307,7 @@ public final class RoaringArray implements Cloneable, Externalizable {
                     "I failed to find the right cookie.");
 
         in.readFully(buffer4);
-        this.size = buffer4[0] | ((buffer4[1] & 0xFF) << 8)
+        this.size = (buffer4[0] & 0xFF) | ((buffer4[1] & 0xFF) << 8)
                 | ((buffer4[2] & 0xFF) << 16)
                 | ((buffer4[3] & 0xFF) << 24);
         if ((this.array == null) || (this.array.length < this.size))

--- a/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -1284,6 +1284,26 @@ public class TestRoaringBitmap {
         Assert.assertTrue(rr.equals(rrback));
     }
 
+    @Test
+    public void testSerialization4() throws IOException, ClassNotFoundException {
+      final RoaringBitmap rr = new RoaringBitmap();
+      for (int k = 1; k <= 10000000; k+=10)
+        rr.add(k);
+      final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+      // Note: you could use a file output steam instead of
+      // ByteArrayOutputStream
+      int howmuch = rr.serializedSizeInBytes();
+      final DataOutputStream oo = new DataOutputStream(bos);
+      rr.serialize(oo);
+      oo.close();
+      Assert.assertEquals(howmuch, bos.toByteArray().length);
+      final RoaringBitmap rrback = new RoaringBitmap();
+      final ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
+      rrback.deserialize(new DataInputStream(bis));
+      Assert.assertEquals(rr.getCardinality(), rrback.getCardinality());
+      Assert.assertTrue(rr.equals(rrback));
+    }
+
 
     @Test
     public void XORtest() {


### PR DESCRIPTION
RoaringArray doesn't mask first byte when deserializing the size of the array, thereby extending the sign of the byte to the resulting int. This can cause NegativeArraySizeException when deserializing bitmaps. Commit includes fix (masking with 0xFF) and test.
