### PR TITLE
fixed bug on hashCode() method. It entered an infinite loop.

### DIFF
--- a/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringArray.java
+++ b/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringArray.java
@@ -410,6 +410,7 @@ public final class ImmutableRoaringArray implements PointableRoaringArray {
         while (cp.hasContainer()) {
             int th = cp.key() * 0xF0F0F0 + cp.getContainer().hashCode();
             hashvalue = 31 * hashvalue + th;
+            cp.advance();
         }
         return hashvalue;
     }


### PR DESCRIPTION
fixed: The container pointer wasn't advanced, and when adding an instance to a Map the application hanged.

The equals() method should also be implemented to be consistent with the hashCode(). I don't know exactly when two arrays should be considered equal ( checking every single byte might be too expensive, depending on how the arrays are used )