### PR TITLE
fix: java.lang.ClassCastException

### DIFF
--- a/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -510,7 +510,7 @@ public class ImmutableRoaringBitmap implements Iterable<Integer>, Cloneable, Imm
     @Override
     public ImmutableRoaringBitmap clone() {
         try {
-            final ImmutableRoaringBitmap x = (MutableRoaringBitmap) super
+            final ImmutableRoaringBitmap x = (ImmutableRoaringBitmap) super
                     .clone();
             x.highLowContainer = highLowContainer.clone();
             return x;


### PR DESCRIPTION
org.roaringbitmap.buffer.ImmutableRoaringBitmap cannot be cast to org.roaringbitmap.buffer.MutableRoaringBitmap