### PR TITLE
squid:S2293 - The diamond operator ("<>") should be used

### DIFF
--- a/src/main/java/org/roaringbitmap/FastAggregation.java
+++ b/src/main/java/org/roaringbitmap/FastAggregation.java
@@ -227,7 +227,7 @@ public final class FastAggregation {
         final boolean[] istmp = new boolean[buffer.length];
         for(int k = 0 ; k < sizes.length; ++k)
             sizes[k] = buffer[k].getSizeInBytes();
-        PriorityQueue<Integer> pq = new PriorityQueue<Integer>(128, new Comparator<Integer>() {
+        PriorityQueue<Integer> pq = new PriorityQueue<>(128, new Comparator<Integer>() {
             @Override
             public int compare(Integer a,
                     Integer b) {
@@ -277,14 +277,14 @@ public final class FastAggregation {
         if (!bitmaps.hasNext())
             return new RoaringBitmap();
         // we buffer the call to getSizeInBytes(), hence the code complexity
-        ArrayList<RoaringBitmap> buffer = new ArrayList<RoaringBitmap>();
+        ArrayList<RoaringBitmap> buffer = new ArrayList<>();
         while(bitmaps.hasNext())
             buffer.add(bitmaps.next());
         final int[] sizes = new int[buffer.size()];
         final boolean[] istmp = new boolean[buffer.size()];
         for(int k = 0 ; k < sizes.length; ++k)
             sizes[k] = buffer.get(k).getSizeInBytes();
-        PriorityQueue<Integer> pq = new PriorityQueue<Integer>(128, new Comparator<Integer>() {
+        PriorityQueue<Integer> pq = new PriorityQueue<>(128, new Comparator<Integer>() {
             @Override
             public int compare(Integer a,
                     Integer b) {
@@ -336,7 +336,7 @@ public final class FastAggregation {
         RoaringBitmap answer = new RoaringBitmap();
         if (bitmaps.length == 0)
             return answer;
-        PriorityQueue<ContainerPointer> pq = new PriorityQueue<ContainerPointer>(bitmaps.length);
+        PriorityQueue<ContainerPointer> pq = new PriorityQueue<>(bitmaps.length);
         for(int k = 0; k < bitmaps.length; ++k) {
             ContainerPointer x = bitmaps[k].highLowContainer.getContainerPointer();
             if(x.getContainer() != null)
@@ -388,7 +388,7 @@ public final class FastAggregation {
         RoaringBitmap answer = new RoaringBitmap();
         if (bitmaps.isEmpty())
             return answer;
-        PriorityQueue<ContainerPointer> pq = new PriorityQueue<ContainerPointer>(bitmaps.size());
+        PriorityQueue<ContainerPointer> pq = new PriorityQueue<>(bitmaps.size());
         for(int k = 0; k < bitmaps.size(); ++k) {
             ContainerPointer x = bitmaps.get(k).highLowContainer.getContainerPointer();
             if(x.getContainer() != null)
@@ -441,7 +441,7 @@ public final class FastAggregation {
         if (bitmaps.length == 0)
             return new RoaringBitmap();
 
-        PriorityQueue<RoaringBitmap> pq = new PriorityQueue<RoaringBitmap>(bitmaps.length, new Comparator<RoaringBitmap>() {
+        PriorityQueue<RoaringBitmap> pq = new PriorityQueue<>(bitmaps.length, new Comparator<RoaringBitmap>() {
             @Override
             public int compare(RoaringBitmap a,
                                RoaringBitmap b) {
@@ -470,7 +470,7 @@ public final class FastAggregation {
         RoaringBitmap answer = new RoaringBitmap();
         if (bitmaps.length == 0)
             return answer;
-        PriorityQueue<ContainerPointer> pq = new PriorityQueue<ContainerPointer>(bitmaps.length);
+        PriorityQueue<ContainerPointer> pq = new PriorityQueue<>(bitmaps.length);
         for(int k = 0; k < bitmaps.length; ++k) {
             ContainerPointer x = bitmaps[k].highLowContainer.getContainerPointer();
             if(x.getContainer() != null)

--- a/src/main/java/org/roaringbitmap/buffer/BufferFastAggregation.java
+++ b/src/main/java/org/roaringbitmap/buffer/BufferFastAggregation.java
@@ -359,7 +359,7 @@ public final class BufferFastAggregation {
         MutableRoaringBitmap answer = new MutableRoaringBitmap();
         if (bitmaps.length == 0)
             return answer;
-        PriorityQueue<MappeableContainerPointer> pq = new PriorityQueue<MappeableContainerPointer>(
+        PriorityQueue<MappeableContainerPointer> pq = new PriorityQueue<>(
                 bitmaps.length);
         for (int k = 0; k < bitmaps.length; ++k) {
             MappeableContainerPointer x = bitmaps[k].highLowContainer
@@ -432,7 +432,7 @@ public final class BufferFastAggregation {
         MutableRoaringBitmap answer = new MutableRoaringBitmap();
         if (bitmaps.length == 0)
             return answer;
-        PriorityQueue<MappeableContainerPointer> pq = new PriorityQueue<MappeableContainerPointer>(
+        PriorityQueue<MappeableContainerPointer> pq = new PriorityQueue<>(
                 bitmaps.length);
         for (int k = 0; k < bitmaps.length; ++k) {
             MappeableContainerPointer x = bitmaps[k].highLowContainer
@@ -496,7 +496,7 @@ public final class BufferFastAggregation {
         final boolean[] istmp = new boolean[buffer.length];
         for(int k = 0 ; k < sizes.length; ++k)
             sizes[k] = buffer[k].serializedSizeInBytes();
-        PriorityQueue<Integer> pq = new PriorityQueue<Integer>(128, new Comparator<Integer>() {
+        PriorityQueue<Integer> pq = new PriorityQueue<>(128, new Comparator<Integer>() {
             @Override
             public int compare(Integer a,
                     Integer b) {
@@ -547,14 +547,14 @@ public final class BufferFastAggregation {
         if (!bitmaps.hasNext())
             return new MutableRoaringBitmap();
         // we buffer the call to getSizeInBytes(), hence the code complexity
-        ArrayList<ImmutableRoaringBitmap> buffer = new ArrayList<ImmutableRoaringBitmap>();
+        ArrayList<ImmutableRoaringBitmap> buffer = new ArrayList<>();
         while(bitmaps.hasNext())
             buffer.add((ImmutableRoaringBitmap) bitmaps.next());
         final int[] sizes = new int[buffer.size()];
         final boolean[] istmp = new boolean[buffer.size()];
         for(int k = 0 ; k < sizes.length; ++k)
             sizes[k] = buffer.get(k).getSizeInBytes();
-        PriorityQueue<Integer> pq = new PriorityQueue<Integer>(128, new Comparator<Integer>() {
+        PriorityQueue<Integer> pq = new PriorityQueue<>(128, new Comparator<Integer>() {
             @Override
             public int compare(Integer a,
                     Integer b) {
@@ -607,7 +607,7 @@ public final class BufferFastAggregation {
         // code could be faster, see priorityqueue_or
         if (bitmaps.length < 2)
             throw new IllegalArgumentException("Expecting at least 2 bitmaps");
-        final PriorityQueue<ImmutableRoaringBitmap> pq = new PriorityQueue<ImmutableRoaringBitmap>(
+        final PriorityQueue<ImmutableRoaringBitmap> pq = new PriorityQueue<>(
                 bitmaps.length, new Comparator<ImmutableRoaringBitmap>() {
                     @Override
                     public int compare(ImmutableRoaringBitmap a,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2293 - The diamond operator ("<>") should be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
George Kankava