### PR TITLE
fix unsigned error in runcontainer contains runcontainer

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -744,26 +744,25 @@ public final class RunContainer extends Container implements Cloneable {
   @Override
   protected boolean contains(RunContainer runContainer) {
     int i1 = 0, i2 = 0;
-    final int runCount = numberOfRuns();
-    while(i1 < runCount && i2 < runContainer.numberOfRuns()) {
-      int start1 = getValue(i1);
+    while(i1 < numberOfRuns() && i2 < runContainer.numberOfRuns()) {
+      int start1 = toIntUnsigned(getValue(i1));
       int stop1 = start1 + toIntUnsigned(getLength(i1));
-      int start2 = runContainer.getValue(i2);
+      int start2 = toIntUnsigned(runContainer.getValue(i2));
       int stop2 = start2 + toIntUnsigned(runContainer.getLength(i2));
       if(start1 > start2) {
         return false;
       } else {
         if(stop1 > stop2) {
-          i1++;
+          i2++;
         } else if(stop1 == stop2) {
           i1++;
           i2++;
         } else {
-          i2++;
+          i1++;
         }
       }
     }
-    return i1 == runCount;
+    return i2 == runContainer.numberOfRuns();
   }
 
   @Override

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -2543,26 +2543,25 @@ public final class MappeableRunContainer extends MappeableContainer implements C
   @Override
   protected boolean contains(MappeableRunContainer runContainer) {
     int i1 = 0, i2 = 0;
-    final int runCount = numberOfRuns();
-    while(i1 < runCount && i2 < runContainer.numberOfRuns()) {
-      int start1 = getValue(i1);
+    while(i1 < numberOfRuns() && i2 < runContainer.numberOfRuns()) {
+      int start1 = toIntUnsigned(getValue(i1));
       int stop1 = start1 + toIntUnsigned(getLength(i1));
-      int start2 = runContainer.getValue(i2);
+      int start2 = toIntUnsigned(runContainer.getValue(i2));
       int stop2 = start2 + toIntUnsigned(runContainer.getLength(i2));
       if(start1 > start2) {
         return false;
       } else {
         if(stop1 > stop2) {
-          i1++;
+          i2++;
         } else if(stop1 == stop2) {
           i1++;
           i2++;
         } else {
-          i2++;
+          i1++;
         }
       }
     }
-    return i1 == runCount;
+    return i2 == runContainer.numberOfRuns();
   }
 
   @Override


### PR DESCRIPTION
This fixes a bug in RunContainer.contains(RunContainer) (this was my own handiwork unfortunately) which you would need a truncation of an identical run container to reproduce.