### PR TITLE
Fine tune array-array intersection algorithm #63

### DIFF
--- a/jmh/pom.xml
+++ b/jmh/pom.xml
@@ -38,7 +38,12 @@
         <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
-            <version>[0.5.6-SNAPSHOT,)</version><!-- we use an open interval, hoping that we pick up the last version --> 
+            <version>[0.6.28-SNAPSHOT,)</version><!-- we use an open interval, hoping that we pick up the last version -->
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>3.6.1</version>
         </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>
@@ -65,7 +70,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jmh.version>[1.10.1,)</jmh.version>
+        <jmh.version>1.16</jmh.version>
         <javac.target>1.7</javac.target>
         <uberjar.name>benchmarks</uberjar.name>
     </properties>

--- a/jmh/pom.xml
+++ b/jmh/pom.xml
@@ -56,6 +56,11 @@
             <version>0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>me.lemire.integercompression</groupId>
+            <artifactId>JavaFastPFOR</artifactId>
+            <version>[0.1,)</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>

--- a/jmh/src/main/java/org/roaringbitmap/UtilBechmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/UtilBechmark.java
@@ -1,0 +1,118 @@
+package org.roaringbitmap;
+
+import org.apache.commons.math3.distribution.IntegerDistribution;
+import org.apache.commons.math3.distribution.UniformIntegerDistribution;
+import org.apache.commons.math3.random.Well19937c;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+public class UtilBechmark {
+
+    @Param({"0", "1", "2", "3", "4"})
+    public int index;
+    @Param({"10","15","20","25","30","35", "40", "50","60", "90"})
+    public int param;
+
+    public static BenchmarkData data;
+
+    @Setup
+    public void setup() {
+        data = BenchmarkDataGenerator.generate(param, 5);
+    }
+
+    @Benchmark
+    public void galloping() {
+        BenchmarkContainer small = data.small[index];
+        BenchmarkContainer big = data.big[index];
+        Util.unsignedOneSidedGallopingIntersect2by2(small.content, small.length, big.content, big.length, data.dest);
+    }
+
+    @Benchmark
+    public void local() {
+        BenchmarkContainer small = data.small[index];
+        BenchmarkContainer big = data.big[index];
+        Util.unsignedLocalIntersect2by2(small.content, small.length, big.content, big.length, data.dest);
+    }
+
+    public static void main(String[] arg) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(".*" + UtilBechmark.class.getSimpleName() + ".*")
+                .warmupIterations(12)
+                .measurementIterations(7)
+                .forks(1)
+                .build();
+        new Runner(opt).run();
+    }
+}
+
+class BenchmarkData {
+    BenchmarkData(BenchmarkContainer[] small, BenchmarkContainer[] big) {
+        this.small = small;
+        this.big = big;
+        this.dest = new short[Short.MAX_VALUE];
+    }
+    final BenchmarkContainer[] small;
+    final BenchmarkContainer[] big;
+    final short[] dest;
+}
+
+class BenchmarkContainer {
+    BenchmarkContainer(short[] content) {
+        this.content = content;
+        this.length = content.length;
+    }
+    final short[] content;
+    final int length;
+}
+
+/**
+ * Deterministic generator for benchmark data.
+ * For given *param* it generates *howmany* entries
+ */
+class BenchmarkDataGenerator {
+    static BenchmarkData generate(int param, int howMany) {
+        IntegerDistribution ud = new UniformIntegerDistribution(new Well19937c(param + 17), Short.MIN_VALUE, Short.MAX_VALUE);
+        IntegerDistribution p = new UniformIntegerDistribution(new Well19937c(param + 123), SMALLEST_ARRAY, BIGGEST_ARRAY / param);
+        BenchmarkContainer[] smalls = new BenchmarkContainer[howMany];
+        BenchmarkContainer[] bigs =  new BenchmarkContainer[howMany];
+        for (int i = 0; i < howMany; i++) {
+            int smallSize = p.sample();
+            int bigSize = smallSize * param;
+            short[] small = intArrayToShortArraySorted(ud.sample(smallSize));
+            short[] big = intArrayToShortArraySorted(ud.sample(bigSize));
+            smalls[i] = new BenchmarkContainer(small);
+            bigs[i] = new BenchmarkContainer(big);
+        }
+        return new BenchmarkData(smalls, bigs);
+    }
+
+    private static short[] intArrayToShortArraySorted(int[] source) {
+        short[] result = new short[source.length];
+        for (int i = 0; i < source.length; i++) {
+            result[i] = (short) source[i];
+        }
+        Arrays.sort(result);
+        return result;
+    }
+
+    private final static int SMALLEST_ARRAY = 50;
+    private final static int BIGGEST_ARRAY = 2 * Short.MAX_VALUE;
+}
+
+

