### PR TITLE
Tune MappeableArrayContainer intersection algorithm

### DIFF
--- a/jmh/src/main/java/org/roaringbitmap/buffer/BufferUtilBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/buffer/BufferUtilBenchmark.java
@@ -21,23 +21,23 @@ import java.util.concurrent.TimeUnit;
  * The experiment to test the threshold when it is worth to use galloping strategy of intersecting sorted lists.
  * It allows to generate sample lists where first is *param* times bigger than other one.
  * Both lists can be generated used uniform or clustered distribution.
- * The methodology and results are presented in the issue #63 on Github.
+ * The methodology and results are presented in the issue #130 on Github.
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
-public class UtilBenchmark {
+public class BufferUtilBenchmark {
 
-    @Param({"0", "1"})           // use {"0", "1"} to test both uniform and clustered combinations
+    @Param({"0"})           // use {"0", "1"} to test both uniform and clustered combinations
     public int smallType;   // 0 - uniform, 1 - clustered
-    @Param({"0", "1"})           // use {"0", "1"} to test both uniform and clustered combinations
+    @Param({"0"})           // use {"0", "1"} to test both uniform and clustered combinations
     public int bigType;     // 0 - uniform, 1 - clustered
-    @Param({"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"})           // use {"0", "1", "2"} for three experiments. Update GENERATE_EXAMPLES if changing this
+    @Param({"0"})           // use {"0", "1", "2"} for three experiments. Update GENERATE_EXAMPLES if changing this
     public int index;
-    @Param({"25", "26", "28", "30", "31", "32", "33", "34", "35", "38", "40", "44", "49", "55", "60"})          // use {"20", "25", "30"} to check different thresholds
+    @Param({"35"})          // use {"20", "25", "30"} to check different thresholds
     public int param;
 
-    private static final int GENERATE_EXAMPLES = 10;
+    private static final int GENERATE_EXAMPLES = 1;
     public static BenchmarkData data;
 
     @Setup

--- a/jmh/src/main/java/org/roaringbitmap/buffer/UtilBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/buffer/UtilBenchmark.java
@@ -32,12 +32,12 @@ public class UtilBenchmark {
     public int smallType;   // 0 - uniform, 1 - clustered
     @Param({"0", "1"})           // use {"0", "1"} to test both uniform and clustered combinations
     public int bigType;     // 0 - uniform, 1 - clustered
-    @Param({"0", "1", "2", "3", "4"})           // use {"0", "1", "2"} for three experiments. Update GENERATE_EXAMPLES if changing this
+    @Param({"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"})           // use {"0", "1", "2"} for three experiments. Update GENERATE_EXAMPLES if changing this
     public int index;
-    @Param({"10" ,"15", "21", "23", "25", "26", "28", "30", "35", "40", "60", "90"})          // use {"20", "25", "30"} to check different thresholds
+    @Param({"25", "26", "28", "30", "31", "32", "33", "34", "35", "38", "40", "44", "49", "55", "60"})          // use {"20", "25", "30"} to check different thresholds
     public int param;
 
-    private static final int GENERATE_EXAMPLES = 5;
+    private static final int GENERATE_EXAMPLES = 10;
     public static BenchmarkData data;
 
     @Setup

--- a/jmh/src/main/java/org/roaringbitmap/buffer/UtilBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/buffer/UtilBenchmark.java
@@ -1,0 +1,137 @@
+package org.roaringbitmap.buffer;
+
+import me.lemire.integercompression.synth.ClusteredDataGenerator;
+import org.apache.commons.math3.distribution.IntegerDistribution;
+import org.apache.commons.math3.distribution.UniformIntegerDistribution;
+import org.apache.commons.math3.random.Well19937c;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.nio.ShortBuffer;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The experiment to test the threshold when it is worth to use galloping strategy of intersecting sorted lists.
+ * It allows to generate sample lists where first is *param* times bigger than other one.
+ * Both lists can be generated used uniform or clustered distribution.
+ * The methodology and results are presented in the issue #63 on Github.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+public class UtilBenchmark {
+
+    @Param({"0", "1"})           // use {"0", "1"} to test both uniform and clustered combinations
+    public int smallType;   // 0 - uniform, 1 - clustered
+    @Param({"0", "1"})           // use {"0", "1"} to test both uniform and clustered combinations
+    public int bigType;     // 0 - uniform, 1 - clustered
+    @Param({"0", "1", "2", "3", "4"})           // use {"0", "1", "2"} for three experiments. Update GENERATE_EXAMPLES if changing this
+    public int index;
+    @Param({"10" ,"15", "21", "23", "25", "26", "28", "30", "35", "40", "60", "90"})          // use {"20", "25", "30"} to check different thresholds
+    public int param;
+
+    private static final int GENERATE_EXAMPLES = 5;
+    public static BenchmarkData data;
+
+    @Setup
+    public void setup() {
+        data = BenchmarkDataGenerator.generate(param, GENERATE_EXAMPLES, smallType, bigType);
+    }
+
+    @Benchmark
+    public void galloping() {
+        BenchmarkContainer small = data.small[index];
+        BenchmarkContainer big = data.big[index];
+        BufferUtil.unsignedOneSidedGallopingIntersect2by2(small.content, small.length, big.content, big.length, data.dest);
+    }
+
+    @Benchmark
+    public void local() {
+        BenchmarkContainer small = data.small[index];
+        BenchmarkContainer big = data.big[index];
+        BufferUtil.unsignedLocalIntersect2by2(small.content, small.length, big.content, big.length, data.dest);
+    }
+}
+
+class BenchmarkData {
+    BenchmarkData(BenchmarkContainer[] small, BenchmarkContainer[] big) {
+        this.small = small;
+        this.big = big;
+        this.dest = new short[Short.MAX_VALUE];
+    }
+
+    final BenchmarkContainer[] small;
+    final BenchmarkContainer[] big;
+    final short[] dest;
+}
+
+class BenchmarkContainer {
+    BenchmarkContainer(short[] content) {
+        this.content = ShortBuffer.wrap(content);
+        this.length = content.length;
+    }
+
+    final ShortBuffer content;
+    final int length;
+}
+
+/**
+ * Deterministic generator for benchmark data.
+ * For given *param* it generates *howmany* entries
+ */
+class BenchmarkDataGenerator {
+    static BenchmarkData generate(int param, int howMany, int smallType, int bigType) {
+        IntegerDistribution ud = new UniformIntegerDistribution(new Well19937c(param + 17), Short.MIN_VALUE, Short.MAX_VALUE);
+        ClusteredDataGenerator cd = new ClusteredDataGenerator();
+        IntegerDistribution p = new UniformIntegerDistribution(new Well19937c(param + 123), SMALLEST_ARRAY, BIGGEST_ARRAY / param);
+        BenchmarkContainer[] smalls = new BenchmarkContainer[howMany];
+        BenchmarkContainer[] bigs = new BenchmarkContainer[howMany];
+        for (int i = 0; i < howMany; i++) {
+            int smallSize = p.sample();
+            int bigSize = smallSize * param;
+            short[] small = smallType == 0 ? generateUniform(ud, smallSize) : generateClustered(cd, smallSize);
+            short[] big = bigType == 0 ? generateUniform(ud, bigSize) : generateClustered(cd, bigSize);
+            smalls[i] = new BenchmarkContainer(small);
+            bigs[i] = new BenchmarkContainer(big);
+        }
+        return new BenchmarkData(smalls, bigs);
+    }
+
+    private static short[] intArrayToShortArraySorted(int[] source) {
+        short[] result = new short[source.length];
+        for (int i = 0; i < source.length; i++) {
+            result[i] = (short) source[i];
+        }
+        Arrays.sort(result);
+        return result;
+    }
+
+    private static short[] generateClustered(ClusteredDataGenerator cd, int howMany) {
+        int[] half1raw = cd.generateClustered(howMany / 2, Short.MAX_VALUE);
+        for (int i = 0; i < half1raw.length; i++) {
+            half1raw[i] = -half1raw[i];
+        }
+        short[] half1 = intArrayToShortArraySorted(half1raw);
+        short[] half2 = intArrayToShortArraySorted(cd.generateClustered(howMany / 2, Short.MAX_VALUE));
+        short[] result = new short[half1.length + half2.length];
+        System.arraycopy(half1, 0, result, 0, half1.length);
+        System.arraycopy(half2, 0, result, half1.length, half2.length);
+        return result;
+    }
+
+    private static short[] generateUniform(IntegerDistribution ud, int howMany) {
+        return intArrayToShortArraySorted(ud.sample(howMany));
+    }
+
+    private final static int SMALLEST_ARRAY = 2;
+    private final static int BIGGEST_ARRAY = 4096;
+}
+
+

--- a/src/main/java/org/roaringbitmap/buffer/BufferUtil.java
+++ b/src/main/java/org/roaringbitmap/buffer/BufferUtil.java
@@ -569,9 +569,10 @@ public final class BufferUtil {
 
   protected static int unsignedIntersect2by2(final ShortBuffer set1, final int length1,
       final ShortBuffer set2, final int length2, final short[] buffer) {
-    if (length1 * 64 < length2) {
+    final int THRESHOLD = 34;
+    if (length1 * THRESHOLD < length2) {
       return unsignedOneSidedGallopingIntersect2by2(set1, length1, set2, length2, buffer);
-    } else if (length2 * 64 < length1) {
+    } else if (length2 * THRESHOLD < length1) {
       return unsignedOneSidedGallopingIntersect2by2(set2, length2, set1, length1, buffer);
     } else {
       return unsignedLocalIntersect2by2(set1, length1, set2, length2, buffer);


### PR DESCRIPTION

![unknown-4](https://cloud.githubusercontent.com/assets/3899229/21296396/062e3c26-c56b-11e6-989b-e9996b6a883e.png)
![unknow](https://cloud.githubusercontent.com/assets/3899229/21296398/0655d7ae-c56b-11e6-9194-33a2070f6f96.png)
![unknown-3](https://cloud.githubusercontent.com/assets/3899229/21296397/06544fa6-c56b-11e6-9cc1-834a6942d51f.png)
![unknown-2](https://cloud.githubusercontent.com/assets/3899229/21296399/0655fa2c-c56b-11e6-8433-be6be0a095ca.png)

Seems like the optimal parameter for Buffer version is around 35-40.
Next step is to generate more examples and focus on 25-60 range.
I wonder why is there clear split between "uniform" preferring local and "clustered" preferring galloping
