### PR TITLE
.toString method inconsistent between containers

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -1104,10 +1104,10 @@ public final class ArrayContainer extends Container implements Cloneable {
     StringBuilder sb = new StringBuilder();
     sb.append("{");
     for (int i = 0; i < this.cardinality - 1; i++) {
-      sb.append(this.content[i]);
+      sb.append(Util.toIntUnsigned(this.content[i]));
       sb.append(",");
     }
-    sb.append(this.content[this.cardinality - 1]);
+    sb.append(Util.toIntUnsigned(this.content[this.cardinality - 1]));
     sb.append("}");
     return sb.toString();
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -1229,7 +1229,7 @@ public final class BitmapContainer extends Container implements Cloneable {
     final ShortIterator i = this.getShortIterator();
     sb.append("{");
     while (i.hasNext()) {
-      sb.append(i.next());
+      sb.append(Util.toIntUnsigned(i.next()));
       if (i.hasNext()) {
         sb.append(",");
       }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -1396,10 +1396,10 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     final StringBuilder sb = new StringBuilder();
     sb.append("{");
     for (int i = 0; i < this.cardinality - 1; i++) {
-      sb.append(this.content.get(i));
+      sb.append(toIntUnsigned(this.content.get(i)));
       sb.append(",");
     }
-    sb.append(this.content.get(this.cardinality - 1));
+    sb.append(toIntUnsigned(this.content.get(this.cardinality - 1)));
     sb.append("}");
     return sb.toString();
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -1717,7 +1717,7 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
     final ShortIterator i = this.getShortIterator();
     sb.append("{");
     while (i.hasNext()) {
-      sb.append(i.next());
+      sb.append(BufferUtil.toIntUnsigned(i.next()));
       if (i.hasNext()) {
         sb.append(",");
       }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -2274,7 +2274,7 @@ public final class MappeableRunContainer extends MappeableContainer implements C
       sb.append(toIntUnsigned(this.getValue(k)));
       sb.append(",");
       sb.append(toIntUnsigned(this.getValue(k))
-          + toIntUnsigned(this.getLength(k)) + 1);
+          + toIntUnsigned(this.getLength(k)));
       sb.append("]");
     }
     return sb.toString();

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestArrayContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestArrayContainer.java
@@ -37,7 +37,9 @@ public class TestArrayContainer {
     @Test
     public void testToString() {
         ArrayContainer ac1 = new ArrayContainer(5, 15);
-        Assert.assertEquals("{5,6,7,8,9,10,11,12,13,14}", ac1.toString());
+        ac1.add((short) -3);
+        ac1.add((short) -17);
+        Assert.assertEquals("{5,6,7,8,9,10,11,12,13,14,65519,65533}", ac1.toString());
     }
 
     @Test

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestBitmapContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestBitmapContainer.java
@@ -32,12 +32,12 @@ public class TestBitmapContainer {
 
   @Test
   public void testToString() {
-    BitmapContainer bc2 = new BitmapContainer();
-    bc2.add((short)1);
-    String s = bc2.toString();
-    assertTrue(s.equals("{1}"));
+    BitmapContainer bc2 = new BitmapContainer(5, 15);
+    bc2.add((short) -19);
+    bc2.add((short) -3);
+    assertEquals("{5,6,7,8,9,10,11,12,13,14,65517,65533}", bc2.toString());
   }
-  
+
   @Test  
   public void testXOR() {
     BitmapContainer bc = new BitmapContainer(100,10000);

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestContainer.java
@@ -1032,12 +1032,12 @@ public class TestContainer {
     ArrayContainer ac = new ArrayContainer();
     BitmapContainer bc = new BitmapContainer();
     RunContainer rc = new RunContainer();
-    for (short i : new short[]{0, 1, 17, Short.MAX_VALUE, -3, -1}) {
+    for (short i : new short[]{0, 2, 17, Short.MAX_VALUE, -3, -1}) {
       ac.add(i);
       bc.add(i);
       rc.add(i);
     }
-    String expected = "{0,1,17,32767,-3,-1}";
+    String expected = "{0,2,17,32767,65533,65535}";
 
     assertEquals(expected, ac.toString());
     assertEquals(expected, bc.toString());

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestContainer.java
@@ -1027,7 +1027,26 @@ public class TestContainer {
         new short[] {3, 4, (short) 50001, (short) 50002, (short) 50003, (short) 50004}));
   }
 
+  @Test
+  public void testConsistentToString() {
+    ArrayContainer ac = new ArrayContainer();
+    BitmapContainer bc = new BitmapContainer();
+    RunContainer rc = new RunContainer();
+    for (short i : new short[]{0, 1, 17, Short.MAX_VALUE, -3, -1}) {
+      ac.add(i);
+      bc.add(i);
+      rc.add(i);
+    }
+    String expected = "{0,1,17,32767,-3,-1}";
 
+    assertEquals(expected, ac.toString());
+    assertEquals(expected, bc.toString());
+    String normalizedRCstr = rc.toString()
+        .replaceAll("\\d+\\]\\[", "")
+        .replace('[', '{')
+        .replaceFirst(",\\d+\\]", "}");
+    assertEquals(expected, normalizedRCstr.toString());
+  }
 
   @Test
   public void xor4() {

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestContainer.java
@@ -1045,7 +1045,7 @@ public class TestContainer {
         .replaceAll("\\d+\\]\\[", "")
         .replace('[', '{')
         .replaceFirst(",\\d+\\]", "}");
-    assertEquals(expected, normalizedRCstr.toString());
+    assertEquals(expected, normalizedRCstr);
   }
 
   @Test

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
@@ -2982,9 +2982,9 @@ public class TestRunContainer {
 
   @Test
   public void testToString() {
-    Container rc = new RunContainer();
-    rc.add((short)1);
-    assertEquals("[1,1]", rc.toString());
+    Container rc = new RunContainer(32200, 35000);
+    rc.add((short)-1);
+    assertEquals("[32200,34999][65535,65535]", rc.toString());
   }
 
   @Test

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestContainer.java
@@ -820,4 +820,25 @@ public class TestContainer {
     }
   }
 
+  @Test
+  public void testConsistentToString() {
+    MappeableArrayContainer ac = new MappeableArrayContainer();
+    MappeableBitmapContainer bc = new MappeableBitmapContainer();
+    MappeableRunContainer rc = new MappeableRunContainer();
+    for (short i : new short[]{0, 2, 17, Short.MAX_VALUE, -3, -1}) {
+      ac.add(i);
+      bc.add(i);
+      rc.add(i);
+    }
+    String expected = "{0,2,17,32767,65533,65535}";
+
+    assertEquals(expected, ac.toString());
+    assertEquals(expected, bc.toString());
+    String normalizedRCstr = rc.toString()
+        .replaceAll("\\d+\\]\\[", "")
+        .replace('[', '{')
+        .replaceFirst(",\\d+\\]", "}");
+    assertEquals(expected, normalizedRCstr);
+  }
+
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestMappeableArrayContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestMappeableArrayContainer.java
@@ -279,4 +279,11 @@ public class TestMappeableArrayContainer {
     assertThat(repaired, instanceOf(MappeableRunContainer.class));
   }
 
+  @Test
+  public void testToString() {
+    MappeableArrayContainer ac1 = new MappeableArrayContainer(5, 15);
+    ac1.add((short) -3);
+    ac1.add((short) -17);
+    assertEquals("{5,6,7,8,9,10,11,12,13,14,65519,65533}", ac1.toString());
+  }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestMappeableBitmapContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestMappeableBitmapContainer.java
@@ -39,12 +39,14 @@ public class TestMappeableBitmapContainer {
     }
     return bc;
   }
+
   @Test
   public void testToString() {
-    MappeableBitmapContainer bc2 = new MappeableBitmapContainer();
-    bc2.add((short)1);
+    MappeableBitmapContainer bc2 = new MappeableBitmapContainer(5, 15);
+    bc2.add((short) -19);
+    bc2.add((short) -3);
     String s = bc2.toString();
-    assertTrue(s.equals("{1}"));
+    assertTrue(s.equals("{5,6,7,8,9,10,11,12,13,14,65517,65533}"));
   }
   
   @Test  

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestRunContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestRunContainer.java
@@ -31,6 +31,13 @@ public class TestRunContainer {
   }
 
   @Test
+  public void testToString() {
+    MappeableRunContainer rc = new MappeableRunContainer(32200, 35000);
+    rc.add((short)-1);
+    assertEquals("[32200,34999][65535,65535]", rc.toString());
+  }
+
+  @Test
   public void testRunOpti() {
     MutableRoaringBitmap mrb = new MutableRoaringBitmap();
     for(int r = 0; r< 100000; r+=3 ) {


### PR DESCRIPTION
For `RunContainers` the test fails with
```
org.junit.ComparisonFailure: 
Expected :{0,1,17,32767,-3,-1}
Actual   :{0,17,32767,65533,65535}
```
as the `toString()` for `RC` returns `[0,1][17,17][32767,32767][65533,65533][65535,65535]`
This was very misleading for me during my first pull requests.
The purpose of this PR is to decide what is the correct convention of `toString()` method or argumentation why there should be an exception.