--- a/jmh/src/main/java/org/roaringbitmap/UtilBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/UtilBenchmark.java
@@ -12,29 +12,31 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.runner.Runner;
-import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
-import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * The experiment to test the threshold when it is worth to use galloping strategy of intersecting sorted lists.
+ * It allows to generate sample lists where first is *param* times bigger than other one.
+ * Both lists can be generated used uniform or clustered distribution.
+ * The methodology and results are presented in the issue #63 on Github.
+ */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 public class UtilBenchmark {
 
-    @Param({"0", "1"})
-    public int smallType; // 0 - uniform, 1 - clustered
-    @Param({"0", "1"})
-    public int bigType;   // 0 - uniform, 1 - clustered
-    @Param({"0", "1", "2", "3", "4"})  // update GENERATE_EXAMPLES if changing this
+    @Param({"0"})           // use {"0", "1"} to test both uniform and clustered combinations
+    public int smallType;   // 0 - uniform, 1 - clustered
+    @Param({"0"})           // use {"0", "1"} to test both uniform and clustered combinations
+    public int bigType;     // 0 - uniform, 1 - clustered
+    @Param({"0"})           // use {"0", "1", "2"} for three experiments. Update GENERATE_EXAMPLES if changing this
     public int index;
-    @Param({"15", "25", "30", "35", "45", "60"})
+    @Param({"25"})          // use {"20", "25", "30"} to check different thresholds
     public int param;
 
-    private static final int GENERATE_EXAMPLES = 5;
+    private static final int GENERATE_EXAMPLES = 1;
     public static BenchmarkData data;
 
     @Setup
@@ -54,16 +56,6 @@ public class UtilBenchmark {
         BenchmarkContainer small = data.small[index];
         BenchmarkContainer big = data.big[index];
         Util.unsignedLocalIntersect2by2(small.content, small.length, big.content, big.length, data.dest);
-    }
-
-    public static void main(String[] arg) throws RunnerException {
-        Options opt = new OptionsBuilder()
-                .include(".*" + UtilBenchmark.class.getSimpleName() + ".*")
-                .warmupIterations(12)
-                .measurementIterations(7)
-                .forks(1)
-                .build();
-        new Runner(opt).run();
     }
 }
 

--- a/jmh/src/main/java/org/roaringbitmap/UtilBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/UtilBenchmark.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
-public class UtilBechmark {
+public class UtilBenchmark {
 
     @Param({"0", "1", "2", "3", "4"})
     public int index;
@@ -52,7 +52,7 @@ public class UtilBechmark {
 
     public static void main(String[] arg) throws RunnerException {
         Options opt = new OptionsBuilder()
-                .include(".*" + UtilBechmark.class.getSimpleName() + ".*")
+                .include(".*" + UtilBenchmark.class.getSimpleName() + ".*")
                 .warmupIterations(12)
                 .measurementIterations(7)
                 .forks(1)

--- a/src/main/java/org/roaringbitmap/Util.java
+++ b/src/main/java/org/roaringbitmap/Util.java
@@ -657,9 +657,10 @@ public final class Util {
    */
   public static int unsignedIntersect2by2(final short[] set1, final int length1, final short[] set2,
       final int length2, final short[] buffer) {
-    if (set1.length * 64 < set2.length) {
+    final int THRESHOLD = 25;
+    if (set1.length * THRESHOLD < set2.length) {
       return unsignedOneSidedGallopingIntersect2by2(set1, length1, set2, length2, buffer);
-    } else if (set2.length * 64 < set1.length) {
+    } else if (set2.length * THRESHOLD < set1.length) {
       return unsignedOneSidedGallopingIntersect2by2(set2, length2, set1, length1, buffer);
     } else {
       return unsignedLocalIntersect2by2(set1, length1, set2, length2, buffer);


### PR DESCRIPTION
The aim of the commit is to verify optimal value for Util.unsignedIntersect2by2 parameter.
Currently it's is param=64
The commit contains first version of benchmarking the `galloping` and `local` algorithm variants.
For param={"10","15","20","25","30","35", "40", "50","60", "90"} it generates five different examples:
 * small container S
 * big contained B (B.length = param * S.size)
The container values are generated by Uniform Distribution in version1.
The examples are deterministic, random seed is hardcoded.