### PR TITLE
Handle signedness correctly in RunContainer.first

### DIFF
--- a/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/src/main/java/org/roaringbitmap/RunContainer.java
@@ -2467,7 +2467,7 @@ public final class RunContainer extends Container implements Cloneable {
   @Override
   public int first() {
     assertNonEmpty(numberOfRuns() == 0);
-    return valueslength[0];
+    return Util.toIntUnsigned(valueslength[0]);
   }
 
   @Override

--- a/src/test/java/org/roaringbitmap/TestRunContainer.java
+++ b/src/test/java/org/roaringbitmap/TestRunContainer.java
@@ -3099,6 +3099,13 @@ public class TestRunContainer {
   }
 
   @Test
+  public void testFirstUnsigned() {
+    RoaringBitmap roaringWithRun = new RoaringBitmap();
+    roaringWithRun.add(32768L, 65536); // (1 << 15) to (1 << 16).
+    assertEquals(roaringWithRun.first(), 32768);
+  }
+
+  @Test
   public void testContainsBitmapContainer_EmptyContainsEmpty() {
     Container rc = new RunContainer();
     Container subset = new BitmapContainer();


### PR DESCRIPTION
This fixes a bug where the first value would be returned as a negative
number when the start of the run used all 16 bits.