### PR TITLE
speed up reverse iteration, add more illustrious benchmark modes to I…

### DIFF
--- a/jmh/src/main/java/org/roaringbitmap/iteration/IteratorsBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/iteration/IteratorsBenchmark.java
@@ -14,8 +14,8 @@ import java.util.Iterator;
 /**
  * Created by Borislav Ivanov on 4/2/15.
  */
-@BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode({Mode.SampleTime, Mode.Throughput, Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class IteratorsBenchmark {
 
    @Benchmark


### PR DESCRIPTION
I observed a good speed up replacing the call to Long.reverse with Long.numberOfLeadingZeroes. I took the liberty of adding SampleTime and Throughput benchmark modes to IteratorsBenchmark, and changed the timeunit to milliseconds since most benchmarks were taking at least thousands of microseconds.

Before:
```
Benchmark                                                                   Mode   Cnt     Score      Error   Units
IteratorsBenchmark.testReverseStandard_a                                   thrpt     5     1.414 ±    0.284  ops/ms
IteratorsBenchmark.testReverseStandard_b                                   thrpt     5     0.008 ±    0.001  ops/ms
IteratorsBenchmark.testReverseStandard_c                                   thrpt     5     0.001 ±    0.001  ops/ms
IteratorsBenchmark.testReverseStandard_a                                    avgt     5     0.730 ±    0.195   ms/op
IteratorsBenchmark.testReverseStandard_b                                    avgt     5   138.611 ±   33.262   ms/op
IteratorsBenchmark.testReverseStandard_c                                    avgt     5  1903.108 ±  987.489   ms/op
IteratorsBenchmark.testReverseStandard_a                                  sample  4215     1.189 ±    0.022   ms/op
IteratorsBenchmark.testReverseStandard_a:testReverseStandard_a·p0.00      sample           0.611              ms/op
IteratorsBenchmark.testReverseStandard_a:testReverseStandard_a·p0.50      sample           1.288              ms/op
IteratorsBenchmark.testReverseStandard_a:testReverseStandard_a·p0.90      sample           1.788              ms/op
IteratorsBenchmark.testReverseStandard_a:testReverseStandard_a·p0.95      sample           1.849              ms/op
IteratorsBenchmark.testReverseStandard_a:testReverseStandard_a·p0.99      sample           2.241              ms/op
IteratorsBenchmark.testReverseStandard_a:testReverseStandard_a·p0.999     sample           3.438              ms/op
IteratorsBenchmark.testReverseStandard_a:testReverseStandard_a·p0.9999    sample           5.554              ms/op
IteratorsBenchmark.testReverseStandard_a:testReverseStandard_a·p1.00      sample           5.554              ms/op
IteratorsBenchmark.testReverseStandard_b                                  sample    28   201.547 ±   25.650   ms/op
IteratorsBenchmark.testReverseStandard_b:testReverseStandard_b·p0.00      sample         111.411              ms/op
IteratorsBenchmark.testReverseStandard_b:testReverseStandard_b·p0.50      sample         214.434              ms/op
IteratorsBenchmark.testReverseStandard_b:testReverseStandard_b·p0.90      sample         217.396              ms/op
IteratorsBenchmark.testReverseStandard_b:testReverseStandard_b·p0.95      sample         255.879              ms/op
IteratorsBenchmark.testReverseStandard_b:testReverseStandard_b·p0.99      sample         286.786              ms/op
IteratorsBenchmark.testReverseStandard_b:testReverseStandard_b·p0.999     sample         286.786              ms/op
IteratorsBenchmark.testReverseStandard_b:testReverseStandard_b·p0.9999    sample         286.786              ms/op
IteratorsBenchmark.testReverseStandard_b:testReverseStandard_b·p1.00      sample         286.786              ms/op
IteratorsBenchmark.testReverseStandard_c                                  sample     5  2223.401 ± 1005.708   ms/op
IteratorsBenchmark.testReverseStandard_c:testReverseStandard_c·p0.00      sample        1772.093              ms/op
IteratorsBenchmark.testReverseStandard_c:testReverseStandard_c·p0.50      sample        2319.450              ms/op
IteratorsBenchmark.testReverseStandard_c:testReverseStandard_c·p0.90      sample        2432.696              ms/op
IteratorsBenchmark.testReverseStandard_c:testReverseStandard_c·p0.95      sample        2432.696              ms/op
IteratorsBenchmark.testReverseStandard_c:testReverseStandard_c·p0.99      sample        2432.696              ms/op
IteratorsBenchmark.testReverseStandard_c:testReverseStandard_c·p0.999     sample        2432.696              ms/op
IteratorsBenchmark.testReverseStandard_c:testReverseStandard_c·p0.9999    sample        2432.696              ms/op
IteratorsBenchmark.testReverseStandard_c:testReverseStandard_c·p1.00      sample        2432.696              ms/op
```

After:

```
Benchmark                                                                   Mode   Cnt     Score     Error   Units

IteratorsBenchmark.testReverseStandard_a                                   thrpt     5     1.380 ±   0.231  ops/ms
IteratorsBenchmark.testReverseStandard_b                                   thrpt     5     0.008 ±   0.002  ops/ms
IteratorsBenchmark.testReverseStandard_c                                   thrpt     5     0.001 ±   0.001  ops/ms
IteratorsBenchmark.testReverseStandard_a                                    avgt     5     0.705 ±   0.151   ms/op
IteratorsBenchmark.testReverseStandard_b                                    avgt     5   131.287 ±  39.452   ms/op
IteratorsBenchmark.testReverseStandard_c                                    avgt     5  1493.856 ± 147.338   ms/op
IteratorsBenchmark.testReverseStandard_a                                  sample  5682     0.886 ±   0.017   ms/op
IteratorsBenchmark.testReverseStandard_a:testReverseStandard_a·p0.00      sample           0.613             ms/op
IteratorsBenchmark.testReverseStandard_a:testReverseStandard_a·p0.50      sample           0.671             ms/op
IteratorsBenchmark.testReverseStandard_a:testReverseStandard_a·p0.90      sample           1.489             ms/op
IteratorsBenchmark.testReverseStandard_a:testReverseStandard_a·p0.95      sample           1.589             ms/op
IteratorsBenchmark.testReverseStandard_a:testReverseStandard_a·p0.99      sample           1.913             ms/op
IteratorsBenchmark.testReverseStandard_a:testReverseStandard_a·p0.999     sample           3.509             ms/op
IteratorsBenchmark.testReverseStandard_a:testReverseStandard_a·p0.9999    sample           8.585             ms/op
IteratorsBenchmark.testReverseStandard_a:testReverseStandard_a·p1.00      sample           8.585             ms/op
IteratorsBenchmark.testReverseStandard_b                                  sample    40   133.038 ±  14.202   ms/op
IteratorsBenchmark.testReverseStandard_b:testReverseStandard_b·p0.00      sample         111.018             ms/op
IteratorsBenchmark.testReverseStandard_b:testReverseStandard_b·p0.50      sample         125.829             ms/op
IteratorsBenchmark.testReverseStandard_b:testReverseStandard_b·p0.90      sample         179.149             ms/op
IteratorsBenchmark.testReverseStandard_b:testReverseStandard_b·p0.95      sample         187.092             ms/op
IteratorsBenchmark.testReverseStandard_b:testReverseStandard_b·p0.99      sample         201.064             ms/op
IteratorsBenchmark.testReverseStandard_b:testReverseStandard_b·p0.999     sample         201.064             ms/op
IteratorsBenchmark.testReverseStandard_b:testReverseStandard_b·p0.9999    sample         201.064             ms/op
IteratorsBenchmark.testReverseStandard_b:testReverseStandard_b·p1.00      sample         201.064             ms/op
IteratorsBenchmark.testReverseStandard_c                                  sample     5  1469.684 ± 318.615   ms/op
IteratorsBenchmark.testReverseStandard_c:testReverseStandard_c·p0.00      sample        1379.926             ms/op
IteratorsBenchmark.testReverseStandard_c:testReverseStandard_c·p0.50      sample        1442.841             ms/op
IteratorsBenchmark.testReverseStandard_c:testReverseStandard_c·p0.90      sample        1591.738             ms/op
IteratorsBenchmark.testReverseStandard_c:testReverseStandard_c·p0.95      sample        1591.738             ms/op
IteratorsBenchmark.testReverseStandard_c:testReverseStandard_c·p0.99      sample        1591.738             ms/op
IteratorsBenchmark.testReverseStandard_c:testReverseStandard_c·p0.999     sample        1591.738             ms/op
IteratorsBenchmark.testReverseStandard_c:testReverseStandard_c·p0.9999    sample        1591.738             ms/op
IteratorsBenchmark.testReverseStandard_c:testReverseStandard_c·p1.00      sample        1591.738             ms/op
```