### PR TITLE
make getLength and getValue public

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -1001,7 +1001,14 @@ public final class RunContainer extends Container implements Cloneable {
     return sum;
   }
 
-  short getLength(int index) {
+  /**
+   * Gets the length of the run at the index.
+   * @param index the index of the run.
+   * @return the length of the run at the index.
+   * @throws ArrayIndexOutOfBoundsException if index is negative or larger than the index of the
+   *     last run.
+   */
+  public short getLength(int index) {
     return valueslength[2 * index + 1];
   }
 
@@ -1020,7 +1027,14 @@ public final class RunContainer extends Container implements Cloneable {
     return this.nbrruns * 4 + 4;
   }
 
-  short getValue(int index) {
+  /**
+   * Gets the value of the first element of the run at the index.
+   * @param index the index of the run.
+   * @return the value of the first element of the run at the index.
+   * @throws ArrayIndexOutOfBoundsException if index is negative or larger than the index of the
+   *     last run.
+   */
+  public short getValue(int index) {
     return valueslength[2 * index];
   }
 

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -918,7 +918,14 @@ public final class MappeableRunContainer extends MappeableContainer implements C
     return sum;
   }
 
-  short getLength(int index) {
+  /**
+   * Gets the length of the run at the index.
+   * @param index the index of the run.
+   * @return the length of the run at the index.
+   * @throws ArrayIndexOutOfBoundsException if index is negative or larger than the index of the
+   *     last run.
+   */
+  public short getLength(int index) {
     return valueslength.get(2 * index + 1);
   }
 
@@ -943,7 +950,14 @@ public final class MappeableRunContainer extends MappeableContainer implements C
     return this.nbrruns * 4 + 4; // not sure about how exact it will be
   }
 
-  short getValue(int index) {
+  /**
+   * Gets the value of the first element of the run at the index.
+   * @param index the index of the run.
+   * @return the value of the first element of the run at the index.
+   * @throws ArrayIndexOutOfBoundsException if index is negative or larger than the index of the
+   *     last run.
+   */
+  public short getValue(int index) {
     return valueslength.get(2 * index);
   }
 


### PR DESCRIPTION
I have found that if calling code "knows" about runs, it's much easier to make the code as fast as possible. I imagine there will be some pushback on this. This is a small, low risk change, but might evoke strong feelings from a software engineering point of view.