### PR TITLE
Add missing shebang to memory/run.sh

### DIFF
--- a/memory/run.sh
+++ b/memory/run.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 BASEDIR=$(dirname $0)
 
 echo "Building RoaringBitmap jar"


### PR DESCRIPTION
Using /usr/bin/env bash as suggested by the top SO answer:
http://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang