### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -804,7 +804,7 @@ public final class BitmapContainer extends Container implements Cloneable {
         final int x = Util.toIntUnsigned(i);
         int index = x / 64;
         long bef = bitmap[index];
-        long mask = (1L << x);
+        long mask = 1L << x;
         if (cardinality == ArrayContainer.DEFAULT_MAX_SIZE + 1) {// this is
             // the
             // uncommon
@@ -887,7 +887,7 @@ public final class BitmapContainer extends Container implements Cloneable {
         for (int k = 0; k < c; ++k) {
             short vc =  value2.content[k];
             final int index = Util.toIntUnsigned(vc) >>> 6;
-            final long mask = (1L << vc);
+            final long mask = 1L << vc;
             final long val = answer.bitmap[index];
             // TODO: check whether a branchy version could be faster
             answer.cardinality += 1 - 2 * ((val & mask) >>> vc);

--- a/src/main/java/org/roaringbitmap/RoaringArray.java
+++ b/src/main/java/org/roaringbitmap/RoaringArray.java
@@ -359,7 +359,7 @@ public final class RoaringArray implements Cloneable, Externalizable {
         }
         for (int k = 0; k < size; ++k) {
             out.writeShort(Short.reverseBytes(this.keys[k]));
-            out.writeShort(Short.reverseBytes((short) ((this.values[k].getCardinality() - 1))));
+            out.writeShort(Short.reverseBytes((short) (this.values[k].getCardinality() - 1)));
         }
         if((! hasrun) || (this.size >= NO_OFFSET_THRESHOLD) ) {
             //writing the containers offsets

--- a/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/src/main/java/org/roaringbitmap/RunContainer.java
@@ -787,7 +787,7 @@ public final class RunContainer extends Container implements Cloneable {
         //could try using unsignedInterleavedBinarySearch(valueslength, 0, nbrruns, rangeStart) instead of sequential scan
         //to find the starting location
 
-        for(; (k < myNbrRuns) && ((Util.toIntUnsigned(this.getValue(k)) < rangeStart)) ; ++k) {
+        for(; (k < myNbrRuns) && (Util.toIntUnsigned(this.getValue(k)) < rangeStart) ; ++k) {
             // since it is atop self, there is no copying needed
             //ans.valueslength[2 * k] = this.valueslength[2 * k];
             //ans.valueslength[2 * k + 1] = this.valueslength[2 * k + 1];
@@ -880,7 +880,7 @@ public final class RunContainer extends Container implements Cloneable {
         if (rangeEnd <= rangeStart) return this.clone();
         RunContainer ans = new RunContainer(nbrruns+1);
         int k = 0;
-        for(; (k < this.nbrruns) && ((Util.toIntUnsigned(this.getValue(k)) < rangeStart)) ; ++k) {
+        for(; (k < this.nbrruns) && (Util.toIntUnsigned(this.getValue(k)) < rangeStart) ; ++k) {
                 ans.valueslength[2 * k] = this.valueslength[2 * k];
                 ans.valueslength[2 * k + 1] = this.valueslength[2 * k + 1];
                 ans.nbrruns++;
@@ -1941,7 +1941,7 @@ public final class RunContainer extends Container implements Cloneable {
         }
 
         while (rlepos < nbrruns) {
-            this.smartAppend(this.getValue(offset + rlepos), this.getLength((offset + rlepos)));
+            this.smartAppend(this.getValue(offset + rlepos), this.getLength(offset + rlepos));
             ++rlepos;
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava