### PR TITLE
Fix MappeableRunContainer rank computation

### DIFF
--- a/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -1875,7 +1875,7 @@ public final class MappeableRunContainer extends MappeableContainer implements C
       int length = BufferUtil.toIntUnsigned(getLength(k));
       if (x < value) {
         return answer;
-      } else if (value + length + 1 >= x) {
+      } else if (value + length + 1 > x) {
         return answer + x - value + 1;
       }
       answer += length + 1;

--- a/src/test/java/org/roaringbitmap/buffer/TestRunContainer.java
+++ b/src/test/java/org/roaringbitmap/buffer/TestRunContainer.java
@@ -2,22 +2,16 @@ package org.roaringbitmap.buffer;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.roaringbitmap.IntIterator;
+import org.roaringbitmap.ShortIterator;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.BitSet;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 
-import org.roaringbitmap.IntIterator;
-import org.roaringbitmap.ShortIterator;
-
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.*;
 import static org.roaringbitmap.buffer.MappeableArrayContainer.DEFAULT_MAX_SIZE;
 
@@ -1769,6 +1763,15 @@ public class TestRunContainer {
     assertEquals(5, container.rank((short) 1024));
   }
 
+  @Test
+  public void shortRangeRank() {
+    MappeableContainer container = new MappeableRunContainer();
+    container = container.add(16, 32);
+    assertThat(container, instanceOf(MappeableRunContainer.class));
+    // results in correct value: 16
+    // assertEquals(16, container.toBitmapContainer().rank((short) 32));
+    assertEquals(16, container.rank((short) 32));
+  }
 
   @Test
   public void remove() {


### PR DESCRIPTION
In rare cases calling .rank() method on a run container returns a value that's off by one.

The provided test case reproduces the issue.
I include a proposed fix.