### PR TITLE
Checkstyle fixes

### DIFF
--- a/jmh/run.sh
+++ b/jmh/run.sh
@@ -2,18 +2,23 @@
 BASEDIR=$(dirname $0)
 
 
-
 echo "Building RoaringBitmap jar"
 rm -f $BASEDIR/../target/RoaringBitmap*.jar
 mvn -f $BASEDIR/../pom.xml clean install -DskipTests -Dgpg.skip=true
+
+[[ $? -eq 0 ]] || exit
 
 echo "Building Real Roaring Dataset jar"
 rm -f $BASEDIR/../real-roaring-dataset/target/real-roaring-dataset*.jar
 mvn -f $BASEDIR/../real-roaring-dataset/pom.xml clean install
 
+[[ $? -eq 0 ]] || exit
+
 echo "Building benchmarks jar"
 rm -f  $BASEDIR/target/benchmarks.jar
 mvn -f $BASEDIR/pom.xml clean install -Dtest=*$1* -DfailIfNoTests=false
+
+[[ $? -eq 0 ]] || exit
 
 echo "Running benchmarks"
 java -jar $BASEDIR/target/benchmarks.jar  true -wi 5 -i 5 -f 1 $1

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>LATEST</version>
+            <version>6.19</version>
           </dependency>
           <dependency>
             <groupId>org.apache.maven.plugins</groupId>

--- a/style/roaring_google_checks.xml
+++ b/style/roaring_google_checks.xml
@@ -57,7 +57,7 @@
         <module name="RightCurly"/>
         <module name="RightCurly">
             <property name="option" value="alone"/>
-            <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/>
+            <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
         </module>
         <!--<module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>


### PR DESCRIPTION
Hey,

can someone please verify, if the current master branch can not be built because of checkstyle violations? Because here it does:

``
$ mvn clean package -DskipTests -Dgpg.skip=true
`` 

It does so on do/while blocks, when the "while" statement is put on the same line as the curly bracket.

If this is wanted, then i fixed those violations.

I also added checks for "run.sh" in the jmh folder, so that it fails, whenever one of the "mvn" commands fails. Right now it always ran through and jmh used old deployed versions of the jars (grrrr, took me some time to figure out, that it failed bcs of checkstyle)
