### PR TITLE
Trim() is not releasing all unused bytes

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
@@ -198,6 +198,17 @@ public final class RoaringArray implements Cloneable, Externalizable {
     this.size = 0;
   }
 
+  /**
+   * If possible, recover wasted memory.
+   */
+  public void trim() {
+    keys = Arrays.copyOf(keys, size);
+    values = Arrays.copyOf(values, size);
+    for (Container c : values) {
+      c.trim();
+    }
+  }
+
   @Override
   public RoaringArray clone() throws CloneNotSupportedException {
     RoaringArray sa;

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -2298,9 +2298,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
    */
   @Override
   public void trim() {
-    for (int i = 0; i < this.highLowContainer.size(); i++) {
-      this.highLowContainer.getContainerAtIndex(i).trim();
-    }
+    this.highLowContainer.trim();
   }
 
 


### PR DESCRIPTION
The RoaringArray's `keys` and `values` arrays are extended with some extra space according to [code](https://github.com/RoaringBitmap/RoaringBitmap/blob/master/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java#L320).
The space is not recovered after `RoaringBitmap.trim()` call. This could cause huge heap usage while building millions of bitmaps.
The unit tests shows how to easily waste `5292 bytes` per one bitmap.