### PR TITLE
Speed up incremental sequential writes and batch creation from unsorted data

### DIFF
--- a/jmh/src/main/java/org/roaringbitmap/writer/WriteSequential.java
+++ b/jmh/src/main/java/org/roaringbitmap/writer/WriteSequential.java
@@ -1,0 +1,77 @@
+package org.roaringbitmap.writer;
+
+
+import org.openjdk.jmh.annotations.*;
+import org.roaringbitmap.OrderedWriter;
+import org.roaringbitmap.RoaringBitmap;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class WriteSequential {
+
+  @Param({"10000", "100000", "1000000", "10000000"})
+  int size;
+
+  @Param({"0.1", "0.5", "0.9"})
+  double randomness;
+
+  int[] data;
+
+  @Setup(Level.Trial)
+  public void init() {
+    data = generateArray(1D - randomness);
+  }
+
+  private int[] generateArray(double runThreshold) {
+    Random random = new Random();
+    int[] data = new int[size];
+    int last = 0;
+    int i = 0;
+    while (i < size) {
+      if (random.nextGaussian() > runThreshold) {
+        int runLength = random.nextInt(Math.min(size - i, 1 << 16));
+        for (int j = 1; j < runLength; ++j) {
+          data[i + j] = last + 1;
+          last = data[i + j];
+        }
+        i += runLength;
+      } else {
+        data[i] = last + 1 + random.nextInt(999);
+        last = data[i];
+        ++i;
+      }
+    }
+    Arrays.sort(data);
+    return data;
+  }
+
+  @Benchmark
+  public RoaringBitmap buildRoaringBitmap() {
+    return RoaringBitmap.bitmapOf(data);
+  }
+
+  @Benchmark
+  public RoaringBitmap incrementalNativeAdd() {
+    RoaringBitmap bitmap = new RoaringBitmap();
+    for (int i = 0; i < data.length; ++i) {
+      bitmap.add(data[i]);
+    }
+    return bitmap;
+  }
+
+  @Benchmark
+  public RoaringBitmap incrementalUseOrderedWriter() {
+    RoaringBitmap bitmap = new RoaringBitmap();
+    OrderedWriter writer = new OrderedWriter(bitmap);
+    for (int i = 0; i < data.length; ++i) {
+      writer.add(data[i]);
+    }
+    writer.flush();
+    return bitmap;
+  }
+}

--- a/jmh/src/main/java/org/roaringbitmap/writer/WriteUnordered.java
+++ b/jmh/src/main/java/org/roaringbitmap/writer/WriteUnordered.java
@@ -1,0 +1,79 @@
+package org.roaringbitmap.writer;
+
+import org.openjdk.jmh.annotations.*;
+import org.roaringbitmap.RoaringBitmap;
+import org.roaringbitmap.Util;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class WriteUnordered {
+
+  @Param({"10000", "100000", "1000000", "10000000"})
+  int size;
+  @Param({"0.1", "0.5", "0.9"})
+  double randomness;
+
+  int[] data;
+
+  @Setup(Level.Trial)
+  public void init() {
+    data = generateArray();
+  }
+
+  private int[] generateArray() {
+    Random random = new Random();
+    List<Integer> ints = new ArrayList<>(size);
+    int last = 0;
+    for (int i = 0; i < size; ++i) {
+      if (random.nextGaussian() > 1 - randomness) {
+        last = last + 1;
+      } else {
+        last = last + 1 + random.nextInt(99);
+      }
+      ints.add(last);
+    }
+    Collections.shuffle(ints);
+    int[] data = new int[size];
+    int i = 0;
+    for (Integer value : ints) {
+      data[i++] = value;
+    }
+    return data;
+  }
+
+  @Benchmark
+  public int[] setupCost() {
+    return Arrays.copyOf(data, data.length);
+  }
+
+  @Benchmark
+  public RoaringBitmap bitmapOfUnordered() {
+    int[] copy = Arrays.copyOf(data, data.length);
+    return RoaringBitmap.bitmapOfUnordered(copy);
+  }
+
+  @Benchmark
+  public RoaringBitmap sortThenBitmapOf() {
+    int[] copy = Arrays.copyOf(data, data.length);
+    Arrays.sort(copy);
+    return RoaringBitmap.bitmapOf(copy);
+  }
+
+  @Benchmark
+  public RoaringBitmap bitmapOf() {
+    int[] copy = Arrays.copyOf(data, data.length);
+    return RoaringBitmap.bitmapOf(copy);
+  }
+
+  @Benchmark
+  public RoaringBitmap partialSortThenBitmapOf() {
+    int[] copy = Arrays.copyOf(data, data.length);
+    Util.partialRadixSort(copy);
+    return RoaringBitmap.bitmapOf(copy);
+  }
+}
+

