### PR TITLE
Fix to avoid double copy in in-place array OR

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,4 +20,5 @@ Olivier Peyrusse,
 Richard Startin,
 Erik Gorset,
 Benoit Lacelle,
-Yizhu Sun
+Yizhu Sun,
+Amit Desai

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestArrayContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestArrayContainer.java
@@ -1,6 +1,7 @@
 package org.roaringbitmap;
 
 import com.google.common.primitives.Ints;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -14,7 +15,6 @@ import java.util.NoSuchElementException;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertFalse;
 
 public class TestArrayContainer {
 
@@ -339,5 +339,45 @@ public class TestArrayContainer {
         Container disjoint = new ArrayContainer().add(20, 40);
         assertFalse(ac.contains(disjoint));
         assertFalse(disjoint.contains(ac));
+    }
+  
+    @Test
+    public void iorNotIncreaseCapacity() {
+      Container ac1 = new ArrayContainer();
+      Container ac2 = new ArrayContainer();
+      ac1.add((short) 128);
+      ac1.add((short) 256);
+      ac2.add((short) 1024);
+      
+      ac1.ior(ac2);
+      assertTrue(ac1.contains((short) 128));
+      assertTrue(ac1.contains((short) 256));
+      assertTrue(ac1.contains((short) 1024));
+    }
+    
+    @Test
+    public void iorIncreaseCapacity() {
+      Container ac1 = new ArrayContainer();
+      Container ac2 = new ArrayContainer();
+      ac1.add((short) 128);
+      ac1.add((short) 256);
+      ac1.add((short) 512);
+      ac1.add((short) 513);
+      ac2.add((short) 1024);
+      
+      ac1.ior(ac2);
+      assertTrue(ac1.contains((short) 128));
+      assertTrue(ac1.contains((short) 256));
+      assertTrue(ac1.contains((short) 512));
+      assertTrue(ac1.contains((short) 513));
+      assertTrue(ac1.contains((short) 1024));
+    }
+    
+    @Test
+    public void iorSanityCheck() {
+      Container ac = new ArrayContainer().add(0, 10);
+      Container disjoint = new ArrayContainer().add(20, 40);
+      ac.ior(disjoint);
+      assertTrue(ac.contains(disjoint));
     }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestMappeableArrayContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestMappeableArrayContainer.java
@@ -286,4 +286,44 @@ public class TestMappeableArrayContainer {
     ac1.add((short) -17);
     assertEquals("{5,6,7,8,9,10,11,12,13,14,65519,65533}", ac1.toString());
   }
+  
+  @Test
+  public void iorNotIncreaseCapacity() {
+    MappeableArrayContainer ac1 = new MappeableArrayContainer();
+    MappeableArrayContainer ac2 = new MappeableArrayContainer();
+    ac1.add((short) 128);
+    ac1.add((short) 256);
+    ac2.add((short) 1024);
+    
+    ac1.ior(ac2);
+    assertTrue(ac1.contains((short) 128));
+    assertTrue(ac1.contains((short) 256));
+    assertTrue(ac1.contains((short) 1024));
+  }
+  
+  @Test
+  public void iorIncreaseCapacity() {
+    MappeableArrayContainer ac1 = new MappeableArrayContainer();
+    MappeableArrayContainer ac2 = new MappeableArrayContainer();
+    ac1.add((short) 128);
+    ac1.add((short) 256);
+    ac1.add((short) 512);
+    ac1.add((short) 513);
+    ac2.add((short) 1024);
+    
+    ac1.ior(ac2);
+    assertTrue(ac1.contains((short) 128));
+    assertTrue(ac1.contains((short) 256));
+    assertTrue(ac1.contains((short) 512));
+    assertTrue(ac1.contains((short) 513));
+    assertTrue(ac1.contains((short) 1024));
+  }
+  
+  @Test
+  public void iorSanityCheck() {
+    MappeableContainer ac = new MappeableArrayContainer().add(0, 10);
+    MappeableContainer disjoint = new MappeableArrayContainer().add(20, 40);
+    ac.ior(disjoint);
+    assertTrue(ac.contains(disjoint));
+  }
 }


### PR DESCRIPTION
**In case when we increased capacity, we used to follow below steps:**

1. increaseCapacity(Arrays.copyOf)   - Copy 1st time
2. System.arrayCopy to offset  - Copy 2nd time
3. Perform Union

**With changes, it saves 2 copies:**

1. - create new array. (No copy)
2. - Perform union with new array as destination