### PR TITLE
Performance of range operations on bitmap containers #103

### DIFF
--- a/src/test/java/org/roaringbitmap/TestUtil.java
+++ b/src/test/java/org/roaringbitmap/TestUtil.java
@@ -27,4 +27,16 @@ public class TestUtil {
         Assert.assertEquals(-1, Util.branchyUnsignedBinarySearch(data1, 0, 0, (short)0));
         Assert.assertEquals(-10, Util.branchyUnsignedBinarySearch(data1, 0, data1.length, (short) -1));
     }
+
+    @Test
+    public void testCardinalityInBitmapWordRange() {
+        BitmapContainer bc = new BitmapContainer();
+        bc.add((short) 1);
+        bc.add((short) 2);
+        bc.add((short) 31);
+
+        int result = Util.cardinalityInBitmapWordRange(bc.bitmap, 7, 37);
+
+        Assert.assertEquals(1, result);
+    }
 }


### PR DESCRIPTION
Hi, I've started writing code to solve this issue. Description of the problem by @lemire is very clear. I was looking at  method `cardinalityInBitmapWordRange` to get some ideas. I've committed simple test that fails. The question is if this is a bug or the API is not clear (to me)?