### PR TITLE
AC.andNot(RC)

### DIFF
--- a/jmh/src/main/java/org/roaringbitmap/RoaringOnlyBenchmarkState.java
+++ b/jmh/src/main/java/org/roaringbitmap/RoaringOnlyBenchmarkState.java
@@ -1,0 +1,101 @@
+package org.roaringbitmap;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.Lists;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import static org.roaringbitmap.realdata.wrapper.BitmapFactory.*;
+
+@State(Scope.Benchmark)
+public abstract class RoaringOnlyBenchmarkState {
+
+  public List<RoaringBitmap> bitmaps;
+  public List<RoaringBitmap> onlyArrayContainers;
+  public List<RoaringBitmap> onlyRunContainers;
+  public List<RoaringBitmap> onlyBitmapContainers;
+
+  // All tests relying on the same dataset should be run consecutively: the cache will maintain in
+  // memory the associated int arrays
+  private static final Cache<String, List<int[]>> DATASET_CACHE =
+      CacheBuilder.newBuilder().maximumSize(1).build();
+
+  public void setup(final String dataset) throws Exception {
+
+    bitmaps = new ArrayList<RoaringBitmap>();
+    onlyArrayContainers = new ArrayList<RoaringBitmap>();
+    onlyRunContainers = new ArrayList<RoaringBitmap>();
+    onlyBitmapContainers = new ArrayList<RoaringBitmap>();
+
+    List<int[]> ints = DATASET_CACHE.get(dataset, new Callable<List<int[]>>() {
+
+      @Override
+      public List<int[]> call() throws Exception {
+        System.out.println("Loading" + dataset);
+        ZipRealDataRetriever dataRetriever = new ZipRealDataRetriever(dataset);
+        return Lists.newArrayList(dataRetriever.fetchBitPositions());
+      }
+    });
+
+    for (int[] data : ints) {
+      RoaringBitmap roaring = RoaringBitmap.bitmapOf(data);
+      roaring.runOptimize();
+      bitmaps.add(roaring);
+
+    }
+    //Add bitmaps with only RunContainers preserved
+    for (RoaringBitmap rb : bitmaps) {
+      RoaringBitmap runOnly = new RoaringBitmap();
+      ContainerPointer cp = rb.getContainerPointer();
+      while (cp.getContainer() != null) {
+        if (cp.isRunContainer()) {
+          runOnly.highLowContainer.append(cp.key(), cp.getContainer());
+        }
+        cp.advance();
+      }
+      onlyRunContainers.add(runOnly);
+    }
+
+    //Add bitmaps with only ArrayContainers preserved
+    for (RoaringBitmap rb : bitmaps) {
+      RoaringBitmap clone = rb.clone();
+      RoaringBitmap arrayOnly = new RoaringBitmap();
+      clone.removeRunCompression(); //more containers preserved
+      ContainerPointer cp = clone.getContainerPointer();
+      while (cp.getContainer() != null) {
+        if (!cp.isBitmapContainer()) {
+          arrayOnly.highLowContainer.append(cp.key(), cp.getContainer());
+        }
+        cp.advance();
+      }
+      onlyArrayContainers.add(arrayOnly);
+    }
+
+    //Add bitmaps with only BitmapContainers preserved
+    for (RoaringBitmap rb : bitmaps) {
+      RoaringBitmap clone = rb.clone();
+      RoaringBitmap bitmapOnly = new RoaringBitmap();
+      clone.removeRunCompression(); //more containers preserved
+      ContainerPointer cp = clone.getContainerPointer();
+      while (cp.getContainer() != null) {
+        if (cp.isBitmapContainer()) {
+          bitmapOnly.highLowContainer.append(cp.key(), cp.getContainer());
+        }
+        cp.advance();
+      }
+      onlyBitmapContainers.add(bitmapOnly);
+    }
+  }
+
+  @TearDown
+  public void tearDown() {
+    System.out.println("card: "+ArrayContainer.totalByCardinality + " runs: "+ArrayContainer.totalByRuns +"ratio: "+ ((double)ArrayContainer.totalByCardinality)/ArrayContainer.totalByRuns+1);
+  }
+
+}

