### PR TITLE
Implement parallel OR and XOR

### DIFF
--- a/jmh/src/main/java/org/roaringbitmap/realdata/ParallelAggregatorBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/realdata/ParallelAggregatorBenchmark.java
@@ -1,0 +1,104 @@
+package org.roaringbitmap.realdata;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.openjdk.jmh.annotations.*;
+import org.roaringbitmap.FastAggregation;
+import org.roaringbitmap.ParallelAggregation;
+import org.roaringbitmap.RoaringBitmap;
+import org.roaringbitmap.ZipRealDataRetriever;
+import org.roaringbitmap.buffer.BufferFastAggregation;
+import org.roaringbitmap.buffer.BufferParallelAggregation;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.StreamSupport;
+
+import static org.roaringbitmap.RealDataset.*;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class ParallelAggregatorBenchmark {
+
+  private static final Cache<String, RoaringBitmap[]> DATASET_CACHE =
+          CacheBuilder.newBuilder().maximumSize(1).build();
+
+  @Param({// putting the data sets in alpha. order
+          CENSUS_INCOME, CENSUS1881, DIMENSION_008,
+          DIMENSION_003, DIMENSION_033, USCENSUS2000,
+          WEATHER_SEPT_85, WIKILEAKS_NOQUOTES, CENSUS_INCOME_SRT, CENSUS1881_SRT, WEATHER_SEPT_85_SRT,
+          WIKILEAKS_NOQUOTES_SRT
+  })
+  public String dataset;
+
+  RoaringBitmap[] bitmaps;
+  ImmutableRoaringBitmap[] immutableRoaringBitmaps;
+
+  @Setup(Level.Trial)
+  public void setup() throws Exception {
+    bitmaps = DATASET_CACHE.get(dataset, () -> {
+      System.out.println("Loading" + dataset);
+      ZipRealDataRetriever dataRetriever = new ZipRealDataRetriever(dataset);
+      return StreamSupport.stream(dataRetriever.fetchBitPositions().spliterator(), false)
+              .map(RoaringBitmap::bitmapOf)
+              .toArray(RoaringBitmap[]::new);
+    });
+    immutableRoaringBitmaps = Arrays.stream(bitmaps).map(RoaringBitmap::toMutableRoaringBitmap)
+            .toArray(ImmutableRoaringBitmap[]::new);
+  }
+
+  @Benchmark
+  public RoaringBitmap parallelOr() {
+    return ParallelAggregation.or(bitmaps);
+  }
+
+  @Benchmark
+  public RoaringBitmap parallelXor() {
+    return ParallelAggregation.xor(bitmaps);
+  }
+
+  @Benchmark
+  public Object groupByKey() {
+    return ParallelAggregation.groupByKey(bitmaps);
+  }
+
+  @Benchmark
+  public RoaringBitmap fastOr() {
+    return FastAggregation.or(bitmaps);
+  }
+
+  @Benchmark
+  public RoaringBitmap fastXor() {
+    return FastAggregation.xor(bitmaps);
+  }
+
+
+  @Benchmark
+  public MutableRoaringBitmap bufferParallelOr() {
+    return BufferParallelAggregation.or(immutableRoaringBitmaps);
+  }
+
+  @Benchmark
+  public MutableRoaringBitmap bufferParallelXor() {
+    return BufferParallelAggregation.xor(immutableRoaringBitmaps);
+  }
+
+  @Benchmark
+  public Object bufferGroupByKey() {
+    return BufferParallelAggregation.groupByKey(immutableRoaringBitmaps);
+  }
+
+  @Benchmark
+  public MutableRoaringBitmap bufferFastOr() {
+    return BufferFastAggregation.or(immutableRoaringBitmaps);
+  }
+
+  @Benchmark
+  public MutableRoaringBitmap bufferFastXor() {
+    return BufferFastAggregation.xor(immutableRoaringBitmaps);
+  }
+
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -276,6 +276,11 @@ public final class ArrayContainer extends Container implements Cloneable {
   }
 
   @Override
+  public boolean isEmpty() {
+    return cardinality == 0;
+  }
+
+  @Override
   public boolean contains(final short x) {
     return Util.unsignedBinarySearch(content, 0, cardinality, x) >= 0;
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -282,6 +282,11 @@ public final class BitmapContainer extends Container implements Cloneable {
     return new BitmapContainer(this.cardinality, this.bitmap);
   }
 
+  @Override
+  public boolean isEmpty() {
+    return cardinality == 0;
+  }
+
   /**
    * Recomputes the cardinality of the bitmap.
    */

--- a/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
@@ -186,6 +186,12 @@ public abstract class Container implements Iterable<Short>, Cloneable, Externali
   public abstract Container clone();
 
   /**
+   * Checks whether the container is empty or not.
+   * @return true if the container is empty.
+   */
+  public abstract boolean isEmpty();
+
+  /**
    * Checks whether the contain contains the provided value
    *
    * @param x value to check

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ParallelAggregation.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ParallelAggregation.java
@@ -1,0 +1,224 @@
+package org.roaringbitmap;
+
+import java.util.*;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+import java.util.stream.IntStream;
+
+import static org.roaringbitmap.Util.compareUnsigned;
+
+/**
+ *
+ * These utility methods provide parallel implementations of
+ * logical aggregation operators. AND is not implemented
+ * because it is unlikely to be profitable.
+ *
+ * There is a temporary memory overhead in using these methods,
+ * since a materialisation of the rotated containers grouped by key
+ * is created in each case.
+ *
+ * Each method executes on the default fork join pool by default.
+ * If this is undesirable (it usually is) wrap the call inside
+ * a submission of a runnable to your own thread pool.
+ *
+ * <pre>
+ * {@code
+ *
+ *       //...
+ *
+ *       ExecutorService executor = ...
+ *       RoaringBitmap[] bitmaps = ...
+ *       // executes on executors threads
+ *       RoaringBitmap result = executor.submit(() -> ParallelAggregation.or(bitmaps)).get();
+ * }
+ * </pre>
+ */
+public class ParallelAggregation {
+
+  private static final Collector<Map.Entry<Short,List<Container>>, RoaringArray, RoaringBitmap> OR
+          = new ContainerCollector(ParallelAggregation::or);
+
+  private static final Collector<Map.Entry<Short,List<Container>>, RoaringArray, RoaringBitmap> XOR
+          = new ContainerCollector(ParallelAggregation::xor);
+
+  /**
+   * Collects containers grouped by their key into a RoaringBitmap, applying the
+   * supplied aggregation function to each group.
+   */
+  public static class ContainerCollector implements
+          Collector<Map.Entry<Short,List<Container>>, RoaringArray, RoaringBitmap> {
+
+    private final Function<List<Container>, Container> reducer;
+
+    /**
+     * Creates a collector with the reducer function.
+     * @param reducer a function to apply to containers with the same key.
+     */
+    public ContainerCollector(Function<List<Container>, Container> reducer) {
+      this.reducer = reducer;
+    }
+
+    @Override
+    public Supplier<RoaringArray> supplier() {
+      return RoaringArray::new;
+    }
+
+    @Override
+    public BiConsumer<RoaringArray, Map.Entry<Short, List<Container>>> accumulator() {
+      return (l, r) -> {
+        assert l.size == 0 || compareUnsigned(l.keys[l.size - 1], r.getKey()) < 0;
+        Container container = reducer.apply(r.getValue());
+        if (!container.isEmpty()) {
+          l.append(r.getKey(), container);
+        }
+      };
+    }
+
+    @Override
+    public BinaryOperator<RoaringArray> combiner() {
+      return (l, r) -> {
+        assert l.size == 0 || r.size == 0 || compareUnsigned(l.keys[l.size - 1], r.keys[0]) < 0;
+        l.append(r);
+        return l;
+      };
+    }
+
+    @Override
+    public Function<RoaringArray, RoaringBitmap> finisher() {
+      return RoaringBitmap::new;
+    }
+
+    @Override
+    public Set<Characteristics> characteristics() {
+      return EnumSet.noneOf(Characteristics.class);
+    }
+  }
+
+  /**
+   * Collects a list of containers into a single container.
+   */
+  public static class OrCollector
+          implements Collector<List<Container>, Container, Container> {
+
+    @Override
+    public Supplier<Container> supplier() {
+      return () -> new BitmapContainer(new long[1 << 10], -1);
+    }
+
+    @Override
+    public BiConsumer<Container, List<Container>> accumulator() {
+      return (l, r) -> l.lazyIOR(or(r));
+    }
+
+    @Override
+    public BinaryOperator<Container> combiner() {
+      return Container::lazyIOR;
+    }
+
+    @Override
+    public Function<Container, Container> finisher() {
+      return Container::repairAfterLazy;
+    }
+
+    @Override
+    public Set<Characteristics> characteristics() {
+      return EnumSet.of(Characteristics.UNORDERED);
+    }
+  }
+
+  /**
+   * Groups the containers by their keys
+   * @param bitmaps input bitmaps
+   * @return The containers from the bitmaps grouped by key
+   */
+  public static SortedMap<Short, List<Container>> groupByKey(RoaringBitmap... bitmaps) {
+    Map<Short, List<Container>> grouped = new HashMap<>();
+    for (RoaringBitmap bitmap : bitmaps) {
+      RoaringArray ra = bitmap.highLowContainer;
+      for (int i = 0; i < ra.size; ++i) {
+        Container container = ra.values[i];
+        Short key = ra.keys[i];
+        List<Container> slice = grouped.get(key);
+        if (null == slice) {
+          slice = new ArrayList<>();
+          grouped.put(key, slice);
+        }
+        slice.add(container);
+      }
+    }
+    SortedMap<Short, List<Container>> sorted = new TreeMap<>(Util::compareUnsigned);
+    sorted.putAll(grouped);
+    return sorted;
+  }
+
+  /**
+   * Computes the bitwise union of the input bitmaps
+   * @param bitmaps the input bitmaps
+   * @return the union of the bitmaps
+   */
+  public static RoaringBitmap or(RoaringBitmap... bitmaps) {
+    return groupByKey(bitmaps)
+            .entrySet()
+            .parallelStream()
+            .collect(OR);
+  }
+
+  /**
+   * Computes the bitwise symmetric difference of the input bitmaps
+   * @param bitmaps the input bitmaps
+   * @return the symmetric difference of the bitmaps
+   */
+  public static RoaringBitmap xor(RoaringBitmap... bitmaps) {
+    return groupByKey(bitmaps)
+            .entrySet()
+            .parallelStream()
+            .collect(XOR);
+  }
+
+  private static Container or(List<Container> containers) {
+    int parallelism;
+    // if there are few enough containers it's possible no bitmaps will be materialised
+    if (containers.size() < 16) {
+      Container result = containers.get(0).clone();
+      for (int i = 1; i < containers.size(); ++i) {
+        result = result.lazyIOR(containers.get(i));
+      }
+      return result.repairAfterLazy();
+    }
+    // heuristic to save memory if the union is large and likely to end up as a bitmap
+    if (containers.size() < 512 || (parallelism = availableParallelism()) == 1) {
+      Container result = new BitmapContainer(new long[1 << 10], -1);
+      for (Container container : containers) {
+        result = result.lazyIOR(container);
+      }
+      return result.repairAfterLazy();
+    }
+    // we have an enormous slice (probably skewed), parallelise it
+    int partitionSize = (containers.size() + parallelism - 1) / parallelism;
+    return IntStream.range(0, parallelism)
+            .parallel()
+            .mapToObj(i -> containers.subList(i * partitionSize,
+                    Math.min((i + 1) * partitionSize, containers.size())))
+            .collect(new OrCollector());
+  }
+
+  private static Container xor(List<Container> containers) {
+    Container result = containers.get(0).clone();
+    for (int i = 1; i < containers.size(); ++i) {
+      result = result.ixor(containers.get(i));
+    }
+    return result;
+  }
+
+  private static int availableParallelism() {
+    return ForkJoinTask.inForkJoinPool()
+            ? ForkJoinTask.getPool().getParallelism()
+            : ForkJoinPool.getCommonPoolParallelism();
+  }
+
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
@@ -9,6 +9,8 @@ import java.io.*;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
 
+import static org.roaringbitmap.Util.compareUnsigned;
+
 
 /**
  * Specialized array to store the containers used by a RoaringBitmap. This is not meant to be used
@@ -97,6 +99,22 @@ public final class RoaringArray implements Cloneable, Externalizable {
     this.keys[this.size] = key;
     this.values[this.size] = value;
     this.size++;
+  }
+
+  void append(RoaringArray roaringArray) {
+    assert size == 0 || roaringArray.size == 0
+            || compareUnsigned(keys[size - 1], roaringArray.keys[0]) < 0;
+    if (roaringArray.size != 0 && size != 0) {
+      keys = Arrays.copyOf(keys, size + roaringArray.size);
+      values = Arrays.copyOf(values, size + roaringArray.size);
+      System.arraycopy(roaringArray.keys, 0, keys, size, roaringArray.size);
+      System.arraycopy(roaringArray.values, 0, values, size, roaringArray.size);
+      size += roaringArray.size;
+    } else if (size == 0 && roaringArray.size != 0) {
+      keys = Arrays.copyOf(roaringArray.keys, roaringArray.keys.length);
+      values = Arrays.copyOf(roaringArray.values, roaringArray.values.length);
+      size = roaringArray.size;
+    }
   }
 
   /**

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
@@ -35,8 +35,14 @@ public final class RoaringArray implements Cloneable, Externalizable {
   int size = 0;
 
   protected RoaringArray() {
-    this.keys = new short[INITIAL_CAPACITY];
-    this.values = new Container[INITIAL_CAPACITY];
+    this(new short[INITIAL_CAPACITY], new Container[INITIAL_CAPACITY], 0);
+  }
+
+
+  RoaringArray(short[] keys, Container[] values, int size) {
+    this.keys = keys;
+    this.values = values;
+    this.size = size;
   }
 
   /**

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -939,6 +939,14 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     highLowContainer = new RoaringArray();
   }
 
+
+  /**
+   * Wrap an existing high low container
+   */
+  RoaringBitmap(RoaringArray highLowContainer) {
+    this.highLowContainer = highLowContainer;
+  }
+
   /**
    * Create a RoaringBitmap from a MutableRoaringBitmap or ImmutableRoaringBitmap. The source is not
    * modified.

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -718,6 +718,11 @@ public final class RunContainer extends Container implements Cloneable {
     return new RunContainer(nbrruns, valueslength);
   }
 
+  @Override
+  public boolean isEmpty() {
+    return nbrruns == 0;
+  }
+
   // To set the last value of a value length
   private void closeValueLength(int value, int index) {
     int initialValue = toIntUnsigned(getValue(index));

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/BufferParallelAggregation.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/BufferParallelAggregation.java
@@ -1,0 +1,177 @@
+package org.roaringbitmap.buffer;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
+import static org.roaringbitmap.Util.compareUnsigned;
+
+/**
+ *
+ * These utility methods provide parallel implementations of
+ * logical aggregation operators. AND is not implemented
+ * because it is unlikely to be profitable.
+ *
+ * There is a temporary memory overhead in using these methods,
+ * since a materialisation of the rotated containers grouped by key
+ * is created in each case.
+ *
+ * Each method executes on the default fork join pool by default.
+ * If this is undesirable (it usually is) wrap the call inside
+ * a submission of a runnable to your own thread pool.
+ *
+ * <pre>
+ * {@code
+ *
+ *       //...
+ *
+ *       ExecutorService executor = ...
+ *       ImmutableRoaringBitmap[] bitmaps = ...
+ *       // executes on executors threads
+ *       MutableRoaringBitmap result = executor.submit(
+ *            () -> BufferParallelAggregation.or(bitmaps)).get();
+ * }
+ * </pre>
+ */
+public class BufferParallelAggregation {
+
+
+  private static final Collector<
+          Map.Entry<Short,List<MappeableContainer>>, MutableRoaringArray, MutableRoaringBitmap> OR
+          = new ContainerCollector(BufferParallelAggregation::or);
+
+  private static final Collector<
+          Map.Entry<Short,List<MappeableContainer>>, MutableRoaringArray, MutableRoaringBitmap> XOR
+          = new ContainerCollector(BufferParallelAggregation::xor);
+
+  /**
+   * Collects containers grouped by their key into a RoaringBitmap, applying the
+   * supplied aggregation function to each group.
+   */
+  public static class ContainerCollector implements Collector<
+          Map.Entry<Short,List<MappeableContainer>>, MutableRoaringArray, MutableRoaringBitmap> {
+
+    private final Function<List<MappeableContainer>, MappeableContainer> reducer;
+
+    /**
+     * Creates a collector with the reducer function.
+     * @param reducer a function to apply to containers with the same key.
+     */
+    public ContainerCollector(Function<List<MappeableContainer>, MappeableContainer> reducer) {
+      this.reducer = reducer;
+    }
+
+    @Override
+    public Supplier<MutableRoaringArray> supplier() {
+      return MutableRoaringArray::new;
+    }
+
+    @Override
+    public BiConsumer<
+            MutableRoaringArray, Map.Entry<Short, List<MappeableContainer>>> accumulator() {
+      return (l, r) -> {
+        assert l.size == 0 || compareUnsigned(l.keys[l.size - 1], r.getKey()) < 0;
+        MappeableContainer container = reducer.apply(r.getValue());
+        if (!container.isEmpty()) {
+          l.append(r.getKey(), container);
+        }
+      };
+    }
+
+    @Override
+    public BinaryOperator<MutableRoaringArray> combiner() {
+      return (l, r) -> {
+        assert l.size == 0 || r.size == 0 || compareUnsigned(l.keys[l.size - 1], r.keys[0]) < 0;
+        l.append(r);
+        return l;
+      };
+    }
+
+    @Override
+    public Function<MutableRoaringArray, MutableRoaringBitmap> finisher() {
+      return MutableRoaringBitmap::new;
+    }
+
+    @Override
+    public Set<Characteristics> characteristics() {
+      return EnumSet.noneOf(Characteristics.class);
+    }
+  }
+
+  /**
+   * Groups the containers by their keys
+   * @param bitmaps input bitmaps
+   * @return The containers from the bitmaps grouped by key
+   */
+  public static SortedMap<Short, List<MappeableContainer>> groupByKey(
+          ImmutableRoaringBitmap... bitmaps) {
+    Map<Short, List<MappeableContainer>> grouped = new HashMap<>();
+    for (ImmutableRoaringBitmap bitmap : bitmaps) {
+      MappeableContainerPointer it = bitmap.highLowContainer.getContainerPointer();
+      while (null != it.getContainer()) {
+        MappeableContainer container = it.getContainer();
+        Short key = it.key();
+        List<MappeableContainer> slice = grouped.get(key);
+        if (null == slice) {
+          slice = new ArrayList<>();
+          grouped.put(key, slice);
+        }
+        slice.add(container);
+        it.advance();
+      }
+    }
+    SortedMap<Short, List<MappeableContainer>> sorted = new TreeMap<>(BufferUtil::compareUnsigned);
+    sorted.putAll(grouped);
+    return sorted;
+  }
+
+  /**
+   * Computes the bitwise union of the input bitmaps
+   * @param bitmaps the input bitmaps
+   * @return the union of the bitmaps
+   */
+  public static MutableRoaringBitmap or(ImmutableRoaringBitmap... bitmaps) {
+    return groupByKey(bitmaps)
+            .entrySet()
+            .parallelStream()
+            .collect(OR);
+  }
+
+  /**
+   * Computes the bitwise symmetric difference of the input bitmaps
+   * @param bitmaps the input bitmaps
+   * @return the symmetric difference of the bitmaps
+   */
+  public static MutableRoaringBitmap xor(ImmutableRoaringBitmap... bitmaps) {
+    return groupByKey(bitmaps)
+            .entrySet()
+            .parallelStream()
+            .collect(XOR);
+  }
+
+  private static MappeableContainer or(List<MappeableContainer> containers) {
+    MappeableContainer result = containers.get(0).clone();
+    if (containers.size() == 1) {
+      return result;
+    }
+    for (int i = 1; i < containers.size(); ++i) {
+      result = result.lazyIOR(containers.get(i));
+    }
+    return result.repairAfterLazy();
+  }
+
+  private static MappeableContainer xor(List<MappeableContainer> containers) {
+    MappeableContainer result = containers.get(0).clone();
+    for (int i = 1; i < containers.size(); ++i) {
+      result = result.ixor(containers.get(i));
+    }
+    return result;
+  }
+
+}
+

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -212,6 +212,11 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     return this;
   }
 
+  @Override
+  public boolean isEmpty() {
+    return cardinality == 0;
+  }
+
   private int advance(ShortIterator it) {
     if (it.hasNext()) {
       return toIntUnsigned(it.next());

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -141,6 +141,11 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
   }
 
   @Override
+  public boolean isEmpty() {
+    return cardinality == 0;
+  }
+
+  @Override
   public MappeableArrayContainer and(final MappeableArrayContainer value2) {
 
     final MappeableArrayContainer answer = new MappeableArrayContainer(value2.content.limit());

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableContainer.java
@@ -54,6 +54,12 @@ public abstract class MappeableContainer implements Iterable<Short>, Cloneable, 
   public abstract MappeableContainer add(short x);
 
   /**
+   * Checks whether the container is empty or not.
+   * @return true if the container is empty.
+   */
+  public abstract boolean isEmpty();
+
+  /**
    * Computes the bitwise AND of this container with another (intersection). This container as well
    * as the provided container are left unaffected.
    * 

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -377,6 +377,11 @@ public final class MappeableRunContainer extends MappeableContainer implements C
     return this;
   }
 
+  @Override
+  public boolean isEmpty() {
+    return nbrruns == 0;
+  }
+
 
   @Override
   public MappeableContainer and(MappeableArrayContainer x) {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
@@ -100,6 +100,22 @@ public final class MutableRoaringArray implements Cloneable, Externalizable, Poi
     this.size++;
   }
 
+  void append(MutableRoaringArray appendage) {
+    assert size == 0 || appendage.size == 0
+            || BufferUtil.compareUnsigned(keys[size - 1], appendage.keys[0]) < 0;
+    if (appendage.size != 0 && size != 0) {
+      keys = Arrays.copyOf(keys, size + appendage.size);
+      values = Arrays.copyOf(values, size + appendage.size);
+      System.arraycopy(appendage.keys, 0, keys, size, appendage.size);
+      System.arraycopy(appendage.values, 0, values, size, appendage.size);
+      size += appendage.size;
+    } else if (size == 0 && appendage.size != 0) {
+      keys = Arrays.copyOf(appendage.keys, appendage.keys.length);
+      values = Arrays.copyOf(appendage.values, appendage.values.length);
+      size = appendage.size;
+    }
+  }
+
   /**
    * Append copies of the values AFTER a specified key (may or may not be present) to end.
    *

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
@@ -651,9 +651,12 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
    * Create an empty bitmap
    */
   public MutableRoaringBitmap() {
-    highLowContainer = new MutableRoaringArray();
+    this(new MutableRoaringArray());
   }
 
+  public MutableRoaringBitmap(MutableRoaringArray highLowContainer) {
+    this.highLowContainer = highLowContainer;
+  }
 
   /**
    * Create a MutableRoaringBitmap from a RoaringBitmap. The RoaringBitmap is not modified.

--- a/roaringbitmap/src/test/java/org/roaringbitmap/Fuzzer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/Fuzzer.java
@@ -13,6 +13,7 @@ import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
 import static java.util.stream.Collectors.toList;
+import static org.roaringbitmap.RandomisedTestData.randomBitmap;
 
 public class Fuzzer {
 
@@ -21,10 +22,8 @@ public class Fuzzer {
     boolean test(int index, RoaringBitmap bitmap);
   }
 
-  private static final ThreadLocal<long[]> bits = ThreadLocal.withInitial(() -> new long[1 << 10]);
-
   public static <T> void verifyInvarianceArray(Function<RoaringBitmap[], T> left,
-                                          Function<RoaringBitmap[], T> right) {
+                                               Function<RoaringBitmap[], T> right) {
     verifyInvarianceArray(100, 1 << 5, 96, left, right);
   }
 
@@ -36,8 +35,8 @@ public class Fuzzer {
     IntStream.range(0, count)
             .parallel()
             .mapToObj(i -> IntStream.range(0, setSize)
-                                    .mapToObj(j -> randomBitmap(maxKeys))
-                                    .toArray(RoaringBitmap[]::new))
+                    .mapToObj(j -> randomBitmap(maxKeys))
+                    .toArray(RoaringBitmap[]::new))
             .forEach(bitmap -> Assert.assertEquals(left.apply(bitmap), right.apply(bitmap)));
   }
 
@@ -48,10 +47,10 @@ public class Fuzzer {
 
 
   public static <T> void verifyInvarianceIterator(int count,
-                                          int maxKeys,
-                                          int setSize,
-                                          Function<Iterator<RoaringBitmap>, T> left,
-                                          Function<Iterator<RoaringBitmap>, T> right) {
+                                                  int maxKeys,
+                                                  int setSize,
+                                                  Function<Iterator<RoaringBitmap>, T> left,
+                                                  Function<Iterator<RoaringBitmap>, T> right) {
     IntStream.range(0, count)
             .parallel()
             .mapToObj(i -> IntStream.range(0, setSize)
@@ -61,7 +60,7 @@ public class Fuzzer {
   }
 
   public static <T> void verifyInvariance(T value, Function<RoaringBitmap, T> func) {
-    verifyInvariance(1000, 1 << 9, value, func);
+    verifyInvariance(100, 1 << 9, value, func);
   }
 
   public static <T> void verifyInvariance(int count,
@@ -77,7 +76,7 @@ public class Fuzzer {
   public static <T> void verifyInvariance(Predicate<RoaringBitmap> validity,
                                           Function<RoaringBitmap, T> left,
                                           Function<RoaringBitmap, T> right) {
-    verifyInvariance(1000, 1 << 8, validity, left, right);
+    verifyInvariance(100, 1 << 8, validity, left, right);
   }
 
   public static <T> void verifyInvariance(int count,
@@ -94,13 +93,13 @@ public class Fuzzer {
 
   public static <T> void verifyInvariance(BiFunction<RoaringBitmap, RoaringBitmap, T> left,
                                           BiFunction<RoaringBitmap, RoaringBitmap, T> right) {
-    verifyInvariance(1000, 1 << 8, left, right);
+    verifyInvariance(100, 1 << 8, left, right);
   }
 
   public static <T> void verifyInvariance(BiPredicate<RoaringBitmap, RoaringBitmap> validity,
                                           BiFunction<RoaringBitmap, RoaringBitmap, T> left,
                                           BiFunction<RoaringBitmap, RoaringBitmap, T> right) {
-    verifyInvariance(validity,1000, 1 << 8, left, right);
+    verifyInvariance(validity, 100, 1 << 8, left, right);
   }
 
 
@@ -164,15 +163,15 @@ public class Fuzzer {
   @Test
   public void firstSelect0Invariance() {
     verifyInvariance(bitmap -> !bitmap.isEmpty(),
-                     bitmap -> bitmap.first(),
-                     bitmap -> bitmap.select(0));
+            bitmap -> bitmap.first(),
+            bitmap -> bitmap.select(0));
   }
 
   @Test
   public void lastSelectCardinalityInvariance() {
     verifyInvariance(bitmap -> !bitmap.isEmpty(),
-                     bitmap -> bitmap.last(),
-                     bitmap -> bitmap.select(bitmap.getCardinality() - 1));
+            bitmap -> bitmap.last(),
+            bitmap -> bitmap.select(bitmap.getCardinality() - 1));
   }
 
   @Test
@@ -217,9 +216,9 @@ public class Fuzzer {
   @Test
   public void limitCardinalityXorCardinalityInvariance() {
     verifyInvariance(rb -> true,
-                     rb -> rb.getCardinality(),
-                     rb -> rb.getCardinality() / 2
-                             + RoaringBitmap.xorCardinality(rb, rb.limit(rb.getCardinality() / 2)));
+            rb -> rb.getCardinality(),
+            rb -> rb.getCardinality() / 2
+                    + RoaringBitmap.xorCardinality(rb, rb.limit(rb.getCardinality() / 2)));
   }
 
   @Test
@@ -302,69 +301,17 @@ public class Fuzzer {
             bitmaps -> FastAggregation.priorityqueue_xor(bitmaps));
   }
 
-
-  private static RoaringBitmap randomBitmap(int maxKeys) {
-    int[] keys = createSorted16BitInts(ThreadLocalRandom.current().nextInt(1, maxKeys));
-    double rleLimit = ThreadLocalRandom.current().nextDouble();
-    double denseLimit = ThreadLocalRandom.current().nextDouble(rleLimit, 1D);
-    OrderedWriter writer = new OrderedWriter();
-    IntStream.of(keys)
-            .forEach(key -> {
-              double choice = ThreadLocalRandom.current().nextDouble();
-              final IntStream stream;
-              if (choice < rleLimit) {
-                stream = rleRegion();
-              } else if (choice < denseLimit) {
-                stream = denseRegion();
-              } else {
-                stream = sparseRegion();
-              }
-              stream.map(i -> (key << 16) | i).forEach(writer::add);
-            });
-    writer.flush();
-    return writer.getUnderlying();
+  @Test
+  public void parallelOrVsFastOr() {
+    verifyInvarianceArray(
+            bitmaps -> ParallelAggregation.or(bitmaps),
+            bitmaps -> FastAggregation.priorityqueue_or(bitmaps));
   }
 
-  private static IntStream rleRegion() {
-    int numRuns = ThreadLocalRandom.current().nextInt(1,2048);
-    int[] runs = createSorted16BitInts(numRuns * 2);
-    return IntStream.range(0, numRuns)
-            .map(i -> i * 2)
-            .mapToObj(i -> IntStream.range(runs[i], runs[i + 1]))
-            .flatMapToInt(i -> i);
-  }
-
-  private static IntStream sparseRegion() {
-    return IntStream.of(createSorted16BitInts(ThreadLocalRandom.current().nextInt(1, 4096)));
-  }
-
-
-  private static IntStream denseRegion() {
-    return IntStream.of(createSorted16BitInts(ThreadLocalRandom.current().nextInt(4096, 1 << 16)));
-  }
-
-  private static int[] createSorted16BitInts(int howMany) {
-    // we can have at most 65536 keys in a RoaringBitmap
-    long[] bitset = bits.get();
-    Arrays.fill(bitset, 0L);
-    int consumed = 0;
-    while (consumed < howMany) {
-      int value = ThreadLocalRandom.current().nextInt(1 << 16);
-      long bit = (1L << value);
-      consumed += 1 - Long.bitCount(bitset[value >>> 6] & bit);
-      bitset[value >>> 6] |= bit;
-    }
-    int[] keys = new int[howMany];
-    int prefix = 0;
-    int k = 0;
-    for (int i = bitset.length - 1; i >= 0; --i) {
-      long word = bitset[i];
-      while (word != 0) {
-        keys[k++] = prefix + Long.numberOfTrailingZeros(word);
-        word ^= Long.lowestOneBit(word);
-      }
-      prefix += 64;
-    }
-    return keys;
+  @Test
+  public void parallelXorVsFastXor() {
+    verifyInvarianceArray(
+            bitmaps -> ParallelAggregation.xor(bitmaps),
+            bitmaps -> FastAggregation.priorityqueue_xor(bitmaps));
   }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/ParallelAggregationTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/ParallelAggregationTest.java
@@ -1,0 +1,196 @@
+package org.roaringbitmap;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.ForkJoinPool;
+import java.util.stream.IntStream;
+
+import static org.roaringbitmap.RandomisedTestData.TestDataSet.testCase;
+
+public class ParallelAggregationTest {
+
+  private static ForkJoinPool POOL;
+
+  private static ForkJoinPool NO_PARALLELISM_AVAILABLE;
+
+  @BeforeClass
+  public static void init() {
+    POOL = new ForkJoinPool(4);
+    NO_PARALLELISM_AVAILABLE = new ForkJoinPool(1);
+  }
+
+  @AfterClass
+  public static void teardown() {
+    POOL.shutdownNow();
+    NO_PARALLELISM_AVAILABLE.shutdownNow();
+  }
+
+  @Test
+  public void singleContainerOR() {
+    RoaringBitmap one = testCase().withRunAt(0).build();
+    RoaringBitmap two = testCase().withBitmapAt(0).build();
+    RoaringBitmap three = testCase().withArrayAt(0).build();
+    Assert.assertEquals(FastAggregation.or(one, two, three), ParallelAggregation.or(one, two, three));
+  }
+
+  @Test
+  public void twoContainerOR() {
+    RoaringBitmap one = testCase().withRunAt(0).withArrayAt(1).build();
+    RoaringBitmap two = testCase().withBitmapAt(1).build();
+    RoaringBitmap three = testCase().withArrayAt(1).build();
+    Assert.assertEquals(FastAggregation.or(one, two, three), ParallelAggregation.or(one, two, three));
+  }
+
+  @Test
+  public void disjointOR() {
+    RoaringBitmap one = testCase().withRunAt(0).withArrayAt(2).build();
+    RoaringBitmap two = testCase().withBitmapAt(1).build();
+    RoaringBitmap three = testCase().withArrayAt(3).build();
+    Assert.assertEquals(FastAggregation.or(one, two, three), ParallelAggregation.or(one, two, three));
+  }
+
+
+  @Test
+  public void wideOr() {
+    RoaringBitmap[] input = IntStream.range(0, 20)
+            .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build())
+            .toArray(RoaringBitmap[]::new);
+    Assert.assertEquals(FastAggregation.or(input), ParallelAggregation.or(input));
+  }
+
+  @Test
+  public void hugeOr1() {
+    RoaringBitmap[] input = IntStream.range(0, 513)
+            .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build())
+            .toArray(RoaringBitmap[]::new);
+    Assert.assertEquals(FastAggregation.or(input), ParallelAggregation.or(input));
+  }
+
+
+  @Test
+  public void hugeOr2() {
+    RoaringBitmap[] input = IntStream.range(0, 1999)
+            .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build())
+            .toArray(RoaringBitmap[]::new);
+    Assert.assertEquals(FastAggregation.or(input), ParallelAggregation.or(input));
+  }
+
+  @Test
+  public void hugeOr3() {
+    RoaringBitmap[] input = IntStream.range(0, 4096)
+            .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build())
+            .toArray(RoaringBitmap[]::new);
+    Assert.assertEquals(FastAggregation.or(input), ParallelAggregation.or(input));
+  }
+
+  @Test
+  public void hugeOrNoParallelismAvailable1() {
+    RoaringBitmap[] input = IntStream.range(0, 513)
+            .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build())
+            .toArray(RoaringBitmap[]::new);
+    Assert.assertEquals(FastAggregation.or(input),
+            NO_PARALLELISM_AVAILABLE.submit(() -> ParallelAggregation.or(input)).join());
+  }
+
+
+  @Test
+  public void hugeOrNoParallelismAvailable2() {
+    RoaringBitmap[] input = IntStream.range(0, 2000)
+            .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build())
+            .toArray(RoaringBitmap[]::new);
+    Assert.assertEquals(FastAggregation.or(input),
+            NO_PARALLELISM_AVAILABLE.submit(() -> ParallelAggregation.or(input)).join());
+  }
+
+  @Test
+  public void hugeOrNoParallelismAvailable3() {
+    RoaringBitmap[] input = IntStream.range(0, 4096)
+            .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build())
+            .toArray(RoaringBitmap[]::new);
+    Assert.assertEquals(FastAggregation.or(input),
+            NO_PARALLELISM_AVAILABLE.submit(() -> ParallelAggregation.or(input)).join());
+  }
+
+
+  @Test
+  public void hugeOrInFJP1() {
+    RoaringBitmap[] input = IntStream.range(0, 513)
+            .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build())
+            .toArray(RoaringBitmap[]::new);
+    Assert.assertEquals(FastAggregation.or(input),
+                        POOL.submit(() -> ParallelAggregation.or(input)).join());
+  }
+
+
+  @Test
+  public void hugeOrInFJP2() {
+    RoaringBitmap[] input = IntStream.range(0, 2000)
+            .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build())
+            .toArray(RoaringBitmap[]::new);
+    Assert.assertEquals(FastAggregation.or(input),
+            POOL.submit(() -> ParallelAggregation.or(input)).join());
+  }
+
+  @Test
+  public void hugeOrInFJP3() {
+    RoaringBitmap[] input = IntStream.range(0, 4096)
+            .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build())
+            .toArray(RoaringBitmap[]::new);
+    Assert.assertEquals(FastAggregation.or(input),
+            POOL.submit(() -> ParallelAggregation.or(input)).join());
+  }
+
+  @Test
+  public void disjointBigKeysOR() {
+    RoaringBitmap one = testCase().withRunAt(0).withArrayAt(2).withBitmapAt((1 << 15) | 1).build();
+    RoaringBitmap two = testCase().withBitmapAt(1).withRunAt((1 << 15) | 2).build();
+    RoaringBitmap three = testCase().withArrayAt(3).withRunAt((1 << 15) | 3).build();
+    Assert.assertEquals(FastAggregation.or(one, two, three), ParallelAggregation.or(one, two, three));
+  }
+
+  @Test
+  public void singleContainerXOR() {
+    RoaringBitmap one = testCase().withRunAt(0).build();
+    RoaringBitmap two = testCase().withBitmapAt(0).build();
+    RoaringBitmap three = testCase().withArrayAt(0).build();
+    Assert.assertEquals(FastAggregation.xor(one, two, three), ParallelAggregation.xor(one, two, three));
+  }
+
+
+  @Test
+  public void missingMiddleContainerXOR() {
+    RoaringBitmap one = testCase().withRunAt(0).withBitmapAt(1).withArrayAt(2).build();
+    RoaringBitmap two = testCase().withBitmapAt(0).withArrayAt(2).build();
+    RoaringBitmap three = testCase().withArrayAt(0).withBitmapAt(1).withArrayAt(2).build();
+    Assert.assertEquals(FastAggregation.xor(one, two, three), ParallelAggregation.xor(one, two, three));
+  }
+
+  @Test
+  public void twoContainerXOR() {
+    RoaringBitmap one = testCase().withRunAt(0).withArrayAt(1).build();
+    RoaringBitmap two = testCase().withBitmapAt(1).build();
+    RoaringBitmap three = testCase().withArrayAt(1).build();
+    Assert.assertEquals(FastAggregation.xor(one, two, three), ParallelAggregation.xor(one, two, three));
+  }
+
+  @Test
+  public void disjointXOR() {
+    RoaringBitmap one = testCase().withRunAt(0).withArrayAt(2).build();
+    RoaringBitmap two = testCase().withBitmapAt(1).build();
+    RoaringBitmap three = testCase().withArrayAt(3).build();
+    Assert.assertEquals(FastAggregation.xor(one, two, three), ParallelAggregation.xor(one, two, three));
+  }
+
+  @Test
+  public void disjointBigKeysXOR() {
+    RoaringBitmap one = testCase().withRunAt(0).withArrayAt(2).withBitmapAt((1 << 15) | 1).build();
+    RoaringBitmap two = testCase().withBitmapAt(1).withRunAt((1 << 15) | 2).build();
+    RoaringBitmap three = testCase().withArrayAt(3).withRunAt((1 << 15) | 3).build();
+    Assert.assertEquals(FastAggregation.xor(one, two, three), ParallelAggregation.xor(one, two, three));
+  }
+
+
+}

--- a/roaringbitmap/src/test/java/org/roaringbitmap/RandomisedTestData.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/RandomisedTestData.java
@@ -1,0 +1,108 @@
+package org.roaringbitmap;
+
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
+
+public class RandomisedTestData {
+
+  private static final ThreadLocal<long[]> bits = ThreadLocal.withInitial(() -> new long[1 << 10]);
+
+  public static RoaringBitmap randomBitmap(int maxKeys) {
+    int[] keys = createSorted16BitInts(ThreadLocalRandom.current().nextInt(1, maxKeys));
+    double rleLimit = ThreadLocalRandom.current().nextDouble();
+    double denseLimit = ThreadLocalRandom.current().nextDouble(rleLimit, 1D);
+    OrderedWriter writer = new OrderedWriter();
+    IntStream.of(keys)
+            .forEach(key -> {
+              double choice = ThreadLocalRandom.current().nextDouble();
+              final IntStream stream;
+              if (choice < rleLimit) {
+                stream = rleRegion();
+              } else if (choice < denseLimit) {
+                stream = denseRegion();
+              } else {
+                stream = sparseRegion();
+              }
+              stream.map(i -> (key << 16) | i).forEach(writer::add);
+            });
+    writer.flush();
+    return writer.getUnderlying();
+  }
+
+  public static IntStream rleRegion() {
+    int numRuns = ThreadLocalRandom.current().nextInt(1, 2048);
+    int[] runs = createSorted16BitInts(numRuns * 2);
+    return IntStream.range(0, numRuns)
+            .map(i -> i * 2)
+            .mapToObj(i -> IntStream.range(runs[i], runs[i + 1]))
+            .flatMapToInt(i -> i);
+  }
+
+  public static IntStream sparseRegion() {
+    return IntStream.of(createSorted16BitInts(ThreadLocalRandom.current().nextInt(1, 4096)));
+  }
+
+
+  public static IntStream denseRegion() {
+    return IntStream.of(createSorted16BitInts(ThreadLocalRandom.current().nextInt(4096, 1 << 16)));
+  }
+
+  private static int[] createSorted16BitInts(int howMany) {
+    // we can have at most 65536 keys in a RoaringBitmap
+    long[] bitset = bits.get();
+    Arrays.fill(bitset, 0L);
+    int consumed = 0;
+    while (consumed < howMany) {
+      int value = ThreadLocalRandom.current().nextInt(1 << 16);
+      long bit = (1L << value);
+      consumed += 1 - Long.bitCount(bitset[value >>> 6] & bit);
+      bitset[value >>> 6] |= bit;
+    }
+    int[] keys = new int[howMany];
+    int prefix = 0;
+    int k = 0;
+    for (int i = bitset.length - 1; i >= 0; --i) {
+      long word = bitset[i];
+      while (word != 0) {
+        keys[k++] = prefix + Long.numberOfTrailingZeros(word);
+        word ^= Long.lowestOneBit(word);
+      }
+      prefix += 64;
+    }
+    return keys;
+  }
+
+  public static class TestDataSet {
+
+
+    public static TestDataSet testCase() {
+      return new TestDataSet();
+    }
+
+    OrderedWriter writer = new OrderedWriter();
+
+    public TestDataSet withRunAt(int key) {
+      assert key < 1 << 16;
+      rleRegion().map(i -> (key << 16) | i).forEach(writer::add);
+      return this;
+    }
+
+    public TestDataSet withArrayAt(int key) {
+      assert key < 1 << 16;
+      sparseRegion().map(i -> (key << 16) | i).forEach(writer::add);
+      return this;
+    }
+
+    public TestDataSet withBitmapAt(int key) {
+      assert key < 1 << 16;
+      denseRegion().map(i -> (key << 16) | i).forEach(writer::add);
+      return this;
+    }
+
+    public RoaringBitmap build() {
+      writer.flush();
+      return writer.getUnderlying();
+    }
+  }
+}

--- a/roaringbitmap/src/test/java/org/roaringbitmap/RoaringArrayTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/RoaringArrayTest.java
@@ -1,0 +1,80 @@
+package org.roaringbitmap;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RoaringArrayTest {
+
+
+  @Test
+  public void whenAppendEmpty_ShouldBeUnchanged() {
+    RoaringArray array = new RoaringArray();
+    array.keys = new short[2];
+    array.values = new Container[2];
+    array.size = 1;
+
+    RoaringArray appendage = new RoaringArray();
+    appendage.size = 0;
+    appendage.keys = new short[4];
+    appendage.values = new Container[4];
+
+    array.append(appendage);
+    assertEquals(1, array.size);
+    assertEquals(2, array.keys.length);
+  }
+
+  @Test
+  public void whenAppendToEmpty_ShouldEqualAppendage() {
+    RoaringArray array = new RoaringArray();
+    array.size = 0;
+    array.keys = new short[4];
+    array.values = new Container[4];
+
+    RoaringArray appendage = new RoaringArray();
+    appendage.size = 3;
+    appendage.keys = new short[4];
+    appendage.values = new Container[4];
+
+    array.append(appendage);
+
+    assertEquals(3, array.size);
+    assertEquals(4, array.keys.length);
+  }
+
+  @Test
+  public void whenAppendNonEmpty_SizeShouldEqualSumOfSizes() {
+    RoaringArray array = new RoaringArray();
+    array.size = 2;
+    array.keys = new short[]{0, 2, 0, 0};
+    array.values = new Container[4];
+
+    RoaringArray appendage = new RoaringArray();
+    appendage.size = 3;
+    appendage.keys = new short[]{5, 6, 7, 0};
+    appendage.values = new Container[4];
+
+    array.append(appendage);
+
+    assertEquals(5, array.size);
+  }
+
+
+  @Test
+  public void whenAppendNonEmpty_ResultantKeysShouldBeMonotonic() {
+    RoaringArray array = new RoaringArray();
+    array.size = 2;
+    array.keys = new short[]{0, 2, 0, 0};
+    array.values = new Container[4];
+
+    RoaringArray appendage = new RoaringArray();
+    appendage.size = 3;
+    appendage.keys = new short[]{5, 6, 7, 0};
+    appendage.values = new Container[4];
+
+    array.append(appendage);
+
+    assertArrayEquals(new short[] {0, 2, 5, 6, 7}, array.keys);
+  }
+
+}

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/BufferParallelAggregationTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/BufferParallelAggregationTest.java
@@ -1,0 +1,93 @@
+package org.roaringbitmap.buffer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.roaringbitmap.RandomisedTestData.TestDataSet.testCase;
+
+public class BufferParallelAggregationTest {
+
+  @Test
+  public void singleContainerOR() {
+    ImmutableRoaringBitmap one = testCase().withRunAt(0).build().toMutableRoaringBitmap();
+    ImmutableRoaringBitmap two = testCase().withBitmapAt(0).build().toMutableRoaringBitmap();
+    ImmutableRoaringBitmap three = testCase().withArrayAt(0).build().toMutableRoaringBitmap();
+    Assert.assertEquals(BufferFastAggregation.or(one, two, three), BufferParallelAggregation.or(one, two, three));
+  }
+
+  @Test
+  public void twoContainerOR() {
+    ImmutableRoaringBitmap one = testCase().withRunAt(0).withArrayAt(1).build().toMutableRoaringBitmap();
+    ImmutableRoaringBitmap two = testCase().withBitmapAt(1).build().toMutableRoaringBitmap();
+    ImmutableRoaringBitmap three = testCase().withArrayAt(1).build().toMutableRoaringBitmap();
+    Assert.assertEquals(BufferFastAggregation.or(one, two, three), BufferParallelAggregation.or(one, two, three));
+  }
+
+  @Test
+  public void disjointOR() {
+    ImmutableRoaringBitmap one = testCase().withRunAt(0).withArrayAt(2).build().toMutableRoaringBitmap();
+    ImmutableRoaringBitmap two = testCase().withBitmapAt(1).build().toMutableRoaringBitmap();
+    ImmutableRoaringBitmap three = testCase().withArrayAt(3).build().toMutableRoaringBitmap();
+    Assert.assertEquals(BufferFastAggregation.or(one, two, three), BufferParallelAggregation.or(one, two, three));
+  }
+
+  @Test
+  public void disjointBigKeysOR() {
+    ImmutableRoaringBitmap one = testCase().withRunAt(0).withArrayAt(2).withBitmapAt((1 << 15) | 1).build()
+            .toMutableRoaringBitmap();
+    ImmutableRoaringBitmap two = testCase().withBitmapAt(1).withRunAt((1 << 15) | 2).build()
+            .toMutableRoaringBitmap();
+    ImmutableRoaringBitmap three = testCase().withArrayAt(3).withRunAt((1 << 15) | 3).build()
+            .toMutableRoaringBitmap();
+    Assert.assertEquals(BufferFastAggregation.or(one, two, three), BufferParallelAggregation.or(one, two, three));
+  }
+
+  @Test
+  public void singleContainerXOR() {
+    ImmutableRoaringBitmap one = testCase().withRunAt(0).build().toMutableRoaringBitmap();
+    ImmutableRoaringBitmap two = testCase().withBitmapAt(0).build().toMutableRoaringBitmap();
+    ImmutableRoaringBitmap three = testCase().withArrayAt(0).build().toMutableRoaringBitmap();
+    Assert.assertEquals(BufferFastAggregation.xor(one, two, three), BufferParallelAggregation.xor(one, two, three));
+  }
+
+
+  @Test
+  public void missingMiddleContainerXOR() {
+    ImmutableRoaringBitmap one = testCase().withRunAt(0).withBitmapAt(1).withArrayAt(2).build()
+            .toMutableRoaringBitmap();
+    ImmutableRoaringBitmap two = testCase().withBitmapAt(0).withArrayAt(2).build().toMutableRoaringBitmap();
+    ImmutableRoaringBitmap three = testCase().withArrayAt(0).withBitmapAt(1).withArrayAt(2).build()
+            .toMutableRoaringBitmap();
+    Assert.assertEquals(BufferFastAggregation.xor(one, two, three), BufferParallelAggregation.xor(one, two, three));
+  }
+
+  @Test
+  public void twoContainerXOR() {
+    ImmutableRoaringBitmap one = testCase().withRunAt(0).withArrayAt(1).build().toMutableRoaringBitmap();
+    ImmutableRoaringBitmap two = testCase().withBitmapAt(1).build().toMutableRoaringBitmap();
+    ImmutableRoaringBitmap three = testCase().withArrayAt(1).build().toMutableRoaringBitmap();
+    Assert.assertEquals(BufferFastAggregation.xor(one, two, three), BufferParallelAggregation.xor(one, two, three));
+  }
+
+  @Test
+  public void disjointXOR() {
+    ImmutableRoaringBitmap one = testCase().withRunAt(0).withArrayAt(2).build().toMutableRoaringBitmap();
+    ImmutableRoaringBitmap two = testCase().withBitmapAt(1).build().toMutableRoaringBitmap();
+    ImmutableRoaringBitmap three = testCase().withArrayAt(3).build().toMutableRoaringBitmap();
+    Assert.assertEquals(BufferFastAggregation.xor(one, two, three), BufferParallelAggregation.xor(one, two, three));
+  }
+
+  @Test
+  public void disjointBigKeysXOR() {
+    ImmutableRoaringBitmap one = testCase().withRunAt(0).withArrayAt(2).withBitmapAt((1 << 15) | 1).build()
+            .toMutableRoaringBitmap();
+    ImmutableRoaringBitmap two = testCase().withBitmapAt(1).withRunAt((1 << 15) | 2).build()
+            .toMutableRoaringBitmap();
+    ImmutableRoaringBitmap three = testCase().withArrayAt(3).withRunAt((1 << 15) | 3).build()
+            .toMutableRoaringBitmap();
+    Assert.assertEquals(BufferFastAggregation.xor(one, two, three), BufferParallelAggregation.xor(one, two, three));
+  }
+}
+
+
+


### PR DESCRIPTION
This PR provides a way to execute arbitrary boolean reductions on bitmaps in parallel. 

Parallel `AND` and `ANDNOT` were implemented but found to be unprofitable. They can be implemented as circuits if necessary.