### PR TITLE
Optimize ArrayContainer.ior(ArrayContainer)

### DIFF
--- a/jmh/src/main/java/org/roaringbitmap/realdata/RealDataBenchmarkIOr.java
+++ b/jmh/src/main/java/org/roaringbitmap/realdata/RealDataBenchmarkIOr.java
@@ -1,0 +1,25 @@
+package org.roaringbitmap.realdata;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.roaringbitmap.realdata.state.RealDataBenchmarkState;
+import org.roaringbitmap.realdata.wrapper.Bitmap;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class RealDataBenchmarkIOr {
+
+   @Benchmark
+   public int pairwiseIOr(RealDataBenchmarkState bs) {
+      Bitmap bitmap = bs.bitmaps.get(0).clone();
+      for(int k = 1; k < bs.bitmaps.size(); ++k) {
+          bitmap.ior(bs.bitmaps.get(k));
+      }
+      return bitmap.cardinality();
+   }
+
+}

--- a/jmh/src/main/java/org/roaringbitmap/realdata/wrapper/Bitmap.java
+++ b/jmh/src/main/java/org/roaringbitmap/realdata/wrapper/Bitmap.java
@@ -21,6 +21,8 @@ public interface Bitmap {
 
    Bitmap or(Bitmap other);
 
+   Bitmap ior(Bitmap other);
+
    Bitmap xor(Bitmap other);
 
    Bitmap flip( int rangeStart, int rangeEnd);
@@ -36,5 +38,7 @@ public interface Bitmap {
    void forEach(IntConsumer ic);
 
    void serialize(DataOutputStream dos) throws IOException;
+
+   Bitmap clone();
 
 }

--- a/jmh/src/main/java/org/roaringbitmap/realdata/wrapper/ConciseSetWrapper.java
+++ b/jmh/src/main/java/org/roaringbitmap/realdata/wrapper/ConciseSetWrapper.java
@@ -54,6 +54,11 @@ final class ConciseSetWrapper implements Bitmap {
    }
 
    @Override
+   public Bitmap ior(Bitmap other) {
+      throw new UnsupportedOperationException("Not implemented in ConciseSet");
+   }
+
+   @Override
    public Bitmap xor(Bitmap other) {
       return new ConciseSetWrapper(bitmap.symmetricDifference(((ConciseSetWrapper) other).bitmap));
    }
@@ -146,6 +151,11 @@ final class ConciseSetWrapper implements Bitmap {
    @Override
    public void serialize(DataOutputStream dos) throws IOException {
       throw new UnsupportedOperationException("Not implemented in ConciseSet");
+   }
+
+   @Override
+   public Bitmap clone() {
+      return new ConciseSetWrapper(bitmap.clone());
    }
 
 }

--- a/jmh/src/main/java/org/roaringbitmap/realdata/wrapper/Ewah32BitmapWrapper.java
+++ b/jmh/src/main/java/org/roaringbitmap/realdata/wrapper/Ewah32BitmapWrapper.java
@@ -52,6 +52,11 @@ final class Ewah32BitmapWrapper implements Bitmap {
    }
 
    @Override
+   public Bitmap ior(Bitmap other) {
+      throw new UnsupportedOperationException("Not implemented in Ewah32");
+   }
+
+   @Override
    public Bitmap xor(Bitmap other) {
       return new Ewah32BitmapWrapper(bitmap.xor(((Ewah32BitmapWrapper) other).bitmap));
    }
@@ -152,6 +157,15 @@ final class Ewah32BitmapWrapper implements Bitmap {
    @Override
    public void serialize(DataOutputStream dos) throws IOException {
       bitmap.serialize(dos);
+   }
+
+   @Override
+   public Bitmap clone() {
+      try {
+         return new Ewah32BitmapWrapper(bitmap.clone());
+      } catch (CloneNotSupportedException e) {
+         throw new RuntimeException(e);
+      }
    }
 
 }

--- a/jmh/src/main/java/org/roaringbitmap/realdata/wrapper/EwahBitmapWrapper.java
+++ b/jmh/src/main/java/org/roaringbitmap/realdata/wrapper/EwahBitmapWrapper.java
@@ -52,6 +52,11 @@ final class EwahBitmapWrapper implements Bitmap {
    }
 
    @Override
+   public Bitmap ior(Bitmap other) {
+      throw new UnsupportedOperationException("Not implemented in Ewah");
+   }
+
+   @Override
    public Bitmap xor(Bitmap other) {
       return new EwahBitmapWrapper(bitmap.xor(((EwahBitmapWrapper) other).bitmap));
    }
@@ -150,6 +155,15 @@ final class EwahBitmapWrapper implements Bitmap {
    @Override
    public void serialize(DataOutputStream dos) throws IOException {
       bitmap.serialize(dos);
+   }
+
+   @Override
+   public Bitmap clone() {
+      try {
+         return new EwahBitmapWrapper(bitmap.clone());
+      } catch (CloneNotSupportedException e) {
+         throw new RuntimeException(e);
+      }
    }
 
 }

--- a/jmh/src/main/java/org/roaringbitmap/realdata/wrapper/ImmutableConciseSetWrapper.java
+++ b/jmh/src/main/java/org/roaringbitmap/realdata/wrapper/ImmutableConciseSetWrapper.java
@@ -66,6 +66,11 @@ final class ImmutableConciseSetWrapper implements Bitmap {
    }
 
    @Override
+   public Bitmap ior(Bitmap other) {
+      throw new UnsupportedOperationException("Not implemented in ImmutableConciseSet");
+   }
+
+   @Override
    public Bitmap xor(Bitmap other) {
       throw new UnsupportedOperationException("Not implemented in ImmutableConciseSet");
    }
@@ -157,6 +162,11 @@ final class ImmutableConciseSetWrapper implements Bitmap {
 
    @Override
    public void serialize(DataOutputStream dos) throws IOException {
+      throw new UnsupportedOperationException("Not implemented in ImmutableConciseSet");
+   }
+
+   @Override
+   public Bitmap clone() {
       throw new UnsupportedOperationException("Not implemented in ImmutableConciseSet");
    }
 

--- a/jmh/src/main/java/org/roaringbitmap/realdata/wrapper/ImmutableRoaringBitmapWrapper.java
+++ b/jmh/src/main/java/org/roaringbitmap/realdata/wrapper/ImmutableRoaringBitmapWrapper.java
@@ -52,6 +52,11 @@ final class ImmutableRoaringBitmapWrapper implements Bitmap {
    }
 
    @Override
+   public Bitmap ior(Bitmap other) {
+      throw new UnsupportedOperationException("Not implemented in ImmutableRoaringBitmap");
+   }
+
+   @Override
    public Bitmap xor(Bitmap other) {
       return new ImmutableRoaringBitmapWrapper(ImmutableRoaringBitmap.xor(bitmap, ((ImmutableRoaringBitmapWrapper) other).bitmap));
    }
@@ -129,6 +134,11 @@ final class ImmutableRoaringBitmapWrapper implements Bitmap {
    @Override
    public void serialize(DataOutputStream dos) throws IOException {
       bitmap.serialize(dos);
+   }
+
+   @Override
+   public Bitmap clone() {
+      return new ImmutableRoaringBitmapWrapper(bitmap.clone());
    }
 
 }

--- a/jmh/src/main/java/org/roaringbitmap/realdata/wrapper/RoaringBitmapWrapper.java
+++ b/jmh/src/main/java/org/roaringbitmap/realdata/wrapper/RoaringBitmapWrapper.java
@@ -51,6 +51,11 @@ final class RoaringBitmapWrapper implements Bitmap {
       return new RoaringBitmapWrapper(RoaringBitmap.or(bitmap, ((RoaringBitmapWrapper) other).bitmap));
    }
 
+   @Override
+   public Bitmap ior(Bitmap other) {
+      bitmap.or(((RoaringBitmapWrapper) other).bitmap);
+      return this;
+   }
 
    @Override
    public Bitmap flip(int rangeStart, int rangeEnd) {
@@ -133,6 +138,11 @@ final class RoaringBitmapWrapper implements Bitmap {
    @Override
    public void serialize(DataOutputStream dos) throws IOException {
       bitmap.serialize(dos);
+   }
+
+   @Override
+   public Bitmap clone() {
+      return new RoaringBitmapWrapper(bitmap.clone());
    }
 
 }

--- a/jmh/src/test/java/org/roaringbitmap/realdata/RealDataBenchmarkIOrTest.java
+++ b/jmh/src/test/java/org/roaringbitmap/realdata/RealDataBenchmarkIOrTest.java
@@ -1,0 +1,50 @@
+package org.roaringbitmap.realdata;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.roaringbitmap.RealDataset.*;
+import static org.roaringbitmap.realdata.wrapper.BitmapFactory.*;
+
+
+public class RealDataBenchmarkIOrTest extends RealDataBenchmarkSanityTest {
+
+    private static final Map<String, Integer> EXPECTED_RESULTS =
+            ImmutableMap.<String, Integer>builder()
+                    .put(CENSUS_INCOME, 199523)
+                    .put(CENSUS1881, 988653)
+                    .put(DIMENSION_008, 148278)
+                    .put(DIMENSION_003, 3866847)
+                    .put(DIMENSION_033, 3866847)
+                    .put(USCENSUS2000, 5985)
+                    .put(WEATHER_SEPT_85, 1015367)
+                    .put(WIKILEAKS_NOQUOTES, 242540)
+                    .put(CENSUS_INCOME_SRT, 199523)
+                    .put(CENSUS1881_SRT, 656346)
+                    .put(WEATHER_SEPT_85_SRT, 1015367)
+                    .put(WIKILEAKS_NOQUOTES_SRT, 236436)
+            .build();
+
+    @Before
+    public void setup() throws Exception {
+        Assume.assumeFalse(type.equals(CONCISE));
+        Assume.assumeFalse(type.equals(WAH));
+        Assume.assumeFalse(type.equals(EWAH));
+        Assume.assumeFalse(type.equals(EWAH32));
+        Assume.assumeFalse((type.equals(ROARING) || type.equals(ROARING_WITH_RUN)) && immutable);
+        super.setup();
+    }
+
+    @Test
+    public void test() throws Exception {
+        int expected = EXPECTED_RESULTS.get(dataset);
+        RealDataBenchmarkIOr bench = new RealDataBenchmarkIOr();
+        assertEquals(expected, bench.pairwiseIOr(bs));
+    }
+
+}

--- a/src/main/java/org/roaringbitmap/Util.java
+++ b/src/main/java/org/roaringbitmap/Util.java
@@ -905,24 +905,28 @@ public final class Util {
    * Unite two sorted lists and write the result to the provided output array
    *
    * @param set1 first array
+   * @param offset1 offset of first array
    * @param length1 length of first array
    * @param set2 second array
+   * @param offset2 offset of second array
    * @param length2 length of second array
    * @param buffer output array
    * @return cardinality of the union
    */
-  public static int unsignedUnion2by2(final short[] set1, final int length1, final short[] set2,
-      final int length2, final short[] buffer) {
-    int pos = 0;
-    int k1 = 0, k2 = 0;
+  public static int unsignedUnion2by2(
+          final short[] set1, final int offset1, final int length1,
+          final short[] set2, final int offset2, final int length2,
+          final short[] buffer) {
     if (0 == length2) {
-      System.arraycopy(set1, 0, buffer, 0, length1);
+      System.arraycopy(set1, offset1, buffer, 0, length1);
       return length1;
     }
     if (0 == length1) {
-      System.arraycopy(set2, 0, buffer, 0, length2);
+      System.arraycopy(set2, offset2, buffer, 0, length2);
       return length2;
     }
+    int pos = 0;
+    int k1 = offset1, k2 = offset2;
     short s1 = set1[k1];
     short s2 = set2[k2];
     while (true) {
@@ -931,31 +935,31 @@ public final class Util {
       if (v1 < v2) {
         buffer[pos++] = s1;
         ++k1;
-        if (k1 >= length1) {
-          System.arraycopy(set2, k2, buffer, pos, length2 - k2);
-          return pos + length2 - k2;
+        if (k1 >= length1 + offset1) {
+          System.arraycopy(set2, k2, buffer, pos, length2 - k2 + offset2);
+          return pos + length2 - k2 + offset2;
         }
         s1 = set1[k1];
       } else if (v1 == v2) {
         buffer[pos++] = s1;
         ++k1;
         ++k2;
-        if (k1 >= length1) {
-          System.arraycopy(set2, k2, buffer, pos, length2 - k2);
-          return pos + length2 - k2;
+        if (k1 >= length1 + offset1) {
+          System.arraycopy(set2, k2, buffer, pos, length2 - k2 + offset2);
+          return pos + length2 - k2 + offset2;
         }
-        if (k2 >= length2) {
-          System.arraycopy(set1, k1, buffer, pos, length1 - k1);
-          return pos + length1 - k1;
+        if (k2 >= length2 + offset2) {
+          System.arraycopy(set1, k1, buffer, pos, length1 - k1 + offset1);
+          return pos + length1 - k1 + offset1;
         }
         s1 = set1[k1];
         s2 = set2[k2];
       } else {// if (set1[k1]>set2[k2])
         buffer[pos++] = s2;
         ++k2;
-        if (k2 >= length2) {
-          System.arraycopy(set1, k1, buffer, pos, length1 - k1);
-          return pos + length1 - k1;
+        if (k2 >= length2 + offset2) {
+          System.arraycopy(set1, k1, buffer, pos, length1 - k1 + offset1);
+          return pos + length1 - k1 + offset1;
         }
         s2 = set2[k2];
       }

--- a/src/main/java/org/roaringbitmap/buffer/BufferUtil.java
+++ b/src/main/java/org/roaringbitmap/buffer/BufferUtil.java
@@ -850,18 +850,22 @@ public final class BufferUtil {
 
   }
 
-  protected static int unsignedUnion2by2(final ShortBuffer set1, final int length1,
-      final ShortBuffer set2, final int length2, final short[] buffer) {
-    int pos = 0;
-    int k1 = 0, k2 = 0;
+  protected static int unsignedUnion2by2(
+          final ShortBuffer set1, final int offset1, final int length1,
+          final ShortBuffer set2, final int offset2, final int length2,
+          final short[] buffer) {
     if (0 == length2) {
+      set1.position(offset1);
       set1.get(buffer, 0, length1);
       return length1;
     }
     if (0 == length1) {
+      set2.position(offset2);
       set2.get(buffer, 0, length2);
       return length2;
     }
+    int pos = 0;
+    int k1 = offset1, k2 = offset2;
     short s1 = set1.get(k1);
     short s2 = set2.get(k2);
     while (true) {
@@ -870,35 +874,35 @@ public final class BufferUtil {
       if (v1 < v2) {
         buffer[pos++] = s1;
         ++k1;
-        if (k1 >= length1) {
+        if (k1 >= length1 + offset1) {
           set2.position(k2);
-          set2.get(buffer, pos, length2 - k2);
-          return pos + length2 - k2;
+          set2.get(buffer, pos, length2 - k2 + offset2);
+          return pos + length2 - k2 + offset2;
         }
         s1 = set1.get(k1);
       } else if (v1 == v2) {
         buffer[pos++] = s1;
         ++k1;
         ++k2;
-        if (k1 >= length1) {
+        if (k1 >= length1 + offset1) {
           set2.position(k2);
-          set2.get(buffer, pos, length2 - k2);
-          return pos + length2 - k2;
+          set2.get(buffer, pos, length2 - k2 + offset2);
+          return pos + length2 - k2 + offset2;
         }
-        if (k2 >= length2) {
+        if (k2 >= length2 + offset2) {
           set1.position(k1);
-          set1.get(buffer, pos, length1 - k1);
-          return pos + length1 - k1;
+          set1.get(buffer, pos, length1 - k1 + offset1);
+          return pos + length1 - k1 + offset1;
         }
         s1 = set1.get(k1);
         s2 = set2.get(k2);
       } else {// if (set1.get(k1)>set2.get(k2))
         buffer[pos++] = s2;
         ++k2;
-        if (k2 >= length2) {
+        if (k2 >= length2 + offset2) {
           set1.position(k1);
-          set1.get(buffer, pos, length1 - k1);
-          return pos + length1 - k1;
+          set1.get(buffer, pos, length1 - k1 + offset1);
+          return pos + length1 - k1 + offset1;
         }
         s2 = set2.get(k2);
       }

--- a/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -748,7 +748,74 @@ public final class MappeableArrayContainer extends MappeableContainer implements
 
   @Override
   public MappeableContainer ior(final MappeableArrayContainer value2) {
-    return this.or(value2);
+    final int totalCardinality = getCardinality() + value2.getCardinality();
+    if (totalCardinality > DEFAULT_MAX_SIZE) {// it could be a bitmap!
+      final MappeableBitmapContainer bc = new MappeableBitmapContainer();
+      if (!BufferUtil.isBackedBySimpleArray(bc.bitmap)) {
+        throw new RuntimeException("Should not happen. Internal bug.");
+      }
+      long[] bitArray = bc.bitmap.array();
+      if (BufferUtil.isBackedBySimpleArray(value2.content)) {
+        short[] sarray = value2.content.array();
+        for (int k = 0; k < value2.cardinality; ++k) {
+          short v = sarray[k];
+          final int i = BufferUtil.toIntUnsigned(v) >>> 6;
+          bitArray[i] |= (1L << v);
+        }
+      } else {
+        for (int k = 0; k < value2.cardinality; ++k) {
+          short v2 = value2.content.get(k);
+          final int i = BufferUtil.toIntUnsigned(v2) >>> 6;
+          bitArray[i] |= (1L << v2);
+        }
+      }
+      if (BufferUtil.isBackedBySimpleArray(content)) {
+        short[] sarray = content.array();
+        for (int k = 0; k < cardinality; ++k) {
+          short v = sarray[k];
+          final int i = BufferUtil.toIntUnsigned(v) >>> 6;
+          bitArray[i] |= (1L << v);
+        }
+      } else {
+        for (int k = 0; k < cardinality; ++k) {
+          short v = content.get(k);
+          final int i = BufferUtil.toIntUnsigned(v) >>> 6;
+          bitArray[i] |= (1L << v);
+        }
+      }
+      bc.cardinality = 0;
+      int len = bc.bitmap.limit();
+      for (int index = 0; index < len; ++index) {
+        bc.cardinality += Long.bitCount(bitArray[index]);
+      }
+      if (bc.cardinality <= DEFAULT_MAX_SIZE) {
+        return bc.toArrayContainer();
+      } else if (bc.isFull()) {
+        return MappeableRunContainer.full();
+      }
+      return bc;
+    }
+    if (totalCardinality >= content.limit()) {
+      increaseCapacity(totalCardinality);
+    }
+    BufferUtil.arraycopy(content, 0, content, value2.cardinality, cardinality);
+    if (BufferUtil.isBackedBySimpleArray(content)
+            && BufferUtil.isBackedBySimpleArray(value2.content)) {
+      cardinality =
+              Util.unsignedUnion2by2(
+                      content.array(), value2.cardinality, cardinality,
+                      value2.content.array(), 0, value2.cardinality,
+                      content.array()
+              );
+    } else {
+      cardinality =
+              BufferUtil.unsignedUnion2by2(
+                      content, value2.cardinality, cardinality,
+                      value2.content, 0, value2.cardinality,
+                      content.array()
+              );
+    }
+    return this;
   }
 
   @Override
@@ -1042,11 +1109,18 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     if (BufferUtil.isBackedBySimpleArray(value1.content)
         && BufferUtil.isBackedBySimpleArray(value2.content)) {
       answer.cardinality =
-          org.roaringbitmap.Util.unsignedUnion2by2(value1.content.array(), value1.getCardinality(),
-              value2.content.array(), value2.getCardinality(), answer.content.array());
+          Util.unsignedUnion2by2(
+                  value1.content.array(), 0, value1.getCardinality(),
+                  value2.content.array(), 0, value2.getCardinality(),
+                  answer.content.array()
+          );
     } else {
-      answer.cardinality = BufferUtil.unsignedUnion2by2(value1.content, value1.getCardinality(),
-          value2.content, value2.getCardinality(), answer.content.array());
+      answer.cardinality =
+              BufferUtil.unsignedUnion2by2(
+                      value1.content, 0, value1.getCardinality(),
+                      value2.content, 0, value2.getCardinality(),
+                      answer.content.array()
+              );
     }
     return answer;
   }
@@ -1095,11 +1169,18 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     if (BufferUtil.isBackedBySimpleArray(value1.content)
         && BufferUtil.isBackedBySimpleArray(value2.content)) {
       answer.cardinality =
-          org.roaringbitmap.Util.unsignedUnion2by2(value1.content.array(), value1.getCardinality(),
-              value2.content.array(), value2.getCardinality(), answer.content.array());
+              Util.unsignedUnion2by2(
+                      value1.content.array(), 0, value1.getCardinality(),
+                      value2.content.array(), 0, value2.getCardinality(),
+                      answer.content.array()
+              );
     } else {
-      answer.cardinality = BufferUtil.unsignedUnion2by2(value1.content, value1.getCardinality(),
-          value2.content, value2.getCardinality(), answer.content.array());
+      answer.cardinality =
+              BufferUtil.unsignedUnion2by2(
+                      value1.content, 0, value1.getCardinality(),
+                      value2.content, 0, value2.getCardinality(),
+                      answer.content.array()
+              );
     }
     return answer;
   }


### PR DESCRIPTION
I stumbled on this operator while working on my personal dataset. The proposed changes simply leverage an optimization that has been used before: if the backed array is large enough to hold the result and its initial content, push the content at the end of the array and write the result at the beginning. 
With less pressure on the garbage collector, I noticed a ~20% improvement in my usecase.
To validate the changes, I added a benchmark on our real dataset. See below the results. There is always either a speedup or no significant regression.

| Benchmark                        | (dataset)              | (immutable) | (type)           | Score before | Score after | Variation |
|----------------------------------|------------------------|-------------|------------------|--------------|-------------|-----------|
| RealDataBenchmarkIOr.pairwiseIOr | census-income          | FALSE       | roaring          | 2435.091     | 2285.147    | 6.16%     |
| RealDataBenchmarkIOr.pairwiseIOr | census-income          | FALSE       | roaring_with_run | 276.821      | 270.427     | 2.31%     |
| RealDataBenchmarkIOr.pairwiseIOr | census1881             | FALSE       | roaring          | 5985.871     | 6116.565    | -2.18%    |
| RealDataBenchmarkIOr.pairwiseIOr | census1881             | FALSE       | roaring_with_run | 7772.466     | 7437.919    | 4.30%     |
| RealDataBenchmarkIOr.pairwiseIOr | dimension_008          | FALSE       | roaring          | 2402.474     | 2364.973    | 1.56%     |
| RealDataBenchmarkIOr.pairwiseIOr | dimension_008          | FALSE       | roaring_with_run | 4068.806     | 3970.744    | 2.41%     |
| RealDataBenchmarkIOr.pairwiseIOr | dimension_003          | FALSE       | roaring          | 15017.826    | 15273.254   | -1.70%    |
| RealDataBenchmarkIOr.pairwiseIOr | dimension_003          | FALSE       | roaring_with_run | 7748.019     | 6580.877    | 15.06%    |
| RealDataBenchmarkIOr.pairwiseIOr | dimension_033          | FALSE       | roaring          | 2674.554     | 2706.902    | -1.21%    |
| RealDataBenchmarkIOr.pairwiseIOr | dimension_033          | FALSE       | roaring_with_run | 1176.172     | 1197.942    | -1.85%    |
| RealDataBenchmarkIOr.pairwiseIOr | uscensus2000           | FALSE       | roaring          | 418.675      | 420.828     | -0.51%    |
| RealDataBenchmarkIOr.pairwiseIOr | uscensus2000           | FALSE       | roaring_with_run | 437.241      | 408.776     | 6.51%     |
| RealDataBenchmarkIOr.pairwiseIOr | weather_sept_85        | FALSE       | roaring          | 1914.518     | 1899.064    | 0.81%     |
| RealDataBenchmarkIOr.pairwiseIOr | weather_sept_85        | FALSE       | roaring_with_run | 1989.191     | 1914.704    | 3.74%     |
| RealDataBenchmarkIOr.pairwiseIOr | wikileaks-noquotes     | FALSE       | roaring          | 5180.151     | 5092.232    | 1.70%     |
| RealDataBenchmarkIOr.pairwiseIOr | wikileaks-noquotes     | FALSE       | roaring_with_run | 13735.464    | 12436.016   | 9.46%     |
| RealDataBenchmarkIOr.pairwiseIOr | census-income_srt      | FALSE       | roaring          | 1189.468     | 1133.497    | 4.71%     |
| RealDataBenchmarkIOr.pairwiseIOr | census-income_srt      | FALSE       | roaring_with_run | 81.35        | 70.371      | 13.50%    |
| RealDataBenchmarkIOr.pairwiseIOr | census1881_srt         | FALSE       | roaring          | 8143.423     | 7826.395    | 3.89%     |
| RealDataBenchmarkIOr.pairwiseIOr | census1881_srt         | FALSE       | roaring_with_run | 9015.314     | 9221.516    | -2.29%    |
| RealDataBenchmarkIOr.pairwiseIOr | weather_sept_85_srt    | FALSE       | roaring          | 702.266      | 706.214     | -0.56%    |
| RealDataBenchmarkIOr.pairwiseIOr | weather_sept_85_srt    | FALSE       | roaring_with_run | 1081.853     | 1046.578    | 3.26%     |
| RealDataBenchmarkIOr.pairwiseIOr | wikileaks-noquotes_srt | FALSE       | roaring          | 5601.957     | 5218.003    | 6.85%     |
| RealDataBenchmarkIOr.pairwiseIOr | wikileaks-noquotes_srt | FALSE       | roaring_with_run | 2782.501     | 2801.871    | -0.70%    |