### PR TITLE
Correct release process

### DIFF
--- a/jmh/pom.xml
+++ b/jmh/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmapParent</artifactId>
-        <version>0.6.53</version>
+        <version>0.6.54-SNAPSHOT</version>
     </parent>
     <artifactId>jmh</artifactId>
     <packaging>jar</packaging>

--- a/jmh/pom.xml
+++ b/jmh/pom.xml
@@ -140,4 +140,13 @@
             <url>https://metamx.artifactoryonline.com/metamx/pub-libs-releases-local</url>
         </repository>
     </repositories>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/memory/pom.xml
+++ b/memory/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmapParent</artifactId>
-        <version>0.6.53</version>
+        <version>0.6.54-SNAPSHOT</version>
     </parent>
 
     <artifactId>memory</artifactId>

--- a/memory/pom.xml
+++ b/memory/pom.xml
@@ -62,4 +62,13 @@
         </repository>
     </repositories>
 
+    <profiles>
+        <profile>
+            <id>release</id>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.roaringbitmap</groupId>
     <artifactId>RoaringBitmapParent</artifactId>
-    <version>0.6.53</version>
+    <version>0.6.54-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,66 +9,31 @@
 
     <modules>
         <module>roaringbitmap</module>
-        <!-- <module>jmh</module> --> <!-- jmh testing can take hours and make release fail. -->
-        <!-- <module>memory</module> --> <!-- unnecessary -->
         <module>real-roaring-dataset</module>
+        <module>jmh</module>
+        <module>memory</module>
     </modules>
     <profiles>
         <profile>
-          <id>ci</id>
-          <modules>
-            <module>roaringbitmap</module>
-            <module>jmh</module>
-            <module>memory</module>
-            <module>real-roaring-dataset</module>
-          </modules>
-        </profile>
-        <profile>
-          <id>release</id>
-          <build>
-            <plugins>
-              <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-javadoc-plugin</artifactId>
-                  <version>2.10.4</version>
-                  <executions>
-                      <execution>
-                          <id>attach-javadocs</id>
-                          <goals>
-                              <goal>jar</goal>
-                          </goals>
-                      </execution>
-                  </executions>
-              </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-          </plugins>
-          </build>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 
@@ -176,17 +141,12 @@ The settings.xml file should contain:
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.5.3</version>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <configuration>
-                            <goals>deploy</goals>
-
-                            <!-- https://stackoverflow.com/questions/10694139/maven-3-0s-mvn-releaseperform-doesnt-like-a-pom-xml-that-isnt-in-its-git-r -->
-                            <!-- <pomFileName>parent/pom.xml</pomFileName> -->
-                        </configuration>
-                    </execution>
-                </executions>
+                <configuration>
+                    <goals>deploy</goals>
+                    <releaseProfiles>release</releaseProfiles>
+                    <arguments>-Prelease</arguments>
+                    <tagNameFormat>RoaringBitmap-@{project.version}</tagNameFormat>
+                </configuration>
             </plugin>
 
             <!-- https://github.com/sonatype/nexus-maven-plugins/tree/master/staging/maven-plugin -->

--- a/real-roaring-dataset/pom.xml
+++ b/real-roaring-dataset/pom.xml
@@ -20,4 +20,13 @@
 
         <checkstyle.configLocation>${basedir}/../roaringbitmap/style/roaring_google_checks.xml</checkstyle.configLocation>
     </properties>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/real-roaring-dataset/pom.xml
+++ b/real-roaring-dataset/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmapParent</artifactId>
-        <version>0.6.53</version>
+        <version>0.6.54-SNAPSHOT</version>
     </parent>
 
     <artifactId>real-roaring-dataset</artifactId>

--- a/roaringbitmap/pom.xml
+++ b/roaringbitmap/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.roaringbitmap</groupId>
     <artifactId>RoaringBitmapParent</artifactId>
-    <version>0.6.53</version>
+    <version>0.6.54-SNAPSHOT</version>
   </parent>
   <artifactId>RoaringBitmap</artifactId>
   <name>RoaringBitmap</name>

--- a/roaringbitmap/pom.xml
+++ b/roaringbitmap/pom.xml
@@ -98,4 +98,53 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.10.4</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Hello all,

I can offer you the following changes to support back the old release process.
It added a new profile `release` that deactivates tests for _jmh_, _memory_ and _real-data-set_, although I am not sure it we should deactivate the last.
The profile is automatically activated by the configuration of maven-release-plugin.
And it also restores the old release tag name.

I did not tested the full release process, only to `release:prepare`, not to commit the real files.
I let you decide how you want to ensure it works completely.

By the way, you can reduce your command by using the following `mvn release:clean release:prepare release:perform`.

Final note: I could have added another profile for the perform phase not to run again the tests. But as you did not mention it, I assume it was not bothering you so I let it that way :smile: 