### PR TITLE
Negative values documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Please see the examples folder for more examples.
 Unsigned integers
 ------------------
 
-Java lacks native unsigned integers, but integers are still considered to be unsigned within Roaring, and ordered  according to  ``Integer.compareUnsigned``. This means that Java will order the numbers like so 0, 1, ..., 2147483647, -2147483648, -2147483647,..., -1. To intepret correctly, you can use ``Integer.toUnsignedLong`` and ``Integer.toUnsignedString``.
+JVM lacks native unsigned integers but integers are still considered to be unsigned within Roaring and ordered according to ``Integer.compareUnsigned``. This means that JVM will order the numbers like so 0, 1, ..., 2147483647, -2147483648, -2147483647,..., -1. To interpret correctly, you can use ``Integer.toUnsignedLong`` and ``Integer.toUnsignedString``.
 
 
 Working with memory-mapped bitmaps

--- a/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -929,6 +929,10 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
   /**
    * Add the value to the container (set the value to "true"), whether it already appears or not.
    *
+   * JVM lacks native unsigned integers but the `x` argument is considered to be unsigned.
+   * Within bitmap numbers are ordered according to {@link Integer#compareUnsigned}.
+   * JVM will order the numbers like 0, 1, ..., 2147483647, -2147483648, -2147483647,..., -1.
+   *
    * @param x integer value
    */
   public void add(final int x) {

--- a/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
+++ b/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
@@ -678,6 +678,10 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
   /**
    * Add the value to the container (set the value to "true"), whether it already appears or not.
    *
+   * JVM lacks native unsigned integers but the `x` argument is considered to be unsigned.
+   * Within bitmap numbers are ordered according to {@link Integer#compareUnsigned}.
+   * JVM will order the numbers like 0, 1, ..., 2147483647, -2147483648, -2147483647,..., -1.
+   *
    * @param x integer value
    */
   @Override

--- a/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -4568,4 +4568,22 @@ public class TestRoaringBitmap {
     Assert.assertEquals(1, RoaringBitmap.bitmapOf(65537).rank(65538));
   }
 
+
+  @Test
+  public void testNegativeAdd() {
+    RoaringBitmap bitmap = new RoaringBitmap();
+    bitmap.add(-7);
+
+    Assert.assertEquals("{4294967289}", bitmap.toString());
+  }
+
+  @Test
+  public void testNegative_last() {
+    RoaringBitmap bitmap = new RoaringBitmap();
+    bitmap.add(-7);
+    bitmap.add(777);
+
+    Assert.assertEquals(-7, bitmap.last());
+  }
+
 }

--- a/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
+++ b/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
@@ -1395,4 +1395,22 @@ public class TestImmutableRoaringBitmap {
     Assert.assertEquals(1, ImmutableRoaringBitmap.bitmapOf(65537).rank(65537));
     Assert.assertEquals(1, ImmutableRoaringBitmap.bitmapOf(65537).rank(65538));
   }
+
+
+  @Test
+  public void testNegativeAdd() {
+    MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+    bitmap.add(-7);
+
+    Assert.assertEquals("{4294967289}", bitmap.toString());
+  }
+
+  @Test
+  public void testNegative_last() {
+    MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+    bitmap.add(-7);
+    bitmap.add(777);
+
+    Assert.assertEquals(-7, bitmap.last());
+  }
 }


### PR DESCRIPTION
I was trying to confirm what is expected behaviour of bitmaps with negatives values. 
From the tests it was obvious that arguments are teated as UNSIGNED_INT.
Later I found it nicely documented in README but it would be great to have it documented it in javadoc.