### PR TITLE
Better use of bit manipulation instructions for bitmap iterations

### DIFF
--- a/jmh/src/main/java/org/roaringbitmap/iteration/BitmapIteratorBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/iteration/BitmapIteratorBenchmark.java
@@ -1,0 +1,85 @@
+package org.roaringbitmap.iteration;
+
+
+import org.openjdk.jmh.annotations.*;
+import org.roaringbitmap.BitmapContainer;
+import org.roaringbitmap.Container;
+import org.roaringbitmap.PeekableShortIterator;
+import org.roaringbitmap.ShortIterator;
+import org.roaringbitmap.buffer.MappeableArrayContainer;
+import org.roaringbitmap.buffer.MappeableBitmapContainer;
+import org.roaringbitmap.buffer.MappeableContainer;
+
+import java.nio.LongBuffer;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode({Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(jvmArgsPrepend = "-XX:-TieredCompilation")
+public class BitmapIteratorBenchmark {
+
+
+  @Param({"0.1", "0.2", "0.3", "0.4", "0.5"})
+  double density;
+
+  private Container container;
+  private MappeableContainer bufferContainer;
+
+  @Setup
+  public void init() {
+    long[] bitmap = new long[1024];
+    int cardinality = 0;
+    int targetCardinality = (int)(density * 65536);
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+    while (cardinality < targetCardinality) {
+      int index = random.nextInt(65536);
+      long before = bitmap[index >>> 6];
+      bitmap[index >>> 6] |= (1L << index);
+      cardinality += Long.bitCount(before ^ bitmap[index >>> 6]);
+    }
+    container = new BitmapContainer(bitmap, cardinality);
+    bufferContainer = new MappeableBitmapContainer(LongBuffer.wrap(bitmap), cardinality);
+  }
+
+  @Benchmark
+  public short forwards() {
+    PeekableShortIterator it = container.getShortIterator();
+    short max = 0;
+    while (it.hasNext()) {
+      max = it.next();
+    }
+    return max;
+  }
+
+  @Benchmark
+  public short backwards() {
+    ShortIterator it = container.getReverseShortIterator();
+    short min = 0;
+    while (it.hasNext()) {
+      min = it.next();
+    }
+    return min;
+  }
+
+  @Benchmark
+  public short forwardsBuffer() {
+    PeekableShortIterator it = bufferContainer.getShortIterator();
+    short max = 0;
+    while (it.hasNext()) {
+      max = it.next();
+    }
+    return max;
+  }
+
+  @Benchmark
+  public short backwardsBuffer() {
+    ShortIterator it = bufferContainer.getReverseShortIterator();
+    short min = 0;
+    while (it.hasNext()) {
+      min = it.next();
+    }
+    return min;
+  }
+}

--- a/jmh/src/main/java/org/roaringbitmap/iteration/IteratorsBenchmark32.java
+++ b/jmh/src/main/java/org/roaringbitmap/iteration/IteratorsBenchmark32.java
@@ -20,9 +20,9 @@ import org.roaringbitmap.RoaringBitmap;
 /**
  * Created by Borislav Ivanov on 4/2/15.
  */
-@BenchmarkMode({Mode.SampleTime, Mode.Throughput, Mode.AverageTime})
+@BenchmarkMode({Mode.AverageTime})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-public class IteratorsBenchmark {
+public class IteratorsBenchmark32 {
 
   @Benchmark
   public int testBoxed_a(BenchmarkState benchmarkState) {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -12,6 +12,9 @@ import java.nio.LongBuffer;
 import java.util.Arrays;
 import java.util.Iterator;
 
+import static java.lang.Long.numberOfLeadingZeros;
+import static java.lang.Long.numberOfTrailingZeros;
+
 
 /**
  * Simple bitset-like container.
@@ -35,7 +38,7 @@ public final class BitmapContainer extends Container implements Cloneable {
 
   /**
    * Return a bitmap iterator over this array
-   * 
+   *
    * @param bitmap array to be iterated over
    * @return an iterator
    */
@@ -45,7 +48,7 @@ public final class BitmapContainer extends Container implements Cloneable {
 
   /**
    * Return a bitmap iterator over this array
-   * 
+   *
    * @param bitmap array to be iterated over
    * @return an iterator
    */
@@ -97,7 +100,7 @@ public final class BitmapContainer extends Container implements Cloneable {
 
   /**
    * Create a new container, no copy is made.
-   * 
+   *
    * @param newBitmap content
    * @param newCardinality desired cardinality.
    */
@@ -110,7 +113,7 @@ public final class BitmapContainer extends Container implements Cloneable {
 
   /**
    * Creates a new non-mappeable container from a mappeable one. This copies the data.
-   * 
+   *
    * @param bc the original container
    */
   public BitmapContainer(MappeableBitmapContainer bc) {
@@ -379,7 +382,7 @@ public final class BitmapContainer extends Container implements Cloneable {
     return (bitmap[x / 64] >>> x ) & 1;
   }
 
-  
+
   @Override
   public void deserialize(DataInput in) throws IOException {
     // little endian
@@ -417,9 +420,8 @@ public final class BitmapContainer extends Container implements Cloneable {
     for (int k = 0; k < bitmap.length; ++k) {
       long bitset = bitmap[k];
       while (bitset != 0) {
-        long t = bitset & -bitset;
-        array[pos++] = (short) (base + Long.bitCount(t - 1));
-        bitset ^= t;
+        array[pos++] = (short) (base + numberOfTrailingZeros(bitset));
+        bitset &= (bitset - 1);
       }
       base += 64;
     }
@@ -432,9 +434,8 @@ public final class BitmapContainer extends Container implements Cloneable {
     for (int k = 0; k < bitmap.length; ++k) {
       long bitset = bitmap[k];
       while (bitset != 0) {
-        long t = bitset & -bitset;
-        x[pos++] = base + Long.bitCount(t - 1);
-        bitset ^= t;
+        x[pos++] = base + numberOfTrailingZeros(bitset);
+        bitset &= (bitset - 1);
       }
       base += 64;
     }
@@ -871,10 +872,9 @@ public final class BitmapContainer extends Container implements Cloneable {
       for (int k = 0; (ac.cardinality < maxcardinality) && (k < bitmap.length); ++k) {
         long bitset = bitmap[k];
         while ((ac.cardinality < maxcardinality) && (bitset != 0)) {
-          long t = bitset & -bitset;
-          ac.content[pos++] = (short) (k * 64 + Long.bitCount(t - 1));
+          ac.content[pos++] = (short) (k * 64 + numberOfTrailingZeros(bitset));
           ac.cardinality++;
-          bitset ^= t;
+          bitset &= (bitset - 1);
         }
       }
       return ac;
@@ -912,11 +912,11 @@ public final class BitmapContainer extends Container implements Cloneable {
     long w = bitmap[x];
     w >>>= i;
     if (w != 0) {
-      return i + Long.numberOfTrailingZeros(w);
+      return i + numberOfTrailingZeros(w);
     }
     for (++x; x < bitmap.length; ++x) {
       if (bitmap[x] != 0) {
-        return x * 64 + Long.numberOfTrailingZeros(bitmap[x]);
+        return x * 64 + numberOfTrailingZeros(bitmap[x]);
       }
     }
     return -1;
@@ -933,12 +933,12 @@ public final class BitmapContainer extends Container implements Cloneable {
     long w = ~bitmap[x];
     w >>>= i;
     if (w != 0) {
-      return (short) (i + Long.numberOfTrailingZeros(w));
+      return (short) (i + numberOfTrailingZeros(w));
     }
     ++x;
     for (; x < bitmap.length; ++x) {
       if (bitmap[x] != ~0L) {
-        return (short) (x * 64 + Long.numberOfTrailingZeros(~bitmap[x]));
+        return (short) (x * 64 + numberOfTrailingZeros(~bitmap[x]));
       }
     }
     return -1;
@@ -974,7 +974,7 @@ public final class BitmapContainer extends Container implements Cloneable {
 
   /**
    * Computes the number of runs
-   * 
+   *
    * @return the number of runs
    */
   public int numberOfRunsAdjustment() {
@@ -996,7 +996,7 @@ public final class BitmapContainer extends Container implements Cloneable {
 
   /**
    * Counts how many runs there is in the bitmap, up to a maximum
-   * 
+   *
    * @param mustNotExceed maximum of runs beyond which counting is pointless
    * @return estimated number of courses
    */
@@ -1214,7 +1214,7 @@ public final class BitmapContainer extends Container implements Cloneable {
   /**
    * Return the content of this container as a LongBuffer. This creates a copy and might be
    * relatively slow.
-   * 
+   *
    * @return the LongBuffer
    */
   public LongBuffer toLongBuffer() {
@@ -1306,9 +1306,8 @@ public final class BitmapContainer extends Container implements Cloneable {
     for (int x = 0; x < bitmap.length; ++x) {
       long w = bitmap[x];
       while (w != 0) {
-        long t = w & -w;
-        ic.accept((x * 64 + Long.bitCount(t - 1)) | high);
-        w ^= t;
+        ic.accept((x * 64 + numberOfTrailingZeros(w)) | high);
+        w &= (w - 1);
       }
     }
   }
@@ -1326,7 +1325,7 @@ public final class BitmapContainer extends Container implements Cloneable {
       ++i; // seek forward
     }
     // sizeof(long) * #empty words at start + number of bits preceding the first bit set
-    return i * 64 + Long.numberOfTrailingZeros(bitmap[i]);
+    return i * 64 + numberOfTrailingZeros(bitmap[i]);
   }
 
   @Override
@@ -1372,9 +1371,8 @@ final class BitmapContainerShortIterator implements PeekableShortIterator {
 
   @Override
   public short next() {
-    long t = w & -w;
-    short answer = (short) (x * 64 + Long.bitCount(t - 1));
-    w ^= t;
+    short answer = (short) (x * 64 + numberOfTrailingZeros(w));
+    w &= (w - 1);
     while (w == 0) {
       ++x;
       if (x == bitmap.length) {
@@ -1389,17 +1387,7 @@ final class BitmapContainerShortIterator implements PeekableShortIterator {
 
   @Override
   public int nextAsInt() {
-    long t = w & -w;
-    int answer = x * 64 + Long.bitCount(t - 1);
-    w ^= t;
-    while (w == 0) {
-      ++x;
-      if (x == bitmap.length) {
-        break;
-      }
-      w = bitmap[x];
-    }
-    return answer;
+    return Util.toIntUnsigned(next());
   }
 
   @Override
@@ -1438,8 +1426,7 @@ final class BitmapContainerShortIterator implements PeekableShortIterator {
 
   @Override
   public short peekNext() {
-    long t = w & -w;
-    return (short) (x * 64 + Long.bitCount(t - 1));
+    return (short) (x * 64 + numberOfTrailingZeros(w));
   }
 }
 

--- a/roaringbitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/Util.java
@@ -6,6 +6,8 @@ package org.roaringbitmap;
 
 import java.util.Arrays;
 
+import static java.lang.Long.numberOfTrailingZeros;
+
 /**
  * Various useful methods for roaring bitmaps.
  */
@@ -156,9 +158,8 @@ public final class Util {
     for (int k = 0; k < bitmap1.length; ++k) {
       long bitset = bitmap1[k] & bitmap2[k];
       while (bitset != 0) {
-        long t = bitset & -bitset;
-        container[pos++] = (short) (k * 64 + Long.bitCount(t - 1));
-        bitset ^= t;
+        container[pos++] = (short) (k * 64 + numberOfTrailingZeros(bitset));
+        bitset &= (bitset - 1);
       }
     }
   }
@@ -179,9 +180,8 @@ public final class Util {
     for (int k = 0; k < bitmap1.length; ++k) {
       long bitset = bitmap1[k] & (~bitmap2[k]);
       while (bitset != 0) {
-        long t = bitset & -bitset;
-        container[pos++] = (short) (k * 64 + Long.bitCount(t - 1));
-        bitset ^= t;
+        container[pos++] = (short) (k * 64 + numberOfTrailingZeros(bitset));
+        bitset &= (bitset - 1);
       }
     }
   }
@@ -202,9 +202,8 @@ public final class Util {
     for (int k = 0; k < bitmap1.length; ++k) {
       long bitset = bitmap1[k] ^ bitmap2[k];
       while (bitset != 0) {
-        long t = bitset & -bitset;
-        container[pos++] = (short) (k * 64 + Long.bitCount(t - 1));
-        bitset ^= t;
+        container[pos++] = (short) (k * 64 + numberOfTrailingZeros(bitset));
+        bitset &= (bitset - 1);
       }
     }
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/BufferBitSetUtil.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/BufferBitSetUtil.java
@@ -8,6 +8,8 @@ import java.util.BitSet;
 
 import org.roaringbitmap.IntIterator;
 
+import static java.lang.Long.numberOfTrailingZeros;
+
 
 /***
  *
@@ -32,9 +34,8 @@ public class BufferBitSetUtil {
     for (int i = from, socket = 0; i < to; ++i, socket += Long.SIZE) {
       long word = words[i];
       while (word != 0) {
-        long t = word & -word;
-        content[index++] = (short) (socket + Long.bitCount(t - 1));
-        word ^= t;
+        content[index++] = (short) (socket + numberOfTrailingZeros(word));
+        word &= (word - 1);
       }
     }
     return new MappeableArrayContainer(ShortBuffer.wrap(content), cardinality);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/BufferUtil.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/BufferUtil.java
@@ -11,6 +11,8 @@ import java.nio.ShortBuffer;
 
 import org.roaringbitmap.Util;
 
+import static java.lang.Long.numberOfTrailingZeros;
+
 /**
  * Various useful methods for roaring bitmaps.
  *
@@ -195,9 +197,8 @@ public final class BufferUtil {
       for (int k = 0; k < len; ++k) {
         long bitset = b1[k] & b2[k];
         while (bitset != 0) {
-          final long t = bitset & -bitset;
-          container[pos++] = (short) (k * 64 + Long.bitCount(t - 1));
-          bitset ^= t;
+          container[pos++] = (short) (k * 64 + numberOfTrailingZeros(bitset));
+          bitset &= (bitset - 1);
         }
       }
     } else {
@@ -205,9 +206,8 @@ public final class BufferUtil {
       for (int k = 0; k < len; ++k) {
         long bitset = bitmap1.get(k) & bitmap2.get(k);
         while (bitset != 0) {
-          final long t = bitset & -bitset;
-          container[pos++] = (short) (k * 64 + Long.bitCount(t - 1));
-          bitset ^= t;
+          container[pos++] = (short) (k * 64 + numberOfTrailingZeros(bitset));
+          bitset &= (bitset - 1);
         }
       }
     }
@@ -225,9 +225,8 @@ public final class BufferUtil {
       for (int k = 0; k < len; ++k) {
         long bitset = b1[k] & (~b2[k]);
         while (bitset != 0) {
-          final long t = bitset & -bitset;
-          container[pos++] = (short) (k * 64 + Long.bitCount(t - 1));
-          bitset ^= t;
+          container[pos++] = (short) (k * 64 + numberOfTrailingZeros(bitset));
+          bitset &= (bitset - 1);
         }
       }
     } else {
@@ -235,9 +234,8 @@ public final class BufferUtil {
       for (int k = 0; k < len; ++k) {
         long bitset = bitmap1.get(k) & (~bitmap2.get(k));
         while (bitset != 0) {
-          final long t = bitset & -bitset;
-          container[pos++] = (short) (k * 64 + Long.bitCount(t - 1));
-          bitset ^= t;
+          container[pos++] = (short) (k * 64 + numberOfTrailingZeros(bitset));
+          bitset &= (bitset - 1);
         }
       }
     }
@@ -255,9 +253,8 @@ public final class BufferUtil {
       for (int k = 0; k < len; ++k) {
         long bitset = bitmap1.get(k) ^ bitmap2.get(k);
         while (bitset != 0) {
-          final long t = bitset & -bitset;
-          container[pos++] = (short) (k * 64 + Long.bitCount(t - 1));
-          bitset ^= t;
+          container[pos++] = (short) (k * 64 + numberOfTrailingZeros(bitset));
+          bitset &= (bitset - 1);
         }
       }
     }


### PR DESCRIPTION
I aim to speed container iteration up. Before doing that I did some instruction profiling, which revealed some suboptimal instructions were being JIT compiled for bitmap iteration:

```java
long t = bitset & -bitset;
array[pos++] = (short) (base + Long.bitCount(t - 1));
bitset ^= t;
```

```asm
  0.89%    0x0000000004b27296: blsi    rbx,r10           
  0.93%    0x0000000004b2729b: mov     rdi,rbx
  2.22%    0x0000000004b2729e: xor     rdi,r10           
  1.40%    0x0000000004b272a1: mov     qword ptr [r11+10h],rdi  
  2.22%    0x0000000004b272a5: mov     ecx,r8d
  0.57%    0x0000000004b272a8: shl     ecx,6h
  2.06%    0x0000000004b272ab: dec     rbx
  1.24%    0x0000000004b272ae: popcnt  rbx,rbx
  2.25%    0x0000000004b272b3: add     ecx,ebx           
```
Iterating over a bitmap of various densities looks like this:


Benchmark | (density) | Mode | Cnt | Score | Error | Units
-- | -- | -- | -- | -- | -- | --
BitmapIteratorBenchmark.forwards | 0.1 | avgt | 5 | 17.645 | 0.505 | us/op
BitmapIteratorBenchmark.forwards | 0.2 | avgt | 5 | 41.879 | 0.907 | us/op
BitmapIteratorBenchmark.forwards | 0.3 | avgt | 5 | 59.874 | 0.457 | us/op
BitmapIteratorBenchmark.forwards | 0.4 | avgt | 5 | 78.776 | 1.826 | us/op
BitmapIteratorBenchmark.forwards | 0.5 | avgt | 5 | 89.05 | 0.775 | us/op



This is very hotspot/Intel specific but C2 emits better code on Intel ("fusing" `blsi` and `xor` into `blsr`) with the pattern below, `tzcnt` is a drop in for `popcnt` and doesn't require a subtraction.

```java
array[pos++] = (short) (base + numberOfTrailingZeros(bitset));
bitset &= (bitset - 1);
```

```asm
  0.77%    0x0000000005605904: mov     edi,r10d
  1.60%    0x0000000005605907: shl     edi,6h
  3.19%    0x000000000560590a: tzcnt   r8,r11
  1.49%    0x000000000560590f: add     edi,r8d        
  1.41%    0x0000000005605912: blsr    r11,r11           
```

This performs better:

Benchmark | (density) | Mode | Cnt | Score | Error | Units
-- | -- | -- | -- | -- | -- | --
BitmapIteratorBenchmark.forwards | 0.1 | avgt | 5 | 17.051 | 0.412 | us/op
BitmapIteratorBenchmark.forwards | 0.2 | avgt | 5 | 36.951 | 0.456 | us/op
BitmapIteratorBenchmark.forwards | 0.3 | avgt | 5 | 52.025 | 0.924 | us/op
BitmapIteratorBenchmark.forwards | 0.4 | avgt | 5 | 67.616 | 0.974 | us/op
BitmapIteratorBenchmark.forwards | 0.5 | avgt | 5 | 73.792 | 0.781 | us/op

Is this micro-optimisation? Yes. But if you have 5 dense bitmaps it would cost 100us. This only takes effect in code compiled by C2 and I don't know what the tradeoff is on different microarchitectures. 