### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringArray.java
+++ b/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringArray.java
@@ -45,7 +45,7 @@ public final class ImmutableRoaringArray implements PointableRoaringArray {
     if ((cookie & 0xFFFF) != SERIAL_COOKIE && cookie != SERIAL_COOKIE_NO_RUNCONTAINER) {
       throw new RuntimeException("I failed to find one of the right cookies. " + cookie);
     }
-    boolean hasRunContainers = ((cookie & 0xFFFF) == SERIAL_COOKIE);
+    boolean hasRunContainers = (cookie & 0xFFFF) == SERIAL_COOKIE;
     this.size = hasRunContainers ? (cookie >>> 16) + 1 : buffer.getInt(4);
     int theLimit = size > 0 ? computeSerializedSizeInBytes() : headerSize(hasRunContainers);
     buffer.limit(theLimit);

--- a/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -503,7 +503,7 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
   public MappeableContainer flip(short i) {
     final int x = BufferUtil.toIntUnsigned(i);
     final long bef = bitmap.get(x / 64);
-    final long mask = (1L << x);
+    final long mask = 1L << x;
     if (cardinality == MappeableArrayContainer.DEFAULT_MAX_SIZE + 1) {// this
                                                                       // is
       // the
@@ -981,7 +981,7 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
       int c = value2.cardinality;
       for (int k = 0; k < c; ++k) {
         short vc = v2[k];
-        long mask = (1L << v2[k]);
+        long mask = 1L << v2[k];
         final int index = BufferUtil.toIntUnsigned(vc) >>> 6;
         long ba = b[index];
         // TODO: check whether a branchy version could be faster
@@ -993,7 +993,7 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
       int c = value2.cardinality;
       for (int k = 0; k < c; ++k) {
         short v2 = value2.content.get(k);
-        long mask = (1L << v2);
+        long mask = 1L << v2;
         final int index = BufferUtil.toIntUnsigned(v2) >>> 6;
         long ba = b[index];
         // TODO: check whether a branchy version could be faster

--- a/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -1205,7 +1205,7 @@ public final class MappeableRunContainer extends MappeableContainer implements C
     // of sequential scan
     // to find the starting location
 
-    for (; (k < myNbrRuns) && ((BufferUtil.toIntUnsigned(this.getValue(k)) < rangeStart)); ++k) {
+    for (; k < myNbrRuns && BufferUtil.toIntUnsigned(this.getValue(k)) < rangeStart; ++k) {
       // since it is atop self, there is no copying needed
       // ans.valueslength[2 * k] = this.valueslength[2 * k];
       // ans.valueslength[2 * k + 1] = this.valueslength[2 * k + 1];
@@ -1761,8 +1761,8 @@ public final class MappeableRunContainer extends MappeableContainer implements C
 
     if (isArrayBacked()) {
       short[] myVl = valueslength.array();
-      for (; (k < this.nbrruns)
-          && ((BufferUtil.toIntUnsigned(getValue(myVl, k)) < rangeStart)); ++k) {
+      for (; k < this.nbrruns
+          && BufferUtil.toIntUnsigned(getValue(myVl, k)) < rangeStart; ++k) {
         vl[2 * k] = myVl[2 * k];
         vl[2 * k + 1] = myVl[2 * k + 1];
         ans.nbrruns++;
@@ -1773,8 +1773,8 @@ public final class MappeableRunContainer extends MappeableContainer implements C
       }
     } else { // not array backed
 
-      for (; (k < this.nbrruns)
-          && ((BufferUtil.toIntUnsigned(this.getValue(k)) < rangeStart)); ++k) {
+      for (; k < this.nbrruns
+          && BufferUtil.toIntUnsigned(this.getValue(k)) < rangeStart; ++k) {
         vl[2 * k] = getValue(k);
         vl[2 * k + 1] = getLength(k);
         ans.nbrruns++;

--- a/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
+++ b/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
@@ -522,7 +522,7 @@ public final class MutableRoaringArray implements Cloneable, Externalizable, Poi
     }
     for (int k = 0; k < size; ++k) {
       out.writeShort(Short.reverseBytes(this.keys[k]));
-      out.writeShort(Short.reverseBytes((short) ((this.values[k].getCardinality() - 1))));
+      out.writeShort(Short.reverseBytes((short) (this.values[k].getCardinality() - 1)));
     }
     if ((!hasrun) || (this.size >= NO_OFFSET_THRESHOLD)) {
       for (int k = 0; k < this.size; k++) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava