### PR TITLE
Changes to jmh/run.sh

### DIFF
--- a/jmh/run.sh
+++ b/jmh/run.sh
@@ -1,24 +1,36 @@
 #!/bin/bash
 BASEDIR=$(dirname $0)
 
+CLEAN=""
+if [[ "$1" = "-clean" ]]; then
+    echo "Preparing benchmarks. Will clean jars..."
+    CLEAN="clean"
+    shift
+fi
 
 echo "Building RoaringBitmap jar"
-rm -f $BASEDIR/../target/RoaringBitmap*.jar
-mvn -f $BASEDIR/../pom.xml clean install -DskipTests -Dgpg.skip=true -Dcheckstyle.skip
+if [[ "$CLEAN" = "clean" ]]; then
+    rm -f $BASEDIR/../target/RoaringBitmap*.jar
+fi
+mvn -f $BASEDIR/../pom.xml $CLEAN install -DskipTests -Dgpg.skip=true -Dcheckstyle.skip
 
 [[ $? -eq 0 ]] || exit
 
 echo "Building Real Roaring Dataset jar"
-rm -f $BASEDIR/../real-roaring-dataset/target/real-roaring-dataset*.jar
-mvn -f $BASEDIR/../real-roaring-dataset/pom.xml clean install
+if [[ "$CLEAN" = "clean" ]]; then
+    rm -f $BASEDIR/../real-roaring-dataset/target/real-roaring-dataset*.jar
+fi
+mvn -f $BASEDIR/../real-roaring-dataset/pom.xml $CLEAN install
 
 [[ $? -eq 0 ]] || exit
 
 echo "Building benchmarks jar"
-rm -f  $BASEDIR/target/benchmarks.jar
-mvn -f $BASEDIR/pom.xml clean install -Dtest=*$1* -DfailIfNoTests=false -Dcheckstyle.skip
+if [[ "$CLEAN" = "clean" ]]; then
+    rm -f  $BASEDIR/target/benchmarks.jar
+fi
+mvn -f $BASEDIR/pom.xml $CLEAN install -Dtest=*${@:$#}* -DfailIfNoTests=false -Dcheckstyle.skip
 
 [[ $? -eq 0 ]] || exit
 
 echo "Running benchmarks"
-java -jar $BASEDIR/target/benchmarks.jar  true -wi 5 -i 5 -f 1 $@
+java -jar $BASEDIR/target/benchmarks.jar true -wi 5 -i 5 -f 1 $@

--- a/jmh/run.sh
+++ b/jmh/run.sh
@@ -4,7 +4,7 @@ BASEDIR=$(dirname $0)
 
 echo "Building RoaringBitmap jar"
 rm -f $BASEDIR/../target/RoaringBitmap*.jar
-mvn -f $BASEDIR/../pom.xml clean install -DskipTests -Dgpg.skip=true
+mvn -f $BASEDIR/../pom.xml clean install -DskipTests -Dgpg.skip=true -Dcheckstyle.skip
 
 [[ $? -eq 0 ]] || exit
 
@@ -16,7 +16,7 @@ mvn -f $BASEDIR/../real-roaring-dataset/pom.xml clean install
 
 echo "Building benchmarks jar"
 rm -f  $BASEDIR/target/benchmarks.jar
-mvn -f $BASEDIR/pom.xml clean install -Dtest=*$1* -DfailIfNoTests=false
+mvn -f $BASEDIR/pom.xml clean install -Dtest=*$1* -DfailIfNoTests=false -Dcheckstyle.skip
 
 [[ $? -eq 0 ]] || exit
 

--- a/jmh/run.sh
+++ b/jmh/run.sh
@@ -21,4 +21,4 @@ mvn -f $BASEDIR/pom.xml clean install -Dtest=*$1* -DfailIfNoTests=false -Dchecks
 [[ $? -eq 0 ]] || exit
 
 echo "Running benchmarks"
-java -jar $BASEDIR/target/benchmarks.jar  true -wi 5 -i 5 -f 1 $1
+java -jar $BASEDIR/target/benchmarks.jar  true -wi 5 -i 5 -f 1 $@


### PR DESCRIPTION
In this PR I introduce a couple of changes jmh/run.sh:
* running the `clean` Maven target is now optional. Explicitly pass `-clean` as the first argument to revert to old behavior. This cuts down on tool start time.
* skip check style. I don't think there is a point in having checkstyle run for this tool.
* add ability to pass an arbitrary number of arguments to JMH. This allow for easier passing of JMH parameters, like `-p dataset=dimension_003`