### PR TITLE
Repairing short underflow issue in iterators

### DIFF
--- a/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -652,11 +652,11 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
 
             @Override
             public boolean hasNext() {
-                return pos < RoaringBitmap.this.highLowContainer.size();
+                return 0 <= pos && pos < RoaringBitmap.this.highLowContainer.size();
             }
 
             public Iterator<Integer> init() {
-                if (pos < RoaringBitmap.this.highLowContainer.size()) {
+                if (0 <= pos && pos < RoaringBitmap.this.highLowContainer.size()) {
                     iter = RoaringBitmap.this.highLowContainer.getContainerAtIndex(pos).getShortIterator();
                     hs = Util.toIntUnsigned(RoaringBitmap.this.highLowContainer.getKeyAtIndex(pos)) << 16;
                 }
@@ -916,11 +916,11 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
 
         @Override
         public boolean hasNext() {
-            return pos < RoaringBitmap.this.highLowContainer.size();
+            return 0 <= pos && pos < RoaringBitmap.this.highLowContainer.size();
         }
 
         public IntIterator init() {
-            if (pos < RoaringBitmap.this.highLowContainer.size()) {
+            if (0 <= pos && pos < RoaringBitmap.this.highLowContainer.size()) {
                 iter = RoaringBitmap.this.highLowContainer.getContainerAtIndex(pos).getShortIterator();
                 hs = Util.toIntUnsigned(RoaringBitmap.this.highLowContainer.getKeyAtIndex(pos)) << 16;
             }

--- a/src/test/java/org/roaringbitmap/TestIterators.java
+++ b/src/test/java/org/roaringbitmap/TestIterators.java
@@ -1,0 +1,72 @@
+package org.roaringbitmap;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Random;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestIterators {
+    @Test
+    public void testIteration() {
+        final Random source = new Random(0xcb000a2b9b5bdfb6l);
+        final int[] data = takeSortedAndDistinct(source, 450_000);
+
+        RoaringBitmap bitmap = RoaringBitmap.bitmapOf(data);
+        Assert.assertArrayEquals(data, copyOf(bitmap.iterator()));
+        Assert.assertArrayEquals(data, copyOf(bitmap.getIntIterator()));
+    }
+
+    private int[] takeSortedAndDistinct(Random source, int count) {
+        LinkedHashSet<Integer> ints = new LinkedHashSet<Integer>(count);
+        for (int size = 0; size < count; size++) {
+            int next;
+            do {
+                next = Math.abs(source.nextInt());
+            } while (!ints.add(next));
+        }
+        int[] unboxed = copyOf(ints.iterator());
+        Arrays.sort(unboxed);
+        return unboxed;
+    }
+
+    private static int[] copyOf(Iterator<Integer> ints) {
+        class IntIteratorAdapter implements IntIterator {
+            private final Iterator<Integer> ints;
+
+            IntIteratorAdapter(Iterator<Integer> ints) {
+                this.ints = ints;
+            }
+
+            @Override
+            public boolean hasNext() {
+                return ints.hasNext();
+            }
+
+            @Override
+            public int next() {
+                return ints.next();
+            }
+
+            @Override
+            public IntIterator clone() {
+                throw new UnsupportedOperationException();
+            }
+        }
+        return copyOf(new IntIteratorAdapter(ints));
+    }
+
+    private static int[] copyOf(IntIterator ints) {
+        int[] values = new int[10];
+        int size = 0;
+        while (ints.hasNext()) {
+            if (!(size < values.length)) {
+                values = java.util.Arrays.copyOf(values, values.length * 2);
+            }
+            values[size++] = ints.next();
+        }
+        return Arrays.copyOf(values, size);
+    }
+
+}


### PR DESCRIPTION
If the bitmap has Short.MAX_VALUE containers, the iterators would previously throw java.lang.ArrayIndexOutOfBoundsException: -32768 instead of returning `false` from `#hasNext`