--- a/jmh/src/main/java/org/roaringbitmap/RoaringOnlyBenchmarkState.java
+++ b/jmh/src/main/java/org/roaringbitmap/RoaringOnlyBenchmarkState.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Lists;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,6 +22,11 @@ public abstract class RoaringOnlyBenchmarkState {
   public List<RoaringBitmap> onlyRunContainers;
   public List<RoaringBitmap> onlyBitmapContainers;
 
+  public List<ImmutableRoaringBitmap> immutableBitmaps;
+  public List<ImmutableRoaringBitmap> immutableOnlyArrayContainers;
+  public List<ImmutableRoaringBitmap> immutableOnlyRunContainers;
+  public List<ImmutableRoaringBitmap> immutableOnlyBitmapContainers;
+
   // All tests relying on the same dataset should be run consecutively: the cache will maintain in
   // memory the associated int arrays
   private static final Cache<String, List<int[]>> DATASET_CACHE =
@@ -28,10 +34,15 @@ public abstract class RoaringOnlyBenchmarkState {
 
   public void setup(final String dataset) throws Exception {
 
-    bitmaps = new ArrayList<RoaringBitmap>();
-    onlyArrayContainers = new ArrayList<RoaringBitmap>();
-    onlyRunContainers = new ArrayList<RoaringBitmap>();
-    onlyBitmapContainers = new ArrayList<RoaringBitmap>();
+    bitmaps = new ArrayList<>();
+    onlyArrayContainers = new ArrayList<>();
+    onlyRunContainers = new ArrayList<>();
+    onlyBitmapContainers = new ArrayList<>();
+    
+    immutableBitmaps = new ArrayList<>();
+    immutableOnlyArrayContainers = new ArrayList<>();
+    immutableOnlyRunContainers = new ArrayList<>();
+    immutableOnlyBitmapContainers = new ArrayList<>();
 
     List<int[]> ints = DATASET_CACHE.get(dataset, new Callable<List<int[]>>() {
 
@@ -47,6 +58,7 @@ public abstract class RoaringOnlyBenchmarkState {
       RoaringBitmap roaring = RoaringBitmap.bitmapOf(data);
       roaring.runOptimize();
       bitmaps.add(roaring);
+      immutableBitmaps.add(roaring.toMutableRoaringBitmap());
 
     }
     //Add bitmaps with only RunContainers preserved
@@ -60,6 +72,7 @@ public abstract class RoaringOnlyBenchmarkState {
         cp.advance();
       }
       onlyRunContainers.add(runOnly);
+      immutableOnlyRunContainers.add(runOnly.toMutableRoaringBitmap());
     }
 
     //Add bitmaps with only ArrayContainers preserved
@@ -75,6 +88,7 @@ public abstract class RoaringOnlyBenchmarkState {
         cp.advance();
       }
       onlyArrayContainers.add(arrayOnly);
+      immutableOnlyArrayContainers.add(arrayOnly.toMutableRoaringBitmap());
     }
 
     //Add bitmaps with only BitmapContainers preserved
@@ -90,7 +104,10 @@ public abstract class RoaringOnlyBenchmarkState {
         cp.advance();
       }
       onlyBitmapContainers.add(bitmapOnly);
+      immutableOnlyBitmapContainers.add(bitmapOnly.toMutableRoaringBitmap());
     }
+
+
   }
 
   @TearDown

--- a/jmh/src/main/java/org/roaringbitmap/RoaringOnlyBenchmarkState.java
+++ b/jmh/src/main/java/org/roaringbitmap/RoaringOnlyBenchmarkState.java
@@ -38,7 +38,7 @@ public abstract class RoaringOnlyBenchmarkState {
     onlyArrayContainers = new ArrayList<>();
     onlyRunContainers = new ArrayList<>();
     onlyBitmapContainers = new ArrayList<>();
-    
+
     immutableBitmaps = new ArrayList<>();
     immutableOnlyArrayContainers = new ArrayList<>();
     immutableOnlyRunContainers = new ArrayList<>();

--- a/jmh/src/main/java/org/roaringbitmap/RoaringOnlyBenchmarkState.java
+++ b/jmh/src/main/java/org/roaringbitmap/RoaringOnlyBenchmarkState.java
@@ -95,7 +95,6 @@ public abstract class RoaringOnlyBenchmarkState {
 
   @TearDown
   public void tearDown() {
-    System.out.println("card: "+ArrayContainer.totalByCardinality + " runs: "+ArrayContainer.totalByRuns +"ratio: "+ ((double)ArrayContainer.totalByCardinality)/ArrayContainer.totalByRuns+1);
   }
 
 }

--- a/jmh/src/main/java/org/roaringbitmap/realdata/state/RealDataRoaringOnlyBenchmarkState.java
+++ b/jmh/src/main/java/org/roaringbitmap/realdata/state/RealDataRoaringOnlyBenchmarkState.java
@@ -1,0 +1,32 @@
+package org.roaringbitmap.realdata.state;
+
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import static org.roaringbitmap.RealDataset.*;
+import static org.roaringbitmap.realdata.wrapper.BitmapFactory.CONCISE;
+import static org.roaringbitmap.realdata.wrapper.BitmapFactory.EWAH;
+import static org.roaringbitmap.realdata.wrapper.BitmapFactory.EWAH32;
+import static org.roaringbitmap.realdata.wrapper.BitmapFactory.ROARING;
+import static org.roaringbitmap.realdata.wrapper.BitmapFactory.ROARING_WITH_RUN;
+import static org.roaringbitmap.realdata.wrapper.BitmapFactory.WAH;
+
+@State(Scope.Benchmark)
+public class RealDataRoaringOnlyBenchmarkState extends org.roaringbitmap.RoaringOnlyBenchmarkState {
+
+  @Param({// putting the data sets in alpha. order
+      CENSUS_INCOME, CENSUS1881, DIMENSION_008, DIMENSION_003, DIMENSION_033, USCENSUS2000,
+      WEATHER_SEPT_85, WIKILEAKS_NOQUOTES, CENSUS_INCOME_SRT, CENSUS1881_SRT, WEATHER_SEPT_85_SRT,
+      WIKILEAKS_NOQUOTES_SRT})
+  public String dataset;
+
+  public RealDataRoaringOnlyBenchmarkState() {}
+
+  @Setup
+  public void setup() throws Exception {
+    super.setup(dataset);
+  }
+
+}

--- a/jmh/src/main/java/org/roaringbitmap/runcontainer/ArrayContainerAndNotRunContainerBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/runcontainer/ArrayContainerAndNotRunContainerBenchmark.java
@@ -1,0 +1,21 @@
+package org.roaringbitmap.runcontainer;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.roaringbitmap.RoaringBitmap;
+import org.roaringbitmap.RoaringOnlyBenchmarkState;
+import org.roaringbitmap.realdata.state.RealDataRoaringOnlyBenchmarkState;
+
+@BenchmarkMode(Mode.Throughput)
+public class ArrayContainerAndNotRunContainerBenchmark {
+
+  @Benchmark
+  public RoaringBitmap pairwiseACAndNotRC(RealDataRoaringOnlyBenchmarkState bs) {
+    RoaringBitmap last = null;
+    for (int k = 0; k + 1 < bs.bitmaps.size(); ++k) {
+      last = RoaringBitmap.andNot(bs.onlyArrayContainers.get(k), bs.onlyRunContainers.get(k + 1));
+    }
+    return last;
+  }
+}

--- a/jmh/src/main/java/org/roaringbitmap/runcontainer/ArrayContainerAndNotRunContainerBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/runcontainer/ArrayContainerAndNotRunContainerBenchmark.java
@@ -5,6 +5,7 @@ import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
 import org.roaringbitmap.RoaringBitmap;
 import org.roaringbitmap.RoaringOnlyBenchmarkState;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.realdata.state.RealDataRoaringOnlyBenchmarkState;
 
 @BenchmarkMode(Mode.Throughput)
@@ -15,6 +16,15 @@ public class ArrayContainerAndNotRunContainerBenchmark {
     RoaringBitmap last = null;
     for (int k = 0; k + 1 < bs.bitmaps.size(); ++k) {
       last = RoaringBitmap.andNot(bs.onlyArrayContainers.get(k), bs.onlyRunContainers.get(k + 1));
+    }
+    return last;
+  }
+
+  @Benchmark
+  public ImmutableRoaringBitmap immutablePairwiseACAndNotRC(RealDataRoaringOnlyBenchmarkState bs) {
+    ImmutableRoaringBitmap last = null;
+    for (int k = 0; k + 1 < bs.immutableBitmaps.size(); ++k) {
+      last = ImmutableRoaringBitmap.andNot(bs.immutableOnlyArrayContainers.get(k), bs.immutableOnlyRunContainers.get(k + 1));
     }
     return last;
   }

--- a/jmh/src/main/java/org/roaringbitmap/runcontainer/BasicAndNotContainerBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/runcontainer/BasicAndNotContainerBenchmark.java
@@ -72,9 +72,12 @@ public class BasicAndNotContainerBenchmark {
 
   @Benchmark
   public int part3_andNotArrayContainerVSRunContainerContainer(BenchmarkState benchmarkState) {
-    if (benchmarkState.rc2.serializedSizeInBytes() > benchmarkState.ac2.serializedSizeInBytes())
-      throw new RuntimeException("Can't expect run containers to win if they are larger.");
     return benchmarkState.ac4.andNot(benchmarkState.rc2).getCardinality();
+  }
+
+  @Benchmark
+  public int part4_andNotArrayContainerVSRunContainerContainer(BenchmarkState benchmarkState) {
+    return benchmarkState.ac4.andNot(benchmarkState.rc4).getCardinality();
   }
 
   @Benchmark
@@ -101,7 +104,7 @@ public class BasicAndNotContainerBenchmark {
     public int bitsetperword2 = 63;
     public int bitsetperword3 = 1;
 
-    Container rc1, rc2, rc3, ac1, ac2, ac3, ac4;
+    Container rc1, rc2, rc3, rc4, ac1, ac2, ac3, ac4;
     Random rand = new Random();
 
     public BenchmarkState() {
@@ -120,6 +123,8 @@ public class BasicAndNotContainerBenchmark {
 
       rc3 = new RunContainer();
       rc3 = RandomUtil.fillMeUp(rc3, values3);
+
+      rc4 = new RunContainer(new short[]{4, 500, 2000, 1000, 5000, 3000, 16000, 10000, 32000, 600}, 5);
 
       ac1 = new ArrayContainer();
       ac1 = RandomUtil.fillMeUp(ac1, values1);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -40,7 +40,9 @@ public final class ArrayContainer extends Container implements Cloneable {
   public ArrayContainer() {
     this(DEFAULT_INIT_SIZE);
   }
-
+  public static ArrayContainer empty() {
+    return new ArrayContainer();
+  }
   /**
    * Create an array container with specified capacity
    *
@@ -231,6 +233,8 @@ public final class ArrayContainer extends Container implements Cloneable {
     int whichRun;
     if (x.nbrruns == 0) {
       return clone();
+    } else if (x.isFull()) {
+      return ArrayContainer.empty();
     } else {
       runStart = Util.toIntUnsigned(x.getValue(0));
       runEnd = runStart + Util.toIntUnsigned(x.getLength(0));

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -237,7 +237,7 @@ public final class ArrayContainer extends Container implements Cloneable {
     }
     int write = 0;
     int read = 0;
-    short[] buffer = new short[cardinality];
+    ArrayContainer answer = new ArrayContainer(cardinality);
     for (int i = 0; i < x.numberOfRuns() && read < cardinality; ++i) {
       int runStart = Util.toIntUnsigned(x.getValue(i));
       int runEnd = runStart + Util.toIntUnsigned(x.getLength(i));
@@ -246,15 +246,15 @@ public final class ArrayContainer extends Container implements Cloneable {
       }
       int firstInRun = Util.iterateUntil(content, read, cardinality, runStart);
       int toWrite = firstInRun - read;
-      System.arraycopy(content, read, buffer, write, toWrite);
+      System.arraycopy(content, read, answer.content, write, toWrite);
       write += toWrite;
 
       read = Util.iterateUntil(content, firstInRun, cardinality, runEnd + 1);
     }
-    System.arraycopy(content, read, buffer, write, cardinality - read);
+    System.arraycopy(content, read, answer.content, write, cardinality - read);
     write += cardinality - read;
-
-    return new ArrayContainer(write, buffer);
+    answer.cardinality = write;
+    return answer;
   }
 
   @Override

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -40,6 +40,7 @@ public final class ArrayContainer extends Container implements Cloneable {
   public ArrayContainer() {
     this(DEFAULT_INIT_SIZE);
   }
+
   public static ArrayContainer empty() {
     return new ArrayContainer();
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -227,10 +227,8 @@ public final class ArrayContainer extends Container implements Cloneable {
 
   @Override
   public Container andNot(RunContainer x) {
-    int writeLocation = 0;
     int runStart, runEnd; // the current or upcoming run.
     int whichRun;
-    short[] buffer = new short[cardinality];
     if (x.nbrruns == 0) {
       return clone();
     } else {
@@ -238,6 +236,8 @@ public final class ArrayContainer extends Container implements Cloneable {
       runEnd = runStart + Util.toIntUnsigned(x.getLength(0));
       whichRun = 0;
     }
+    int writeLocation = 0;
+    short[] buffer = new short[cardinality];
 
     short val;
     for (int i = 0; i < cardinality; ++i) {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -228,53 +228,12 @@ public final class ArrayContainer extends Container implements Cloneable {
   }
 
   @Override
-  public Container andNot(RunContainer x) {
+  public ArrayContainer andNot(RunContainer x) {
     if (x.numberOfRuns() == 0) {
       return clone();
     } else if (x.isFull()) {
       return ArrayContainer.empty();
     }
-    return byRunsAndNot(x);
-  }
-
-  private Container byCardinalityAndNot(RunContainer x) {
-    int runStart, runEnd; // the current or upcoming run.
-    int whichRun;
-
-    runStart = Util.toIntUnsigned(x.getValue(0));
-    runEnd = runStart + Util.toIntUnsigned(x.getLength(0));
-    whichRun = 0;
-
-    int writeLocation = 0;
-    short[] buffer = new short[cardinality];
-
-    short val;
-    for (int i = 0; i < cardinality;) {
-      val = content[i];
-      int valInt = Util.toIntUnsigned(val);
-      if (valInt < runStart) {
-        buffer[writeLocation++] = val;
-        i++;
-      } else if (valInt <= runEnd) {
-        i++; // don't want item
-      } else {
-        // greater than this run, need to do an advanceUntil on runs
-        // done sequentially for now (no galloping attempts).
-        do {
-          if (whichRun + 1 < x.nbrruns) {
-            whichRun++;
-            runStart = Util.toIntUnsigned(x.getValue(whichRun));
-            runEnd = runStart + Util.toIntUnsigned(x.getLength(whichRun));
-          } else {
-            runStart = runEnd = (1 << 16) + 1; // infinity....
-          }
-        } while (valInt > runEnd);
-      }
-    }
-    return new ArrayContainer(writeLocation, buffer);
-  }
-
-  private ArrayContainer byRunsAndNot(RunContainer x) {
     int write = 0;
     int read = 0;
     short[] buffer = new short[cardinality];

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -244,13 +244,14 @@ public final class ArrayContainer extends Container implements Cloneable {
     short[] buffer = new short[cardinality];
 
     short val;
-    for (int i = 0; i < cardinality; ++i) {
+    for (int i = 0; i < cardinality;) {
       val = content[i];
       int valInt = Util.toIntUnsigned(val);
       if (valInt < runStart) {
         buffer[writeLocation++] = val;
+        i++;
       } else if (valInt <= runEnd) {
-        ; // don't want item
+        i++; // don't want item
       } else {
         // greater than this run, need to do an advanceUntil on runs
         // done sequentially for now (no galloping attempts).
@@ -263,7 +264,6 @@ public final class ArrayContainer extends Container implements Cloneable {
             runStart = runEnd = (1 << 16) + 1; // infinity....
           }
         } while (valInt > runEnd);
-        --i; // need to re-process this val
       }
     }
     return new ArrayContainer(writeLocation, buffer);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -281,7 +281,7 @@ public final class ArrayContainer extends Container implements Cloneable {
     for (int i = 0; i < x.numberOfRuns() && read < cardinality; ++i) {
       int runStart = Util.toIntUnsigned(x.getValue(i));
       int runEnd = runStart + Util.toIntUnsigned(x.getLength(i));
-      if (Util.compareUnsigned(content[read], (short) runEnd) > 0) {
+      if (Util.toIntUnsigned(content[read]) > runEnd) {
         continue;
       }
       int firstInRun = Util.iterateUntil(content, read, cardinality, runStart);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/Util.java
@@ -84,6 +84,24 @@ public final class Util {
 
   }
 
+  /**
+   * Find the smallest integer larger than pos such that array[pos]&gt;= min. If none can be found,
+   * return length.
+   *
+   * @param array array to search within
+   * @param pos starting position of the search
+   * @param length length of the array to search
+   * @param min minimum value
+   * @return x greater than pos such that array[pos] is at least as large as min, pos is is equal to
+   *         length if it is not possible.
+   */
+  public static int iterateUntil(short[] array, int pos, int length, int min) {
+    while (pos < length && toIntUnsigned(array[pos]) < min) {
+      pos++;
+    }
+    return pos;
+  }
+
   protected static int branchyUnsignedBinarySearch(final short[] array, final int begin,
       final int end, final short k) {
     int ikey = toIntUnsigned(k);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/BufferUtil.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/BufferUtil.java
@@ -85,6 +85,24 @@ public final class BufferUtil {
 
   }
 
+  /**
+   * Find the smallest integer larger than pos such that array[pos]&gt;= min. If none can be found,
+   * return length.
+   *
+   * @param array array to search within
+   * @param pos starting position of the search
+   * @param length length of the array to search
+   * @param min minimum value
+   * @return x greater than pos such that array[pos] is at least as large as min, pos is is equal to
+   *         length if it is not possible.
+   */
+  public static int iterateUntil(ShortBuffer array, int pos, int length, int min) {
+    while (pos < length && toIntUnsigned(array.get(pos)) < min) {
+      pos++;
+    }
+    return pos;
+  }
+
 
   protected static void arraycopy(ShortBuffer src, int srcPos, ShortBuffer dest, int destPos,
       int length) {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -304,7 +304,7 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     }
     int write = 0;
     int read = 0;
-    ShortBuffer buffer = ShortBuffer.allocate(cardinality);
+    MappeableArrayContainer answer = new MappeableArrayContainer(cardinality);
     for (int i = 0; i < x.numberOfRuns() && read < cardinality; ++i) {
       int runStart = BufferUtil.toIntUnsigned(x.getValue(i));
       int runEnd = runStart + BufferUtil.toIntUnsigned(x.getLength(i));
@@ -313,15 +313,15 @@ public final class MappeableArrayContainer extends MappeableContainer implements
       }
       int firstInRun = BufferUtil.iterateUntil(content, read, cardinality, runStart);
       int toWrite = firstInRun - read;
-      BufferUtil.arraycopy(content, read, buffer, write, toWrite);
+      BufferUtil.arraycopy(content, read, answer.content, write, toWrite);
       write += toWrite;
 
       read = BufferUtil.iterateUntil(content, firstInRun, cardinality, runEnd + 1);
     }
-    BufferUtil.arraycopy(content, read, buffer, write, cardinality - read);
+    BufferUtil.arraycopy(content, read, answer.content, write, cardinality - read);
     write += cardinality - read;
-
-    return new MappeableArrayContainer(write, buffer);
+    answer.cardinality = write;
+    return answer;
 
   }
 

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -53,6 +53,10 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     this(DEFAULT_INIT_SIZE);
   }
 
+  public static MappeableArrayContainer empty() {
+    return new MappeableArrayContainer();
+  }
+
   /**
    * Creates a new container from a non-mappeable one. This copies the data.
    *
@@ -293,42 +297,32 @@ public final class MappeableArrayContainer extends MappeableContainer implements
 
   @Override
   public MappeableContainer andNot(final MappeableRunContainer x) {
-    int writeLocation = 0;
-    int runStart, runEnd; // the current or upcoming run.
-    if (x.nbrruns == 0) {
+    if (x.numberOfRuns() == 0) {
       return clone();
+    } else if (x.isFull()) {
+      return MappeableArrayContainer.empty();
     }
-
+    int write = 0;
+    int read = 0;
     ShortBuffer buffer = ShortBuffer.allocate(cardinality);
-
-    runStart = toIntUnsigned(x.getValue(0));
-    runEnd = runStart + toIntUnsigned(x.getLength(0));
-    int whichRun = 0;
-
-    short val;
-    for (int i = 0; i < cardinality; ++i) {
-      val = content.get(i);
-      int valInt = toIntUnsigned(val);
-      if (valInt < runStart) {
-        buffer.put(writeLocation++, val);
-      } else if (valInt <= runEnd) {
-        ; // don't want item
-      } else {
-        // greater than this run, need to do an advanceUntil on runs
-        // done sequentially for now (no galloping attempts).
-        do {
-          if (whichRun + 1 < x.nbrruns) {
-            whichRun++;
-            runStart = toIntUnsigned(x.getValue(whichRun));
-            runEnd = runStart + toIntUnsigned(x.getLength(whichRun));
-          } else {
-            runStart = runEnd = (1 << 16) + 1; // infinity....
-          }
-        } while (valInt > runEnd);
-        --i; // need to re-process this val
+    for (int i = 0; i < x.numberOfRuns() && read < cardinality; ++i) {
+      int runStart = BufferUtil.toIntUnsigned(x.getValue(i));
+      int runEnd = runStart + BufferUtil.toIntUnsigned(x.getLength(i));
+      if (BufferUtil.toIntUnsigned(content.get(read)) > runEnd) {
+        continue;
       }
+      int firstInRun = BufferUtil.iterateUntil(content, read, cardinality, runStart);
+      int toWrite = firstInRun - read;
+      BufferUtil.arraycopy(content, read, buffer, write, toWrite);
+      write += toWrite;
+
+      read = BufferUtil.iterateUntil(content, firstInRun, cardinality, runEnd + 1);
     }
-    return new MappeableArrayContainer(writeLocation, buffer);
+    BufferUtil.arraycopy(content, read, buffer, write, cardinality - read);
+    write += cardinality - read;
+
+    return new MappeableArrayContainer(write, buffer);
+
   }
 
   @Override

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
@@ -2157,6 +2157,26 @@ public class TestRunContainer {
     assertTrue(atLeastOneArray);
   }
 
+  @Test
+  public void RunContainerArg_ArrayANDNOT2() {
+    ArrayContainer ac = new ArrayContainer(10, new short[]{0, 2, 4, 8, 10, 15, 16, 48, 50, 61});
+    RunContainer rc = new RunContainer(new short[]{7, 3, 17, 2, 20, 3, 30, 3, 36, 6, 60, 5}, 6);
+    Assert.assertEquals(new ArrayContainer(7, new short[]{0, 2, 4, 15, 16, 48, 50}), ac.andNot(rc));
+  }
+
+  @Test
+  public void FullRunContainerArg_ArrayANDNOT2() {
+    ArrayContainer ac = new ArrayContainer(1, new short[]{3});
+    Container rc = RunContainer.full();
+    Assert.assertEquals(new ArrayContainer(), ac.andNot(rc));
+  }
+
+  @Test
+  public void RunContainerArg_ArrayANDNOT3() {
+    ArrayContainer ac = new ArrayContainer(1, new short[]{5});
+    Container rc = new RunContainer(new short[]{3, 10}, 1);
+    Assert.assertEquals(new ArrayContainer(), ac.andNot(rc));
+  }
 
   @Test
   public void RunContainerArg_ArrayOR() {

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
@@ -2159,9 +2159,9 @@ public class TestRunContainer {
 
   @Test
   public void RunContainerArg_ArrayANDNOT2() {
-    ArrayContainer ac = new ArrayContainer(10, new short[]{0, 2, 4, 8, 10, 15, 16, 48, 50, 61});
-    RunContainer rc = new RunContainer(new short[]{7, 3, 17, 2, 20, 3, 30, 3, 36, 6, 60, 5}, 6);
-    Assert.assertEquals(new ArrayContainer(7, new short[]{0, 2, 4, 15, 16, 48, 50}), ac.andNot(rc));
+    ArrayContainer ac = new ArrayContainer(12, new short[]{0, 2, 4, 8, 10, 15, 16, 48, 50, 61, 80, -2});
+    RunContainer rc = new RunContainer(new short[]{7, 3, 17, 2, 20, 3, 30, 3, 36, 6, 60, 5, -3, 2}, 7);
+    Assert.assertEquals(new ArrayContainer(8, new short[]{0, 2, 4, 15, 16, 48, 50, 80}), ac.andNot(rc));
   }
 
   @Test

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestUtil.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestUtil.java
@@ -83,10 +83,20 @@ public class TestUtil {
 
     @Test
     public void testAdvanceUntil() {
-        short data[] = {0, 3, 16, 18, 21, 29, 30};
+        short data[] = {0, 3, 16, 18, 21, 29, 30,-342};
         Assert.assertEquals(1, Util.advanceUntil(data, -1, data.length, (short) 3));
         Assert.assertEquals(5, Util.advanceUntil(data, -1, data.length, (short) 28));
         Assert.assertEquals(5, Util.advanceUntil(data, -1, data.length, (short) 29));
+        Assert.assertEquals(7, Util.advanceUntil(data, -1, data.length, (short) -342));
+    }
+
+    @Test
+    public void testIterateUntil() {
+        short data[] = {0, 3, 16, 18, 21, 29, 30, -342};
+        Assert.assertEquals(1, Util.iterateUntil(data, -1, data.length, Util.toIntUnsigned((short) 3)));
+        Assert.assertEquals(5, Util.iterateUntil(data, -1, data.length, Util.toIntUnsigned((short) 28)));
+        Assert.assertEquals(5, Util.iterateUntil(data, -1, data.length, Util.toIntUnsigned((short) 29)));
+        Assert.assertEquals(7, Util.iterateUntil(data, -1, data.length, Util.toIntUnsigned((short) -342)));
     }
 
     @Test

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestUtil.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestUtil.java
@@ -80,4 +80,13 @@ public class TestUtil {
         Util.partialRadixSort(test);
         Assert.assertArrayEquals(expected, test);
     }
+
+    @Test
+    public void testAdvanceUntil() {
+        short data[] = {0, 3, 16, 18, 21, 29, 30};
+        Assert.assertEquals(1, Util.advanceUntil(data, -1, data.length, (short) 3));
+        Assert.assertEquals(5, Util.advanceUntil(data, -1, data.length, (short) 28));
+        Assert.assertEquals(5, Util.advanceUntil(data, -1, data.length, (short) 29));
+    }
+
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestUtil.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestUtil.java
@@ -93,10 +93,10 @@ public class TestUtil {
     @Test
     public void testIterateUntil() {
         short data[] = {0, 3, 16, 18, 21, 29, 30, -342};
-        Assert.assertEquals(1, Util.iterateUntil(data, -1, data.length, Util.toIntUnsigned((short) 3)));
-        Assert.assertEquals(5, Util.iterateUntil(data, -1, data.length, Util.toIntUnsigned((short) 28)));
-        Assert.assertEquals(5, Util.iterateUntil(data, -1, data.length, Util.toIntUnsigned((short) 29)));
-        Assert.assertEquals(7, Util.iterateUntil(data, -1, data.length, Util.toIntUnsigned((short) -342)));
+        Assert.assertEquals(1, Util.iterateUntil(data, 0, data.length, Util.toIntUnsigned((short) 3)));
+        Assert.assertEquals(5, Util.iterateUntil(data, 0, data.length, Util.toIntUnsigned((short) 28)));
+        Assert.assertEquals(5, Util.iterateUntil(data, 0, data.length, Util.toIntUnsigned((short) 29)));
+        Assert.assertEquals(7, Util.iterateUntil(data, 0, data.length, Util.toIntUnsigned((short) -342)));
     }
 
     @Test

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestUtil.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestUtil.java
@@ -89,4 +89,22 @@ public class TestUtil {
         Assert.assertEquals(5, Util.advanceUntil(data, -1, data.length, (short) 29));
     }
 
+    @Test
+    public void testToUnsigned() {
+        Assert.assertEquals(0, Util.toIntUnsigned((short) 0));
+        Assert.assertEquals(128, Util.toIntUnsigned((short) 128));
+        Assert.assertEquals(32767, Util.toIntUnsigned(Short.MAX_VALUE));
+        Assert.assertEquals(32768, Util.toIntUnsigned(Short.MIN_VALUE));
+        Assert.assertEquals(65535, Util.toIntUnsigned((short) -1));
+    }
+
+    @Test
+    public void testReverseToUnsigned() {
+        Assert.assertEquals((short) 0,  (short) 0);
+        Assert.assertEquals((short) 128,  (short) 128);
+        Assert.assertEquals(Short.MAX_VALUE,  (short) 32767);
+        Assert.assertEquals(Short.MIN_VALUE,  (short) 32768);
+        Assert.assertEquals((short) -1,  (short) 65535);
+    }
+
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestRunContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestRunContainer.java
@@ -9,6 +9,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ShortBuffer;
 import java.util.*;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -1292,6 +1293,27 @@ public class TestRunContainer {
       }
     }
     assertTrue(atLeastOneArray);
+  }
+
+  @Test
+  public void RunContainerArg_ArrayANDNOT2() {
+    MappeableArrayContainer ac = new MappeableArrayContainer(ShortBuffer.wrap(new short[]{0, 2, 4, 8, 10, 15, 16, 48, 50, 61, 80, -2}), 12);
+    MappeableContainer rc = new MappeableRunContainer(ShortBuffer.wrap(new short[]{7, 3, 17, 2, 20, 3, 30, 3, 36, 6, 60, 5, -3, 2}), 7);
+    Assert.assertEquals(new MappeableArrayContainer(ShortBuffer.wrap(new short[]{0, 2, 4, 15, 16, 48, 50, 80}), 8), ac.andNot(rc));
+  }
+
+  @Test
+  public void FullRunContainerArg_ArrayANDNOT2() {
+    MappeableArrayContainer ac = new MappeableArrayContainer(ShortBuffer.wrap(new short[]{3}), 1);
+    MappeableContainer rc = MappeableRunContainer.full();
+    Assert.assertEquals(new MappeableArrayContainer(), ac.andNot(rc));
+  }
+
+  @Test
+  public void RunContainerArg_ArrayANDNOT3() {
+    MappeableArrayContainer ac = new MappeableArrayContainer(ShortBuffer.wrap(new short[]{5}), 1);
+    MappeableContainer rc = new MappeableRunContainer(ShortBuffer.wrap(new short[]{3, 10}), 1);
+    Assert.assertEquals(new MappeableArrayContainer(), ac.andNot(rc));
   }
 
   @Test

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestUtil.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestUtil.java
@@ -62,4 +62,40 @@ public class TestUtil {
         Assert.assertFalse(BufferUtil.unsignedIntersects(data4, data4.limit(), data5, data5.limit()));
     }
 
+  @Test
+    public void testAdvanceUntil() {
+        ShortBuffer data = ShortBuffer.wrap(new short[] {0, 3, 16, 18, 21, 29, 30, -342});
+        Assert.assertEquals(1, BufferUtil.advanceUntil(data, -1, data.limit(), (short) 3));
+        Assert.assertEquals(5, BufferUtil.advanceUntil(data, -1, data.limit(), (short) 28));
+        Assert.assertEquals(5, BufferUtil.advanceUntil(data, -1, data.limit(), (short) 29));
+        Assert.assertEquals(7, BufferUtil.advanceUntil(data, -1, data.limit(), (short) -342));
+    }
+
+    @Test
+    public void testIterateUntil() {
+        ShortBuffer data = ShortBuffer.wrap(new short[] {0, 3, 16, 18, 21, 29, 30, -342});
+        Assert.assertEquals(1, BufferUtil.iterateUntil(data, 0, data.limit(), BufferUtil.toIntUnsigned((short) 3)));
+        Assert.assertEquals(5, BufferUtil.iterateUntil(data, 0, data.limit(), BufferUtil.toIntUnsigned((short) 28)));
+        Assert.assertEquals(5, BufferUtil.iterateUntil(data, 0, data.limit(), BufferUtil.toIntUnsigned((short) 29)));
+        Assert.assertEquals(7, BufferUtil.iterateUntil(data, 0, data.limit(), BufferUtil.toIntUnsigned((short) -342)));
+    }
+
+    @Test
+    public void testToUnsigned() {
+        Assert.assertEquals(0, BufferUtil.toIntUnsigned((short) 0));
+        Assert.assertEquals(128, BufferUtil.toIntUnsigned((short) 128));
+        Assert.assertEquals(32767, BufferUtil.toIntUnsigned(Short.MAX_VALUE));
+        Assert.assertEquals(32768, BufferUtil.toIntUnsigned(Short.MIN_VALUE));
+        Assert.assertEquals(65535, BufferUtil.toIntUnsigned((short) -1));
+    }
+
+    @Test
+    public void testReverseToUnsigned() {
+        Assert.assertEquals((short) 0, (short) 0);
+        Assert.assertEquals((short) 128, (short) 128);
+        Assert.assertEquals(Short.MAX_VALUE, (short) 32767);
+        Assert.assertEquals(Short.MIN_VALUE, (short) 32768);
+        Assert.assertEquals((short) -1, (short) 65535);
+    }
+
 }


### PR DESCRIPTION
I've decided to try using `Util.advanceUntil` in `andNot` between `ArrayContainer` and `RunContainer`. The implementation present in the commit was verified with present tests and a new one, but for sure I'd test it more if going to be merged.

I run two benchmarks `part{3,4}_andNotArrayContainerVSRunContainerContainer` on `master` and the new branch.
```
BasicAndNotContainerBenchmark.part3_andNotArrayContainerVSRunContainerContainer  avgt   15  3327,444 ± 49,353  ns/op
BasicAndNotContainerBenchmark.part4_andNotArrayContainerVSRunContainerContainer  avgt   15  1877,370 ± 25,888  ns/op

BasicAndNotContainerBenchmark.part3_andNotArrayContainerVSRunContainerContainer  avgt   15  7790,214 ± 81,502  ns/op
BasicAndNotContainerBenchmark.part4_andNotArrayContainerVSRunContainerContainer  avgt   15  638,899 ± 4,385  ns/op
```

The code is slower for the present benchmark which `andNot` Array Container of 1024 elements with very dense Run Container of 1009 runs with 64512 cardinality.
The new benchmark uses Run Container with 5 very long runs and the new code is 3x faster.

I'm opening this Pull Request to discuss
- is it worth to use new approach?
- should there be a switch when to use old and new approach?

I think the new approach will be faster when there are long sequences of array elements covered by runs or between two runs.
If there are very few array elements per run or between runs the old approach should be faster.