### PR TITLE
rank of RoaringBitmap produces incorrect result #158

### DIFF
--- a/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -1775,9 +1775,10 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
 
     for (int i = 0; i < this.highLowContainer.size(); i++) {
       short key = this.highLowContainer.getKeyAtIndex(i);
-      if (Util.compareUnsigned(key, xhigh) < 0) {
+      int comparison = Util.compareUnsigned(key, xhigh);
+      if (comparison < 0) {
         size += this.highLowContainer.getContainerAtIndex(i).getCardinality();
-      } else {
+      } else if (comparison == 0) {
         return size + this.highLowContainer.getContainerAtIndex(i).rank(Util.lowbits(x));
       }
     }

--- a/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -1267,9 +1267,10 @@ public class ImmutableRoaringBitmap
     short xhigh = BufferUtil.highbits(x);
     for (int i = 0; i < this.highLowContainer.size(); i++) {
       short key = this.highLowContainer.getKeyAtIndex(i);
-      if (Util.compareUnsigned(key, xhigh) < 0) {
+      int comparison = Util.compareUnsigned(key, xhigh);
+      if (comparison < 0) {
         size += this.highLowContainer.getCardinality(i);
-      } else {
+      } else if(comparison == 0) {
         return size + this.highLowContainer.getContainerAtIndex(i).rank(BufferUtil.lowbits(x));
       }
     }

--- a/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -4560,4 +4560,12 @@ public class TestRoaringBitmap {
     assertEquals(baseline.getCardinality(), RoaringBitmap.andCardinality(baseline, baseline));
   }
 
+
+  @Test
+  public void testRankOverflow() {
+    Assert.assertEquals(0, RoaringBitmap.bitmapOf(65537).rank(1));
+    Assert.assertEquals(1, RoaringBitmap.bitmapOf(65537).rank(65537));
+    Assert.assertEquals(1, RoaringBitmap.bitmapOf(65537).rank(65538));
+  }
+
 }

--- a/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
+++ b/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
@@ -1388,4 +1388,11 @@ public class TestImmutableRoaringBitmap {
     ImmutableRoaringBitmap andNot = ImmutableRoaringBitmap.andNot(rb, rb2);
     assertEquals(andNot.getCardinality(), ImmutableRoaringBitmap.andNotCardinality(rb, rb2));
   }
+
+  @Test
+  public void testRankOverflow() {
+    Assert.assertEquals(0, ImmutableRoaringBitmap.bitmapOf(65537).rank(1));
+    Assert.assertEquals(1, ImmutableRoaringBitmap.bitmapOf(65537).rank(65537));
+    Assert.assertEquals(1, ImmutableRoaringBitmap.bitmapOf(65537).rank(65538));
+  }
 }


### PR DESCRIPTION
The issue is addressed in the buffer package too.