### PR TITLE
Bitmap add range performance

### DIFF
--- a/jmh/src/main/java/org/roaringbitmap/BasicBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/BasicBenchmark.java
@@ -159,8 +159,15 @@ public class BasicBenchmark {
   }
 
   @Benchmark
-  public RoaringBitmap createBitmapRange() {
+  public RoaringBitmap createBitmapRange_standard() {
     RoaringBitmap r = new RoaringBitmap();
+    r.add(0L, 300_000_000L);
+    return r;
+  }
+
+  @Benchmark
+  public MutableRoaringBitmap createBitmapRange_mutable() {
+    MutableRoaringBitmap r = new MutableRoaringBitmap();
     r.add(0L, 300_000_000L);
     return r;
   }

--- a/jmh/src/main/java/org/roaringbitmap/BasicBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/BasicBenchmark.java
@@ -159,6 +159,13 @@ public class BasicBenchmark {
   }
 
   @Benchmark
+  public RoaringBitmap createBitmapRange() {
+    RoaringBitmap r = new RoaringBitmap();
+    r.add(0L, 300_000_000L);
+    return r;
+  }
+
+  @Benchmark
   public MutableRoaringBitmap createBitmapUnordered_mutable() {
 
     MutableRoaringBitmap r = new MutableRoaringBitmap();

--- a/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
@@ -28,8 +28,7 @@ public abstract class Container implements Iterable<Short>, Cloneable, Externali
     final int sizeAsArrayContainer = ArrayContainer.serializedSizeInBytes(last - start);
     final int sizeAsRunContainer = RunContainer.serializedSizeInBytes(1);
     Container answer =
-        sizeAsRunContainer < sizeAsArrayContainer ? new RunContainer() : new ArrayContainer();
-    answer = answer.iadd(start, last);
+        sizeAsRunContainer < sizeAsArrayContainer ? new RunContainer(start, last) : new ArrayContainer(start, last);
     return answer;
   }
 

--- a/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
@@ -28,7 +28,7 @@ public abstract class Container implements Iterable<Short>, Cloneable, Externali
     final int arrayContainerOverRunThreshold = 2;
     final int cardinality = last - start;
 
-    if (cardinality < arrayContainerOverRunThreshold) {
+    if (cardinality <= arrayContainerOverRunThreshold) {
       return new ArrayContainer(start, last);
     }
     return new RunContainer(start, last);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
@@ -26,7 +26,7 @@ public abstract class Container implements Iterable<Short>, Cloneable, Externali
    */
   public static Container rangeOfOnes(final int start, final int last) {
     final int arrayContainerOverRunThreshold = 2;
-    int cardinality = last - start;
+    final int cardinality = last - start;
 
     if (cardinality < arrayContainerOverRunThreshold) {
       return new ArrayContainer(start, last);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
@@ -25,11 +25,13 @@ public abstract class Container implements Iterable<Short>, Cloneable, Externali
    * @return a new container initialized with the specified values
    */
   public static Container rangeOfOnes(final int start, final int last) {
-    final int sizeAsArrayContainer = ArrayContainer.serializedSizeInBytes(last - start);
-    final int sizeAsRunContainer = RunContainer.serializedSizeInBytes(1);
-    Container answer =
-        sizeAsRunContainer < sizeAsArrayContainer ? new RunContainer(start, last) : new ArrayContainer(start, last);
-    return answer;
+    final int arrayContainerOverRunThreshold = 2;
+    int cardinality = last - start;
+
+    if (cardinality < arrayContainerOverRunThreshold) {
+      return new ArrayContainer(start, last);
+    }
+    return new RunContainer(start, last);
   }
 
   /**

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -141,6 +141,12 @@ public final class RunContainer extends Container implements Cloneable {
     setLength(runCount - 1, (short) runLen);
   }
 
+  /**
+   * Create an run container with a run of ones from firstOfRun to lastOfRun.
+   *
+   * @param firstOfRun first index
+   * @param lastOfRun last index (range is exclusive)
+   */
   public RunContainer(final int firstOfRun, final int lastOfRun) {
     this.nbrruns = 1;
     this.valueslength = new short[]{(short) firstOfRun, (short) (lastOfRun - 1 - firstOfRun)};

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -141,6 +141,11 @@ public final class RunContainer extends Container implements Cloneable {
     setLength(runCount - 1, (short) runLen);
   }
 
+  public RunContainer(final int firstOfRun, final int lastOfRun) {
+    this.nbrruns = 1;
+    this.valueslength = new short[]{(short) firstOfRun, (short) (lastOfRun - 1 - firstOfRun)};
+  }
+
   // convert a bitmap container to a run container somewhat efficiently.
   protected RunContainer(BitmapContainer bc, int nbrRuns) {
     this.nbrruns = nbrRuns;
@@ -1622,8 +1627,8 @@ public final class RunContainer extends Container implements Cloneable {
     return (this.nbrruns == 1) && (this.getValue(0) == 0) && (this.getLength(0) == -1);
   }
 
-  public static Container full() {
-    return new RunContainer(1, new short[]{0, -1});
+  public static RunContainer full() {
+    return new RunContainer(0, 1 << 16);
   }
 
   @Override

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableContainer.java
@@ -30,7 +30,7 @@ public abstract class MappeableContainer implements Iterable<Short>, Cloneable, 
     final int arrayContainerOverRunThreshold = 2;
     final int cardinality = last - start;
 
-    if (cardinality < arrayContainerOverRunThreshold) {
+    if (cardinality <= arrayContainerOverRunThreshold) {
       return new MappeableArrayContainer(start, last);
     }
     return new MappeableRunContainer(start, last);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableContainer.java
@@ -27,12 +27,13 @@ public abstract class MappeableContainer implements Iterable<Short>, Cloneable, 
    * @return a new container initialized with the specified values
    */
   public static MappeableContainer rangeOfOnes(final int start, final int last) {
-    final int sizeAsArrayContainer = MappeableArrayContainer.serializedSizeInBytes(last - start);
-    final int sizeAsRunContainer = MappeableRunContainer.serializedSizeInBytes(1);
-    MappeableContainer answer = sizeAsRunContainer < sizeAsArrayContainer
-        ? new MappeableRunContainer() : new MappeableArrayContainer();
-    answer = answer.iadd(start, last);
-    return answer;
+    final int arrayContainerOverRunThreshold = 2;
+    final int cardinality = last - start;
+
+    if (cardinality < arrayContainerOverRunThreshold) {
+      return new MappeableArrayContainer(start, last);
+    }
+    return new MappeableRunContainer(start, last);
   }
 
   /**

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -182,7 +182,8 @@ public final class MappeableRunContainer extends MappeableContainer implements C
 
   public MappeableRunContainer(final int firstOfRun, final int lastOfRun) {
     this.nbrruns = 1;
-    this.valueslength = ShortBuffer.wrap(new short[]{(short) firstOfRun, (short) (lastOfRun - 1 - firstOfRun)});
+    short[] vl = {(short) firstOfRun, (short) (lastOfRun - 1 - firstOfRun)};
+    this.valueslength = ShortBuffer.wrap(vl);
   }
 
   // convert a bitmap container to a run container somewhat efficiently.

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -180,6 +180,11 @@ public final class MappeableRunContainer extends MappeableContainer implements C
     vl[2 * (runCount - 1) + 1] = (short) runLen;
   }
 
+  public MappeableRunContainer(final int firstOfRun, final int lastOfRun) {
+    this.nbrruns = 1;
+    this.valueslength = ShortBuffer.wrap(new short[]{(short) firstOfRun, (short) (lastOfRun - 1 - firstOfRun)});
+  }
+
   // convert a bitmap container to a run container somewhat efficiently.
   protected MappeableRunContainer(MappeableBitmapContainer bc, int nbrRuns) {
     this.nbrruns = nbrRuns;
@@ -1533,9 +1538,8 @@ public final class MappeableRunContainer extends MappeableContainer implements C
     return (this.nbrruns == 1) && (this.getValue(0) == 0) && (this.getLength(0) == -1);
   }
 
-  public static MappeableContainer full() {
-    ShortBuffer sb = ShortBuffer.wrap(new short[]{0, -1});
-    return new MappeableRunContainer(sb, 1);
+  public static MappeableRunContainer full() {
+    return new MappeableRunContainer(0, 1 << 16);
   }
 
   @Override

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -180,6 +180,12 @@ public final class MappeableRunContainer extends MappeableContainer implements C
     vl[2 * (runCount - 1) + 1] = (short) runLen;
   }
 
+  /**
+   * Create an run container with a run of ones from firstOfRun to lastOfRun.
+   *
+   * @param firstOfRun first index
+   * @param lastOfRun last index (range is exclusive)
+   */
   public MappeableRunContainer(final int firstOfRun, final int lastOfRun) {
     this.nbrruns = 1;
     short[] vl = {(short) firstOfRun, (short) (lastOfRun - 1 - firstOfRun)};

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
@@ -3330,15 +3330,15 @@ public class TestRunContainer {
 
   @Test
   public void testRangeConstructor() {
-    RunContainer full = new RunContainer(0, 1 << 16);
-    Assert.assertTrue(full.isFull());
-    Assert.assertEquals(65536, full.getCardinality());
+    RunContainer c = new RunContainer(0, 1 << 16);
+    Assert.assertTrue(c.isFull());
+    Assert.assertEquals(65536, c.getCardinality());
   }
 
   @Test
   public void testRangeConstructor2() {
-    RunContainer full = new RunContainer(17, 1000);
-    Assert.assertEquals(983, full.getCardinality());
+    RunContainer c = new RunContainer(17, 1000);
+    Assert.assertEquals(983, c.getCardinality());
   }
 
   @Test
@@ -3351,15 +3351,15 @@ public class TestRunContainer {
 
   @Test
   public void testRangeConstructor4() {
-    RunContainer full = new RunContainer(0, 45679);
-    Assert.assertEquals(45679, full.getCardinality());
+    RunContainer c = new RunContainer(0, 45679);
+    Assert.assertEquals(45679, c.getCardinality());
   }
 
   @Test
   public void testSimpleCardinality() {
-    RunContainer r = new RunContainer();
-    r.add((short) 1);
-    r.add((short) 17);
-    Assert.assertEquals(2, r.getCardinality());
+    RunContainer c = new RunContainer();
+    c.add((short) 1);
+    c.add((short) 17);
+    Assert.assertEquals(2, c.getCardinality());
   }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
@@ -3322,4 +3322,44 @@ public class TestRunContainer {
     Container full = new RunContainer().add(0, 1 << 16);
     Assert.assertNotEquals(full, new ArrayContainer().add(0, 10));
   }
+
+  @Test
+  public void testFullConstructor() {
+    Assert.assertTrue(RunContainer.full().isFull());
+  }
+
+  @Test
+  public void testRangeConstructor() {
+    RunContainer full = new RunContainer(0, 1 << 16);
+    Assert.assertTrue(full.isFull());
+    Assert.assertEquals(65536, full.getCardinality());
+  }
+
+  @Test
+  public void testRangeConstructor2() {
+    RunContainer full = new RunContainer(17, 1000);
+    Assert.assertEquals(983, full.getCardinality());
+  }
+
+  @Test
+  public void testRangeConstructor3() {
+    RunContainer a = new RunContainer(17, 45679);
+    RunContainer b = new RunContainer();
+    b.iadd(17, 45679);
+    Assert.assertEquals(a, b);
+  }
+
+  @Test
+  public void testRangeConstructor4() {
+    RunContainer full = new RunContainer(0, 45679);
+    Assert.assertEquals(45679, full.getCardinality());
+  }
+
+  @Test
+  public void testSimpleCardinality() {
+    RunContainer r = new RunContainer();
+    r.add((short) 1);
+    r.add((short) 17);
+    Assert.assertEquals(2, r.getCardinality());
+  }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestRunContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestRunContainer.java
@@ -2394,4 +2394,43 @@ public class TestRunContainer {
     Assert.assertNotEquals(full, new MappeableArrayContainer().add(0, 10));
   }
 
+  @Test
+  public void testFullConstructor() {
+    Assert.assertTrue(MappeableRunContainer.full().isFull());
+  }
+
+  @Test
+  public void testRangeConstructor() {
+    MappeableRunContainer full = new MappeableRunContainer(0, 1 << 16);
+    Assert.assertTrue(full.isFull());
+    Assert.assertEquals(65536, full.getCardinality());
+  }
+
+  @Test
+  public void testRangeConstructor2() {
+    MappeableRunContainer c = new MappeableRunContainer(17, 1000);
+    Assert.assertEquals(983, c.getCardinality());
+  }
+
+  @Test
+  public void testRangeConstructor3() {
+    MappeableRunContainer a = new MappeableRunContainer(17, 45679);
+    MappeableRunContainer b = new MappeableRunContainer();
+    b.iadd(17, 45679);
+    Assert.assertEquals(a, b);
+  }
+
+  @Test
+  public void testRangeConstructor4() {
+    MappeableRunContainer c = new MappeableRunContainer(0, 45679);
+    Assert.assertEquals(45679, c.getCardinality());
+  }
+
+  @Test
+  public void testSimpleCardinality() {
+    MappeableRunContainer c = new MappeableRunContainer();
+    c.add((short) 1);
+    c.add((short) 17);
+    Assert.assertEquals(2, c.getCardinality());
+  }
 }


### PR DESCRIPTION
The code from benchmark is standard way in my codebase to create big bitmap representing the `Universe`, which is later it is used for negations.
The code creating `rangeOfOnes` was using the `iadd` code which is too complicated for this simple case. Instead I've switched to constructors including new one for `RunContainer`
The speed improvement is from `8k ops/s` to `12k ops/s` for standard bitmaps and `7.7k ops/s` to `10.5k ops/s` for `buffered`.