--- a/roaringbitmap/src/main/java/org/roaringbitmap/OrderedWriter.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/OrderedWriter.java
@@ -23,10 +23,10 @@ public class OrderedWriter {
   public void add(int value) {
     short key = Util.highbits(value);
     short low = Util.lowbits(value);
-    if (Util.compareUnsigned(key, currentKey) < 0) {
-      throw new IllegalStateException("Must write in ascending key order");
-    }
     if (key != currentKey) {
+      if (Util.compareUnsigned(key, currentKey) < 0) {
+        throw new IllegalStateException("Must write in ascending key order");
+      }
       flush();
     }
     int ulow = low & 0xFFFF;
@@ -72,11 +72,11 @@ public class OrderedWriter {
     int arrIndex = 0;
     for (int i = 0; i < bitmap.length; ++i) {
       long word = bitmap[i];
-      for (int j = Long.numberOfTrailingZeros(word); j < 64; j = Long.numberOfTrailingZeros(word)) {
-        if ((word & (1L << j)) != 0) {
-          word ^= (1L << j);
-          array[arrIndex++] = (short) ((i << 6) + j);
-        }
+      int j = Long.numberOfTrailingZeros(word);
+      while (j < 64) {
+        word ^= (1L << j);
+        array[arrIndex++] = (short) ((i << 6) + j);
+        j = Long.numberOfTrailingZeros(word);
       }
     }
     return new ArrayContainer(cardinality, array);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/OrderedWriter.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/OrderedWriter.java
@@ -1,0 +1,88 @@
+package org.roaringbitmap;
+
+import java.util.Arrays;
+
+public class OrderedWriter {
+
+  private static final int WORD_COUNT = 1 << 10;
+  private final long[] bitmap;
+  private final RoaringBitmap underlying;
+
+  private short currentKey;
+  private boolean dirty = false;
+
+  public OrderedWriter(RoaringBitmap underlying) {
+    this.underlying = underlying;
+    this.bitmap = new long[WORD_COUNT];
+  }
+
+  /**
+   * Adds the value to the underlying bitmap.
+   * @param value the value to add.
+   */
+  public void add(int value) {
+    short key = Util.highbits(value);
+    short low = Util.lowbits(value);
+    if (Util.compareUnsigned(key, currentKey) < 0) {
+      throw new IllegalStateException("Must write in ascending key order");
+    }
+    if (key != currentKey) {
+      flush();
+    }
+    int ulow = low & 0xFFFF;
+    bitmap[(ulow >>> 6)] |= (1L << ulow);
+    currentKey = key;
+    dirty = true;
+  }
+
+  /**
+   * Ensures that any buffered additions are flushed to the underlying bitmap.
+   */
+  public void flush() {
+    if (dirty) {
+      int cardinality = computeCardinality();
+      underlying.highLowContainer.append(currentKey, chooseBestContainer(cardinality));
+      clearBitmap();
+      dirty = false;
+    }
+  }
+
+  private Container chooseBestContainer(int cardinality) {
+    if (cardinality < WORD_COUNT) {
+      return createArrayContainer(cardinality);
+    }
+    Container bitmapContainer = new BitmapContainer(bitmap, cardinality);
+    Container runOptimised = bitmapContainer.runOptimize();
+    if (runOptimised == bitmapContainer) { // don't let our array escape
+      return new BitmapContainer(Arrays.copyOf(bitmap, bitmap.length), cardinality);
+    }
+    return runOptimised;
+  }
+
+  private ArrayContainer createArrayContainer(int cardinality) {
+    short[] array = new short[cardinality];
+    int arrIndex = 0;
+    for (int i = 0; i < bitmap.length; ++i) {
+      long word = bitmap[i];
+      for (int j = Long.numberOfTrailingZeros(word); j < 64; j = Long.numberOfTrailingZeros(word)) {
+        if ((word & (1L << j)) != 0) {
+          word ^= (1L << j);
+          array[arrIndex++] = (short) ((i << 6) + j);
+        }
+      }
+    }
+    return new ArrayContainer(cardinality, array);
+  }
+
+  private void clearBitmap() {
+    Arrays.fill(bitmap, 0L);
+  }
+
+  private int computeCardinality() {
+    int cardinality = 0;
+    for (int i = 0; i < bitmap.length; ++i) {
+      cardinality += Long.bitCount(bitmap[i]);
+    }
+    return cardinality;
+  }
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -18,6 +18,8 @@ import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MappeableContainerPointer;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
+import static org.roaringbitmap.Util.partialRadixSort;
+
 
 /**
  * RoaringBitmap, a compressed alternative to the BitSet.
@@ -446,6 +448,22 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     final RoaringBitmap ans = new RoaringBitmap();
     ans.add(dat);
     return ans;
+  }
+
+  /**
+   * Efficiently builds a RoaringBitmap from unordered data
+   * @param data unsorted data
+   * @return a new bitmap
+   */
+  public static RoaringBitmap bitmapOfUnordered(final int... data) {
+    partialRadixSort(data);
+    RoaringBitmap bitmap = new RoaringBitmap();
+    OrderedWriter writer = new OrderedWriter(bitmap);
+    for (int i : data) {
+      writer.add(i);
+    }
+    writer.flush();
+    return bitmap;
   }
 
   /**

--- a/roaringbitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/Util.java
@@ -4,6 +4,8 @@
 
 package org.roaringbitmap;
 
+import java.util.Arrays;
+
 /**
  * Various useful methods for roaring bitmaps.
  */
@@ -984,6 +986,33 @@ public final class Util {
   // Duplicated from jdk8 Integer.toUnsignedLong
   public static long toUnsignedLong(int x) {
     return ((long) x) & 0xffffffffL;
+  }
+
+  /**
+   * Sorts the data by the 16 bit prefix.
+   * @param data - the data
+   */
+  public static void partialRadixSort(int[] data) {
+    final int radix = 8;
+    int shift = 16;
+    int mask = 0xFF0000;
+    int[] copy = new int[data.length];
+    int[] histogram = new int[(1 << radix) + 1];
+    while (shift < 32) {
+      for (int i = 0; i < data.length; ++i) {
+        ++histogram[((data[i] & mask) >>> shift) + 1];
+      }
+      for (int i = 0; i < 1 << radix; ++i) {
+        histogram[i + 1] += histogram[i];
+      }
+      for (int i = 0; i < data.length; ++i) {
+        copy[histogram[(data[i] & mask) >>> shift]++] = data[i];
+      }
+      System.arraycopy(copy, 0, data, 0, data.length);
+      shift += radix;
+      mask <<= radix;
+      Arrays.fill(histogram, 0);
+    }
   }
 
   /**

--- a/roaringbitmap/src/test/java/org/roaringbitmap/OrderedWriterRandomisedTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/OrderedWriterRandomisedTest.java
@@ -1,0 +1,81 @@
+package org.roaringbitmap;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class OrderedWriterRandomisedTest {
+
+  @Parameterized.Parameters
+  public static Object[][] tests() {
+    return new Object[][]
+            {
+                    {new int[]{0, 1, 2, 3}},
+                    {randomArray(10)},
+                    {randomArray(100)},
+                    {randomArray(1000)},
+                    {randomArray(10_000)},
+                    {randomArray(100_000)},
+                    {randomArray(1000_000)},
+                    {randomArray(10_000_000)}
+            };
+  }
+
+
+  private final int[] values;
+
+  public OrderedWriterRandomisedTest(int[] values) {
+    this.values = values;
+  }
+
+  @Test
+  public void shouldBuildSameBitmapAsBitmapOf() {
+    RoaringBitmap baseline = RoaringBitmap.bitmapOf(values);
+    RoaringBitmap rb = new RoaringBitmap();
+    OrderedWriter writer = new OrderedWriter(rb);
+    for (int i : values) {
+      writer.add(i);
+    }
+
+    writer.flush();
+    RoaringArray baselineHLC = baseline.highLowContainer;
+    RoaringArray rbHLC = rb.highLowContainer;
+    Assert.assertEquals(baselineHLC.size, rbHLC.size);
+    for (int i = 0; i < baselineHLC.size; ++i) {
+      Container baselineContainer = baselineHLC.getContainerAtIndex(i);
+      Container rbContainer = rbHLC.getContainerAtIndex(i);
+      assertEquals(baselineContainer, rbContainer);
+    }
+    assertEquals(baseline, rb);
+  }
+
+  private static int[] randomArray(int size) {
+    Random random = new Random();
+    int[] data = new int[size];
+    int last = 0;
+    int i = 0;
+    while (i < size) {
+      if (random.nextGaussian() > 0.1) {
+        int runLength = random.nextInt(Math.min(size - i, 1 << 16));
+        for (int j = 1; j < runLength; ++j) {
+          data[i + j] = last + 1;
+          last = data[i + j];
+        }
+        i += runLength;
+      } else {
+        data[i] = last + 1 + random.nextInt(999);
+        last = data[i];
+        ++i;
+      }
+    }
+    Arrays.sort(data);
+    return data;
+  }
+}

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestOrderedWriter.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestOrderedWriter.java
@@ -33,4 +33,13 @@ public class TestOrderedWriter {
     writer.add(1 << 18);
     Assert.assertTrue(bitmap.contains(1 << 17));
   }
+
+  @Test(expected = IllegalStateException.class)
+  public void shouldThrowIfSameKeyIsWrittenToAfterManualFlush() {
+    OrderedWriter writer = new OrderedWriter(new RoaringBitmap());
+    writer.add(0);
+    writer.flush();
+    writer.add(1);
+    writer.flush();
+  }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestOrderedWriter.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestOrderedWriter.java
@@ -1,0 +1,36 @@
+package org.roaringbitmap;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestOrderedWriter {
+
+  @Test(expected = IllegalStateException.class)
+  public void shouldThrowWhenAddingInReverseOrder() {
+    OrderedWriter writer = new OrderedWriter(new RoaringBitmap());
+    writer.add(1 << 17);
+    writer.add(0);
+  }
+
+  @Test
+  public void bitmapShouldContainAllValuesAfterFlush() {
+    RoaringBitmap bitmap = new RoaringBitmap();
+    OrderedWriter writer = new OrderedWriter(bitmap);
+    writer.add(0);
+    writer.add(1 << 17);
+    writer.flush();
+    Assert.assertTrue(bitmap.contains(0));
+    Assert.assertTrue(bitmap.contains(1 << 17));
+  }
+
+  @Test
+  public void newKeyShouldTriggerFlush() {
+    RoaringBitmap bitmap = new RoaringBitmap();
+    OrderedWriter writer = new OrderedWriter(bitmap);
+    writer.add(0);
+    writer.add(1 << 17);
+    Assert.assertTrue(bitmap.contains(0));
+    writer.add(1 << 18);
+    Assert.assertTrue(bitmap.contains(1 << 17));
+  }
+}

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestUtil.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestUtil.java
@@ -3,6 +3,8 @@ package org.roaringbitmap;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 public class TestUtil {
 
     @Test
@@ -35,5 +37,47 @@ public class TestUtil {
         Assert.assertTrue(Util.compareUnsigned((short)2, (short)-32333) < 0);
         Assert.assertTrue(Util.compareUnsigned((short)0,(short)0) ==0);
 
+    }
+
+    @Test
+    public void testPartialRadixSortEmpty() {
+        int[] data = new int[] {};
+        int[] test = Arrays.copyOf(data, data.length);
+        Util.partialRadixSort(test);
+        Assert.assertArrayEquals(data, test);
+    }
+
+    @Test
+    public void testPartialRadixSortIsStableInSameKey() {
+        int[] data = new int[] {25, 1, 0, 10};
+        int[] test = Arrays.copyOf(data, data.length);
+        Util.partialRadixSort(test);
+        Assert.assertArrayEquals(data, test);
+    }
+
+    @Test
+    public void testPartialRadixSortSortsKeysCorrectly() {
+        int key1 = 1 << 16;
+        int key2 = 1 << 17;
+        int[] data = new int[] {key2 | 25, key1 | 1, 0, key2 | 10, 25, key1 | 10, key1, 10};
+        // sort by keys, leave values stable
+        int[] expected = new int[] {0, 25, 10, key1 | 1, key1 | 10, key1, key2 | 25, key2 | 10};
+        int[] test = Arrays.copyOf(data, data.length);
+        Util.partialRadixSort(test);
+        Assert.assertArrayEquals(expected, test);
+    }
+
+    @Test
+    public void testPartialRadixSortSortsKeysCorrectlyWithDuplicates() {
+        int key1 = 1 << 16;
+        int key2 = 1 << 17;
+        int[] data = new int[] {key2 | 25, key1 | 1, 0, key2 | 10, 25, key1 | 10, key1, 10,
+                                key2 | 25, key1 | 1, 0, key2 | 10, 25, key1 | 10, key1, 10};
+        // sort by keys, leave values stable
+        int[] expected = new int[] {0, 25, 10, 0, 25, 10, key1 | 1, key1 | 10,  key1, key1 | 1, key1 | 10,  key1,
+                                    key2 | 25, key2 | 10, key2 | 25, key2 | 10};
+        int[] test = Arrays.copyOf(data, data.length);
+        Util.partialRadixSort(test);
+        Assert.assertArrayEquals(expected, test);
     }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/UnorderedWriterRandomisedTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/UnorderedWriterRandomisedTest.java
@@ -1,0 +1,73 @@
+package org.roaringbitmap;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class UnorderedWriterRandomisedTest {
+
+
+  @Parameterized.Parameters
+  public static Object[][] tests() {
+    return new Object[][] {
+            {generateUnorderedArray(10)},
+            {generateUnorderedArray(100)},
+            {generateUnorderedArray(1000)},
+            {generateUnorderedArray(10000)},
+            {generateUnorderedArray(100000)},
+            {generateUnorderedArray(1000000)},
+    };
+  }
+
+
+  private final int[] data;
+
+  public UnorderedWriterRandomisedTest(int[] data) {
+    this.data = data;
+  }
+
+  @Test
+  public void bitmapOfUnorderedShouldBuildSameBitmapAsBitmapOf() {
+    RoaringBitmap baseline = RoaringBitmap.bitmapOf(data);
+    RoaringBitmap test = RoaringBitmap.bitmapOfUnordered(data);
+    RoaringArray baselineHLC = baseline.highLowContainer;
+    RoaringArray testHLC = test.highLowContainer;
+    Assert.assertEquals(baselineHLC.size, testHLC.size);
+    for (int i = 0; i < baselineHLC.size; ++i) {
+      Container baselineContainer = baselineHLC.getContainerAtIndex(i);
+      Container rbContainer = testHLC.getContainerAtIndex(i);
+      assertEquals(baselineContainer, rbContainer);
+    }
+    assertEquals(baseline, test);
+  }
+
+  private static int[] generateUnorderedArray(int size) {
+    Random random = new Random();
+    List<Integer> ints = new ArrayList<>(size);
+    int last = 0;
+    for (int i = 0; i < size; ++i) {
+      if (random.nextGaussian() > 0.1) {
+        last = last + 1;
+      } else {
+        last = last + 1 + random.nextInt(99);
+      }
+      ints.add(last);
+    }
+    Collections.shuffle(ints);
+    int[] data = new int[size];
+    int i = 0;
+    for (Integer value : ints) {
+      data[i++] = value;
+    }
+    return data;
+  }
+}


### PR DESCRIPTION
This pull request makes it possible to write sequentially and incrementally to a RoaringBitmap efficiently, without collecting values in an `int[]` beforehand. 

**Usage**

`OrderedWriter` wraps a `RoaringBitmap` and requires the caller to flush it to ensure all added data is saved to the bitmap.

```
    OrderedWriter writer = new OrderedWriter(rb);
    // add data incrementally, the most signficant 16 bits must be in ascending unsigned order
    for (int i : values) {
      writer.add(i);
    }
    // flush all buffered data down to the underlying bitmap
    writer.flush();
```

**Testing**

The basic behaviour of `OrderedWriter` is tested in `TestOrderedWriter`.

That a RoaringBitmap built by an `OrderedWriter` is equivalent to one built by `RoaringBitmap.bitmapOf` is tested for random bitmaps of various size in `OrderedWriterRandomisedTest`

**Benchmarks**

`WriteSequential` compares `RoaringBitmap.bitmapOf` (i.e. what you could do if you had the entire array in one go), sequential calls to `RoaringBitmap.add` and `OrderedWriter`. Data is generated for a range of sizes and a range of "runniness" (i.e. how likely it is that the data can be run length encoded.) The results are good: `OrderedWriter` is faster than `RoaringBitmap.bitmapOf` for small data sets. For larger datasets the performance is of similar performance, and a great deal better than sequential calls to `RoaringBitmap.add`.

```
Benchmark                                    (randomness)    (size)  Mode  Cnt       Score       Error  Units
WriteSequential.buildRoaringBitmap                    0.1     10000  avgt    5      53.628 ▒     2.544  us/op
WriteSequential.buildRoaringBitmap                    0.1    100000  avgt    5     354.691 ▒     9.786  us/op
WriteSequential.buildRoaringBitmap                    0.1   1000000  avgt    5    3530.126 ▒   157.438  us/op
WriteSequential.buildRoaringBitmap                    0.1  10000000  avgt    5   31400.821 ▒   529.543  us/op
WriteSequential.buildRoaringBitmap                    0.5     10000  avgt    5      52.083 ▒     2.663  us/op
WriteSequential.buildRoaringBitmap                    0.5    100000  avgt    5     353.520 ▒     7.453  us/op
WriteSequential.buildRoaringBitmap                    0.5   1000000  avgt    5    3492.611 ▒   111.276  us/op
WriteSequential.buildRoaringBitmap                    0.5  10000000  avgt    5   37178.051 ▒  9069.530  us/op
WriteSequential.buildRoaringBitmap                    0.9     10000  avgt    5      59.458 ▒     8.530  us/op
WriteSequential.buildRoaringBitmap                    0.9    100000  avgt    5     360.718 ▒    52.790  us/op
WriteSequential.buildRoaringBitmap                    0.9   1000000  avgt    5    3766.560 ▒  1198.259  us/op
WriteSequential.buildRoaringBitmap                    0.9  10000000  avgt    5   33221.955 ▒  2151.770  us/op
WriteSequential.incrementalNativeAdd                  0.1     10000  avgt    5      95.012 ▒     8.962  us/op
WriteSequential.incrementalNativeAdd                  0.1    100000  avgt    5     780.217 ▒   106.684  us/op
WriteSequential.incrementalNativeAdd                  0.1   1000000  avgt    5    9265.335 ▒   846.230  us/op
WriteSequential.incrementalNativeAdd                  0.1  10000000  avgt    5  101037.210 ▒  6457.910  us/op
WriteSequential.incrementalNativeAdd                  0.5     10000  avgt    5     111.847 ▒    14.197  us/op
WriteSequential.incrementalNativeAdd                  0.5    100000  avgt    5     887.937 ▒    69.129  us/op
WriteSequential.incrementalNativeAdd                  0.5   1000000  avgt    5    7620.004 ▒   500.564  us/op
WriteSequential.incrementalNativeAdd                  0.5  10000000  avgt    5  101455.646 ▒ 14751.135  us/op
WriteSequential.incrementalNativeAdd                  0.9     10000  avgt    5      93.574 ▒     8.004  us/op
WriteSequential.incrementalNativeAdd                  0.9    100000  avgt    5     882.819 ▒    46.454  us/op
WriteSequential.incrementalNativeAdd                  0.9   1000000  avgt    5    7507.996 ▒   426.764  us/op
WriteSequential.incrementalNativeAdd                  0.9  10000000  avgt    5   98675.524 ▒  1715.163  us/op
WriteSequential.incrementalUseOrderedWriter           0.1     10000  avgt    5      26.338 ▒     1.190  us/op
WriteSequential.incrementalUseOrderedWriter           0.1    100000  avgt    5     367.215 ▒    26.818  us/op
WriteSequential.incrementalUseOrderedWriter           0.1   1000000  avgt    5    3832.171 ▒   347.830  us/op
WriteSequential.incrementalUseOrderedWriter           0.1  10000000  avgt    5   43193.867 ▒ 20770.625  us/op
WriteSequential.incrementalUseOrderedWriter           0.5     10000  avgt    5      32.928 ▒    10.230  us/op
WriteSequential.incrementalUseOrderedWriter           0.5    100000  avgt    5     394.717 ▒    93.505  us/op
WriteSequential.incrementalUseOrderedWriter           0.5   1000000  avgt    5    3728.619 ▒   177.213  us/op
WriteSequential.incrementalUseOrderedWriter           0.5  10000000  avgt    5   36694.794 ▒  1931.691  us/op
WriteSequential.incrementalUseOrderedWriter           0.9     10000  avgt    5      26.152 ▒     1.391  us/op
WriteSequential.incrementalUseOrderedWriter           0.9    100000  avgt    5     366.515 ▒    14.643  us/op
WriteSequential.incrementalUseOrderedWriter           0.9   1000000  avgt    5    3696.070 ▒   107.797  us/op
WriteSequential.incrementalUseOrderedWriter           0.9  10000000  avgt    5   36587.744 ▒  1793.303  us/op

```