### PR TITLE
Faster .rank .select

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/FastRankRoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/FastRankRoaringBitmap.java
@@ -26,7 +26,7 @@ public class FastRankRoaringBitmap extends RoaringBitmap {
 
   private void resetCache() {
     // Reset the cache on any write operation
-    // highToCumulatedCardinality = null;
+    highToCumulatedCardinality = null;
   }
 
   @Override
@@ -167,7 +167,7 @@ public class FastRankRoaringBitmap extends RoaringBitmap {
     }
 
     // TODO Should we keep the assertion?
-    assert rank == super.rankLong(x);
+    // assert rank == super.rankLong(x);
 
     return rank;
   }
@@ -210,8 +210,10 @@ public class FastRankRoaringBitmap extends RoaringBitmap {
     long leftover = Util.toUnsignedLong(j);
 
     if (index == highToCumulatedCardinality.length - 1) {
+      // We select the total cardinality: we are selecting the last element
       return this.last();
     } else if (index >= 0) {
+      // We selected a cumulated cardinality: we are selecting the last element of given bucket
       int keycontrib = this.highLowContainer.getKeyAtIndex(index + 1) << 16;
 
       // If first bucket has cardinality 1 and we select 1: we actual select the first item of
@@ -219,10 +221,12 @@ public class FastRankRoaringBitmap extends RoaringBitmap {
       int output = keycontrib + this.highLowContainer.getContainerAtIndex(index + 1).first();
 
       // TODO Should we keep the assertion?
-      assert output == super.select(j);
+      // assert output == super.select(j);
 
       return output;
     } else {
+      // We selected a cardinality not matching exactly the cumulated cardinalities: we are not
+      // selected the last element of a bucket
       fixedIndex = -1 - index;
       if (fixedIndex > 0) {
         leftover -= highToCumulatedCardinality[fixedIndex - 1];
@@ -235,11 +239,8 @@ public class FastRankRoaringBitmap extends RoaringBitmap {
     int value = lowcontrib + keycontrib;
 
     // TODO Should we keep the assertion?
-    assert value == super.select(j);
+    // assert value == super.select(j);
 
     return value;
-
-    // throw new IllegalArgumentException("select " + j + " when the cardinality is " +
-    // this.getCardinality());
   }
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/FastRankRoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/FastRankRoaringBitmap.java
@@ -1,0 +1,245 @@
+package org.roaringbitmap;
+
+import java.util.Arrays;
+
+/**
+ * This extends {@link RoaringBitmap} to provide better performance for .rank and .select
+ * operations, at the cost of maintain a cache of cardinalities.
+ * 
+ * On {@link RoaringBitmap#select(int)} and {@link RoaringBitmap#rank(int)} operations,
+ * {@link RoaringBitmap} needs to iterate along all underlying buckets to cumulate their
+ * cardinalities. This may lead to sub-optimal performance for application doing a large amount of
+ * .rank/.select over read-only {@link RoaringBitmap}, especially if the {@link RoaringBitmap} holds
+ * a large number of underlying buckets.
+ * 
+ * This implementation will discard the cache of cardinality on any write operations, and it will
+ * memoize the computed cardinalities on any .rank or .select operation
+ * 
+ * @author Benoit Lacelle
+ *
+ */
+public class FastRankRoaringBitmap extends RoaringBitmap {
+  // The cache of cardinalities: it maps the index of the underlying bucket to the cumulated
+  // cardinalities (i.e. the sum of current bucket cardinalities plus all previous bucklet
+  // cardinalities)
+  private int[] highToCumulatedCardinality = null;
+
+  private void resetCache() {
+    // Reset the cache on any write operation
+    // highToCumulatedCardinality = null;
+  }
+
+  @Override
+  public void add(long rangeStart, long rangeEnd) {
+    resetCache();
+    super.add(rangeStart, rangeEnd);
+  }
+
+  @Override
+  public void add(int x) {
+    resetCache();
+    super.add(x);
+  }
+
+  @Override
+  public void add(int... dat) {
+    resetCache();
+    super.add(dat);
+  }
+
+  @Deprecated
+  @Override
+  public void add(int rangeStart, int rangeEnd) {
+    resetCache();
+    super.add(rangeStart, rangeEnd);
+  }
+
+  @Override
+  public void clear() {
+    resetCache();
+    super.clear();
+  }
+
+  @Override
+  public void flip(int x) {
+    resetCache();
+    super.flip(x);
+  }
+
+  @Deprecated
+  @Override
+  public void flip(int rangeStart, int rangeEnd) {
+    resetCache();
+    super.flip(rangeStart, rangeEnd);
+  }
+
+  @Override
+  public void flip(long rangeStart, long rangeEnd) {
+    resetCache();
+    super.flip(rangeStart, rangeEnd);
+  }
+
+  @Override
+  public void and(RoaringBitmap x2) {
+    resetCache();
+    super.and(x2);
+  }
+
+  @Override
+  public void andNot(RoaringBitmap x2) {
+    resetCache();
+    super.andNot(x2);
+  }
+
+  @Deprecated
+  @Override
+  public void remove(int rangeStart, int rangeEnd) {
+    resetCache();
+    super.remove(rangeStart, rangeEnd);
+  }
+
+  @Override
+  public void remove(int x) {
+    resetCache();
+    super.remove(x);
+  }
+
+  @Override
+  public void remove(long rangeStart, long rangeEnd) {
+    resetCache();
+    super.remove(rangeStart, rangeEnd);
+  }
+
+  @Override
+  public boolean checkedAdd(int x) {
+    resetCache();
+    return super.checkedAdd(x);
+  }
+
+  @Override
+  public boolean checkedRemove(int x) {
+    resetCache();
+    return super.checkedRemove(x);
+  }
+
+  @Override
+  public void or(RoaringBitmap x2) {
+    resetCache();
+    super.or(x2);
+  }
+
+  @Override
+  public void xor(RoaringBitmap x2) {
+    resetCache();
+    super.xor(x2);
+  }
+
+
+  @Override
+  public long rankLong(int x) {
+    preComputeCardinalities();
+
+    if (highToCumulatedCardinality.length == 0) {
+      return 0L;
+    }
+
+    short xhigh = Util.highbits(x);
+
+    int index = Util.hybridUnsignedBinarySearch(this.highLowContainer.keys, 0,
+        this.highLowContainer.size(), xhigh);
+
+    boolean hasBitmapOnIdex;
+    if (index < 0) {
+      hasBitmapOnIdex = false;
+      index = -1 - index;
+    } else {
+      hasBitmapOnIdex = true;
+    }
+
+    long size = 0;
+    if (index > 0) {
+      size += highToCumulatedCardinality[index - 1];
+    }
+
+    long rank = size;
+    if (hasBitmapOnIdex) {
+      rank = size + this.highLowContainer.getContainerAtIndex(index).rank(Util.lowbits(x));
+    }
+
+    // TODO Should we keep the assertion?
+    assert rank == super.rankLong(x);
+
+    return rank;
+  }
+
+  /**
+   * On any .rank or .select operation, we pre-compute all cumulated cardinalities. It will enable
+   * using a binary-search to spot the relevant underlying bucket
+   */
+  private void preComputeCardinalities() {
+    if (highToCumulatedCardinality == null) {
+      highToCumulatedCardinality = new int[highLowContainer.size()];
+
+      if (highToCumulatedCardinality.length == 0) {
+        return;
+      }
+      highToCumulatedCardinality[0] = highLowContainer.getContainerAtIndex(0).getCardinality();
+
+      for (int i = 1; i < highToCumulatedCardinality.length; i++) {
+        highToCumulatedCardinality[i] = highToCumulatedCardinality[i - 1]
+            + highLowContainer.getContainerAtIndex(i).getCardinality();
+      }
+    }
+  }
+
+  @Override
+  public int select(int j) {
+    preComputeCardinalities();
+
+    if (highToCumulatedCardinality.length == 0) {
+      // empty: .select is out-of-bounds
+
+      throw new IllegalArgumentException(
+          "select " + j + " when the cardinality is " + this.getCardinality());
+    }
+
+    int index = Arrays.binarySearch(highToCumulatedCardinality, j);
+
+    int fixedIndex;
+
+    long leftover = Util.toUnsignedLong(j);
+
+    if (index == highToCumulatedCardinality.length - 1) {
+      return this.last();
+    } else if (index >= 0) {
+      int keycontrib = this.highLowContainer.getKeyAtIndex(index + 1) << 16;
+
+      // If first bucket has cardinality 1 and we select 1: we actual select the first item of
+      // second bucket
+      int output = keycontrib + this.highLowContainer.getContainerAtIndex(index + 1).first();
+
+      // TODO Should we keep the assertion?
+      assert output == super.select(j);
+
+      return output;
+    } else {
+      fixedIndex = -1 - index;
+      if (fixedIndex > 0) {
+        leftover -= highToCumulatedCardinality[fixedIndex - 1];
+      }
+    }
+
+    int keycontrib = this.highLowContainer.getKeyAtIndex(fixedIndex) << 16;
+    int lowcontrib = Util.toIntUnsigned(
+        this.highLowContainer.getContainerAtIndex(fixedIndex).select((int) leftover));
+    int value = lowcontrib + keycontrib;
+
+    // TODO Should we keep the assertion?
+    assert value == super.select(j);
+
+    return value;
+
+    // throw new IllegalArgumentException("select " + j + " when the cardinality is " +
+    // this.getCardinality());
+  }
+}

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap_FastRank.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap_FastRank.java
@@ -13,8 +13,9 @@ import org.junit.Test;
  * Check FastRankRoaringBitmap dismiss the caches cardinalities when necessary
  */
 public class TestRoaringBitmap_FastRank {
+
   @Test
-  public void dismissOnAdd_SingleBucket() {
+  public void addSmallRemoveSmaller() {
     FastRankRoaringBitmap b = new FastRankRoaringBitmap();
 
     b.add(123);
@@ -30,19 +31,195 @@ public class TestRoaringBitmap_FastRank {
   }
 
   @Test
-  public void dismissOnAdd_MultipleBucket() {
+  public void addSmallAddBigRemoveSmall() {
+    FastRankRoaringBitmap b = new FastRankRoaringBitmap();
+
+    b.add(123);
+    Assert.assertEquals(1, b.rank(123));
+    Assert.assertEquals(123, b.select(0));
+
+    // Add smaller element
+    b.add(Integer.MAX_VALUE);
+
+    Assert.assertEquals(123, b.select(0));
+    Assert.assertEquals(Integer.MAX_VALUE, b.select(1));
+
+    Assert.assertEquals(0, b.rank(123 - 1));
+    Assert.assertEquals(1, b.rank(123));
+    Assert.assertEquals(1, b.rank(123 + 1));
+
+    Assert.assertEquals(1, b.rank(Integer.MAX_VALUE - 1));
+    Assert.assertEquals(2, b.rank(Integer.MAX_VALUE));
+    Assert.assertEquals(2, b.rank(Integer.MAX_VALUE + 1));
+
+    // Remove smaller element
+    b.remove(123);
+
+    Assert.assertEquals(Integer.MAX_VALUE, b.select(0));
+
+    Assert.assertEquals(0, b.rank(Integer.MAX_VALUE - 1));
+    Assert.assertEquals(1, b.rank(Integer.MAX_VALUE));
+    Assert.assertEquals(1, b.rank(Integer.MAX_VALUE + 1));
+  }
+
+  @Test
+  public void addSmallAddBigRemoveBig() {
+    FastRankRoaringBitmap b = new FastRankRoaringBitmap();
+
+    b.add(123);
+
+    Assert.assertEquals(123, b.select(0));
+
+    // Add smaller element
+    b.add(Integer.MAX_VALUE);
+
+    Assert.assertEquals(123, b.select(0));
+    Assert.assertEquals(Integer.MAX_VALUE, b.select(1));
+
+    Assert.assertEquals(0, b.rank(123 - 1));
+    Assert.assertEquals(1, b.rank(123));
+    Assert.assertEquals(1, b.rank(123 + 1));
+
+    Assert.assertEquals(1, b.rank(Integer.MAX_VALUE - 1));
+    Assert.assertEquals(2, b.rank(Integer.MAX_VALUE));
+    Assert.assertEquals(2, b.rank(Integer.MAX_VALUE + 1));
+
+    // Remove smaller element
+    b.remove(Integer.MAX_VALUE);
+
+    Assert.assertEquals(123, b.select(0));
+
+    Assert.assertEquals(0, b.rank(123 - 1));
+    Assert.assertEquals(1, b.rank(123));
+    Assert.assertEquals(1, b.rank(123 + 1));
+  }
+
+  @Test
+  public void addSmallAddNegativeRemoveSmall() {
+    FastRankRoaringBitmap b = new FastRankRoaringBitmap();
+
+    b.add(123);
+    Assert.assertEquals(1, b.rank(123));
+    Assert.assertEquals(123, b.select(0));
+
+    // Add negative element
+    b.add(-234);
+
+    Assert.assertEquals(123, b.select(0));
+    Assert.assertEquals(-234, b.select(1));
+
+    Assert.assertEquals(0, b.rank(123 - 1));
+    Assert.assertEquals(1, b.rank(123));
+    Assert.assertEquals(1, b.rank(123 + 1));
+
+    Assert.assertEquals(1, b.rank(-234 - 1));
+    Assert.assertEquals(2, b.rank(-234));
+    Assert.assertEquals(2, b.rank(-234 + 1));
+
+    // Remove smaller element
+    b.remove(123);
+
+    Assert.assertEquals(-234, b.select(0));
+
+    Assert.assertEquals(0, b.rank(-234 - 1));
+    Assert.assertEquals(1, b.rank(-234));
+    Assert.assertEquals(1, b.rank(-234 + 1));
+  }
+
+
+  @Test
+  public void addSmallAddNegativeRemoveNegative() {
+    FastRankRoaringBitmap b = new FastRankRoaringBitmap();
+
+    b.add(123);
+
+    Assert.assertEquals(123, b.select(0));
+
+    // Add negative element
+    b.add(-234);
+
+    Assert.assertEquals(123, b.select(0));
+    Assert.assertEquals(-234, b.select(1));
+
+    Assert.assertEquals(0, b.rank(123 - 1));
+    Assert.assertEquals(1, b.rank(123));
+    Assert.assertEquals(1, b.rank(123 + 1));
+
+    Assert.assertEquals(1, b.rank(-234 - 1));
+    Assert.assertEquals(2, b.rank(-234));
+    Assert.assertEquals(2, b.rank(-234 + 1));
+
+    // Remove smaller element
+    b.remove(-234);
+
+    Assert.assertEquals(123, b.select(0));
+
+    Assert.assertEquals(0, b.rank(123 - 1));
+    Assert.assertEquals(1, b.rank(123));
+    Assert.assertEquals(1, b.rank(123 + 1));
+  }
+
+  @Test
+  public void addManyRandomlyThenRemoveAllRandomly() {
     FastRankRoaringBitmap b = new FastRankRoaringBitmap();
 
     Random r = new Random(0);
 
-    for (int i = 0; i < 100 * 1000; i++) {
-      b.add(r.nextInt());
+    int problemSize = 10 * 1000;
+    int nbReallyAdded = 0;
+
+    // Add randomly
+    for (int i = 0; i < problemSize; i++) {
+      int added = r.nextInt();
+      if (b.checkedAdd(added)) {
+        nbReallyAdded++;
+      }
     }
 
-    for (int i = 0; i < 100 * 1000; i++) {
-      b.remove(b.select(0));
+    // Remove randomly
+    for (int i = 0; i < nbReallyAdded; i++) {
+      int selected = b.select(r.nextInt(nbReallyAdded - i));
+      b.remove(selected);
+
     }
-    Assert.assertEquals(1, b.getLongCardinality());
+    Assert.assertEquals(0, b.getLongCardinality());
+  }
+
+  @Test
+  public void addAndRemoveRandomly() {
+    FastRankRoaringBitmap b = new FastRankRoaringBitmap();
+
+    Random r = new Random(0);
+
+    int problemSize = 10 * 1000;
+
+    int nbReallyAdded = addSelectRemoveRandomly(b, r, problemSize);
+
+    Assert.assertEquals(nbReallyAdded, b.getLongCardinality());
+  }
+
+  private int addSelectRemoveRandomly(RoaringBitmap b, Random r, int problemSize) {
+    // We count ourselves the cardinality
+    int nbReallyAdded = 0;
+
+    // Add randomly
+    for (int i = 0; i < problemSize; i++) {
+      if (r.nextBoolean()) {
+        int added = r.nextInt();
+        if (b.checkedAdd(added)) {
+          nbReallyAdded++;
+        }
+      } else {
+        // Remove randomly
+        if (nbReallyAdded > 0) {
+          int selected = b.select(r.nextInt(nbReallyAdded));
+          b.remove(selected);
+
+          nbReallyAdded--;
+        }
+      }
+    }
+    return nbReallyAdded;
   }
 
   @Test
@@ -57,5 +234,75 @@ public class TestRoaringBitmap_FastRank {
     FastRankRoaringBitmap b = new FastRankRoaringBitmap();
 
     b.select(0);
+  }
+
+  @Test
+  public void performanceTest_MixedAddRemove() {
+    int problemSize = 1000 * 1000;
+
+    long startFast = System.currentTimeMillis();
+    {
+      FastRankRoaringBitmap fast = new FastRankRoaringBitmap();
+      Random r = new Random(0);
+      int nbReallyAdded = addSelectRemoveRandomly(fast, r, problemSize);
+      Assert.assertEquals(nbReallyAdded, fast.getLongCardinality());
+    }
+    long timeFast = System.currentTimeMillis() - startFast;
+
+    long startNormal = System.currentTimeMillis();
+    {
+      RoaringBitmap normal = new RoaringBitmap();
+      Random r = new Random(0);
+      int nbReallyAdded = addSelectRemoveRandomly(normal, r, problemSize);
+      Assert.assertEquals(nbReallyAdded, normal.getLongCardinality());
+    }
+    long timeNormal = System.currentTimeMillis() - startNormal;
+
+    // Mixed workload: "fast" is expected slower as it recomputer cardinality regularly
+    System.out.println("AddSelectRemoveAreMixed Fast=" + timeFast + "ms");
+    System.out.println("AddSelectRemoveAreMixed Normal=" + timeNormal + "ms");
+  }
+
+  @Test
+  public void performanceTest_AddManyThenSelectMany() {
+    int problemSize = 100 * 1000;
+
+    long startFast = System.currentTimeMillis();
+    {
+      FastRankRoaringBitmap fast = new FastRankRoaringBitmap();
+      Random r = new Random(0);
+
+      for (int i = 0; i < problemSize; i++) {
+        fast.add(r.nextInt());
+      }
+
+      int cardinality = fast.getCardinality();
+
+      for (int i = 0; i < problemSize; i++) {
+        fast.select(r.nextInt(cardinality));
+      }
+    }
+    long timeFast = System.currentTimeMillis() - startFast;
+
+    long startNormal = System.currentTimeMillis();
+    {
+      RoaringBitmap fast = new RoaringBitmap();
+      Random r = new Random(0);
+
+      for (int i = 0; i < problemSize; i++) {
+        fast.add(r.nextInt());
+      }
+
+      int cardinality = fast.getCardinality();
+
+      for (int i = 0; i < problemSize; i++) {
+        fast.select(r.nextInt(cardinality));
+      }
+    }
+    long timeNormal = System.currentTimeMillis() - startNormal;
+
+    // And only then select only: "fast" is expected faster as it pre-computes cardinality
+    System.out.println("AddOnlyThenSelectOnly Fast=" + timeFast + "ms");
+    System.out.println("AddOnlyThenSelectOnly Normal=" + timeNormal + "ms");
   }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap_FastRank.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap_FastRank.java
@@ -1,0 +1,61 @@
+/*
+ * (c) the authors Licensed under the Apache License, Version 2.0.
+ */
+package org.roaringbitmap;
+
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * Check FastRankRoaringBitmap dismiss the caches cardinalities when necessary
+ */
+public class TestRoaringBitmap_FastRank {
+  @Test
+  public void dismissOnAdd_SingleBucket() {
+    FastRankRoaringBitmap b = new FastRankRoaringBitmap();
+
+    b.add(123);
+    Assert.assertEquals(1, b.rank(123));
+
+    // Add smaller element
+    b.add(12);
+    Assert.assertEquals(2, b.rank(123));
+
+    // Remove smaller element
+    b.remove(12);
+    Assert.assertEquals(1, b.rank(123));
+  }
+
+  @Test
+  public void dismissOnAdd_MultipleBucket() {
+    FastRankRoaringBitmap b = new FastRankRoaringBitmap();
+
+    Random r = new Random(0);
+
+    for (int i = 0; i < 100 * 1000; i++) {
+      b.add(r.nextInt());
+    }
+
+    for (int i = 0; i < 100 * 1000; i++) {
+      b.remove(b.select(0));
+    }
+    Assert.assertEquals(1, b.getLongCardinality());
+  }
+
+  @Test
+  public void rankOnEmpty() {
+    FastRankRoaringBitmap b = new FastRankRoaringBitmap();
+
+    b.rank(0);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void selectOnEmpty() {
+    FastRankRoaringBitmap b = new FastRankRoaringBitmap();
+
+    b.select(0);
+  }
+}


### PR DESCRIPTION
Hello,

This PR follow-up https://github.com/RoaringBitmap/RoaringBitmap/issues/191

The general idea is to cache cardinalities, cumulated through buckets. This yield better performance when doing a lot of .rank and .select operations over a RoaringBitmap which is not written anymore.

Raw performance results (see TestRoaringBitmap_FastRank):

    AddOnlyThenSelectOnly FastRankRoaringBitmap=207ms
    AddOnlyThenSelectOnly RoaringBitmap=6064ms

    AddSelectRemoveAreMixed FastRankRoaringBitmap=1055ms
    AddSelectRemoveAreMixed RoaringBitmap=375ms


I am not fully-convinced `FastRankRoaringBitmap` is a proper naming for this class