### PR TITLE
constant memory parallel aggregation

### DIFF
--- a/jmh/pom.xml
+++ b/jmh/pom.xml
@@ -73,7 +73,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
     
-        <jmh.version>1.17</jmh.version>
+        <jmh.version>1.20</jmh.version>
         <uberjar.name>benchmarks</uberjar.name>
 
         <!-- JMH does not like checkstyle for now -->

--- a/jmh/src/main/java/org/roaringbitmap/realdata/ParallelAggregatorBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/realdata/ParallelAggregatorBenchmark.java
@@ -36,6 +36,8 @@ public class ParallelAggregatorBenchmark {
 
   RoaringBitmap[] bitmaps;
   ImmutableRoaringBitmap[] immutableRoaringBitmaps;
+  ParallelAggregation.AggregationBuffer buffer;
+  BufferParallelAggregation.AggregationBuffer buffer2;
 
   @Setup(Level.Trial)
   public void setup() throws Exception {
@@ -48,11 +50,18 @@ public class ParallelAggregatorBenchmark {
     });
     immutableRoaringBitmaps = Arrays.stream(bitmaps).map(RoaringBitmap::toMutableRoaringBitmap)
             .toArray(ImmutableRoaringBitmap[]::new);
+    this.buffer = ParallelAggregation.newAggregationBuffer();
+    this.buffer2 = BufferParallelAggregation.newAggregationBuffer();
   }
 
   @Benchmark
   public RoaringBitmap parallelOr() {
     return ParallelAggregation.or(bitmaps);
+  }
+
+  @Benchmark
+  public RoaringBitmap parallelBufferedOr() {
+    return ParallelAggregation.bufferedOr(buffer, bitmaps);
   }
 
   @Benchmark
@@ -79,6 +88,11 @@ public class ParallelAggregatorBenchmark {
   @Benchmark
   public MutableRoaringBitmap bufferParallelOr() {
     return BufferParallelAggregation.or(immutableRoaringBitmaps);
+  }
+
+  @Benchmark
+  public MutableRoaringBitmap bufferParallelBufferedOr() {
+    return BufferParallelAggregation.bufferedOr(buffer2, immutableRoaringBitmaps);
   }
 
   @Benchmark

--- a/roaringbitmap/src/test/java/org/roaringbitmap/Fuzzer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/Fuzzer.java
@@ -308,6 +308,16 @@ public class Fuzzer {
             bitmaps -> FastAggregation.priorityqueue_or(bitmaps));
   }
 
+
+  @Test
+  public void parallelOrVsParallelBufferedOr() {
+    ThreadLocal<ParallelAggregation.AggregationBuffer> buffer =
+            ThreadLocal.withInitial(ParallelAggregation::newAggregationBuffer);
+    verifyInvarianceArray(
+            bitmaps -> ParallelAggregation.or(bitmaps),
+            bitmaps -> ParallelAggregation.bufferedOr(buffer.get(), bitmaps));
+  }
+
   @Test
   public void parallelXorVsFastXor() {
     verifyInvarianceArray(

--- a/roaringbitmap/src/test/java/org/roaringbitmap/ParallelAggregationTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/ParallelAggregationTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.IntStream;
 
+import static org.roaringbitmap.ParallelAggregation.newAggregationBuffer;
 import static org.roaringbitmap.RandomisedTestData.TestDataSet.testCase;
 
 public class ParallelAggregationTest {
@@ -34,6 +35,8 @@ public class ParallelAggregationTest {
     RoaringBitmap two = testCase().withBitmapAt(0).build();
     RoaringBitmap three = testCase().withArrayAt(0).build();
     Assert.assertEquals(FastAggregation.or(one, two, three), ParallelAggregation.or(one, two, three));
+    Assert.assertEquals(ParallelAggregation.or(one, two, three),
+            ParallelAggregation.bufferedOr(newAggregationBuffer(), one, two, three));
   }
 
   @Test
@@ -42,6 +45,8 @@ public class ParallelAggregationTest {
     RoaringBitmap two = testCase().withBitmapAt(1).build();
     RoaringBitmap three = testCase().withArrayAt(1).build();
     Assert.assertEquals(FastAggregation.or(one, two, three), ParallelAggregation.or(one, two, three));
+    Assert.assertEquals(ParallelAggregation.or(one, two, three),
+            ParallelAggregation.bufferedOr(newAggregationBuffer(), one, two, three));
   }
 
   @Test
@@ -50,6 +55,8 @@ public class ParallelAggregationTest {
     RoaringBitmap two = testCase().withBitmapAt(1).build();
     RoaringBitmap three = testCase().withArrayAt(3).build();
     Assert.assertEquals(FastAggregation.or(one, two, three), ParallelAggregation.or(one, two, three));
+    Assert.assertEquals(ParallelAggregation.or(one, two, three),
+            ParallelAggregation.bufferedOr(newAggregationBuffer(), one, two, three));
   }
 
 
@@ -59,6 +66,8 @@ public class ParallelAggregationTest {
             .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build())
             .toArray(RoaringBitmap[]::new);
     Assert.assertEquals(FastAggregation.or(input), ParallelAggregation.or(input));
+    Assert.assertEquals(ParallelAggregation.or(input),
+            ParallelAggregation.bufferedOr(newAggregationBuffer(), input));
   }
 
   @Test
@@ -67,6 +76,8 @@ public class ParallelAggregationTest {
             .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build())
             .toArray(RoaringBitmap[]::new);
     Assert.assertEquals(FastAggregation.or(input), ParallelAggregation.or(input));
+    Assert.assertEquals(ParallelAggregation.or(input),
+            ParallelAggregation.bufferedOr(newAggregationBuffer(), input));
   }
 
 
@@ -76,6 +87,8 @@ public class ParallelAggregationTest {
             .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build())
             .toArray(RoaringBitmap[]::new);
     Assert.assertEquals(FastAggregation.or(input), ParallelAggregation.or(input));
+    Assert.assertEquals(ParallelAggregation.or(input),
+            ParallelAggregation.bufferedOr(newAggregationBuffer(), input));
   }
 
   @Test
@@ -84,6 +97,8 @@ public class ParallelAggregationTest {
             .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build())
             .toArray(RoaringBitmap[]::new);
     Assert.assertEquals(FastAggregation.or(input), ParallelAggregation.or(input));
+    Assert.assertEquals(ParallelAggregation.or(input),
+            ParallelAggregation.bufferedOr(newAggregationBuffer(), input));
   }
 
   @Test
@@ -93,6 +108,9 @@ public class ParallelAggregationTest {
             .toArray(RoaringBitmap[]::new);
     Assert.assertEquals(FastAggregation.or(input),
             NO_PARALLELISM_AVAILABLE.submit(() -> ParallelAggregation.or(input)).join());
+    Assert.assertEquals(FastAggregation.or(input),
+            NO_PARALLELISM_AVAILABLE.submit(() ->
+                    ParallelAggregation.bufferedOr(newAggregationBuffer(), input)).join());
   }
 
 
@@ -103,6 +121,9 @@ public class ParallelAggregationTest {
             .toArray(RoaringBitmap[]::new);
     Assert.assertEquals(FastAggregation.or(input),
             NO_PARALLELISM_AVAILABLE.submit(() -> ParallelAggregation.or(input)).join());
+    Assert.assertEquals(FastAggregation.or(input),
+            NO_PARALLELISM_AVAILABLE.submit(() ->
+                    ParallelAggregation.bufferedOr(newAggregationBuffer(), input)).join());
   }
 
   @Test
@@ -112,6 +133,9 @@ public class ParallelAggregationTest {
             .toArray(RoaringBitmap[]::new);
     Assert.assertEquals(FastAggregation.or(input),
             NO_PARALLELISM_AVAILABLE.submit(() -> ParallelAggregation.or(input)).join());
+    Assert.assertEquals(FastAggregation.or(input),
+            NO_PARALLELISM_AVAILABLE.submit(() ->
+                    ParallelAggregation.bufferedOr(newAggregationBuffer(), input)).join());
   }
 
 
@@ -122,6 +146,8 @@ public class ParallelAggregationTest {
             .toArray(RoaringBitmap[]::new);
     Assert.assertEquals(FastAggregation.or(input),
                         POOL.submit(() -> ParallelAggregation.or(input)).join());
+    Assert.assertEquals(ParallelAggregation.or(input),
+            POOL.submit(() -> ParallelAggregation.bufferedOr(newAggregationBuffer(), input)).join());
   }
 
 
@@ -132,6 +158,8 @@ public class ParallelAggregationTest {
             .toArray(RoaringBitmap[]::new);
     Assert.assertEquals(FastAggregation.or(input),
             POOL.submit(() -> ParallelAggregation.or(input)).join());
+    Assert.assertEquals(ParallelAggregation.or(input),
+            POOL.submit(() -> ParallelAggregation.bufferedOr(newAggregationBuffer(), input)).join());
   }
 
   @Test
@@ -141,6 +169,8 @@ public class ParallelAggregationTest {
             .toArray(RoaringBitmap[]::new);
     Assert.assertEquals(FastAggregation.or(input),
             POOL.submit(() -> ParallelAggregation.or(input)).join());
+    Assert.assertEquals(ParallelAggregation.or(input),
+            POOL.submit(() -> ParallelAggregation.bufferedOr(newAggregationBuffer(), input)).join());
   }
 
   @Test
@@ -149,6 +179,8 @@ public class ParallelAggregationTest {
     RoaringBitmap two = testCase().withBitmapAt(1).withRunAt((1 << 15) | 2).build();
     RoaringBitmap three = testCase().withArrayAt(3).withRunAt((1 << 15) | 3).build();
     Assert.assertEquals(FastAggregation.or(one, two, three), ParallelAggregation.or(one, two, three));
+    Assert.assertEquals(ParallelAggregation.or(one, two, three),
+            ParallelAggregation.bufferedOr(newAggregationBuffer(), one, two, three));
   }
 
   @Test

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/BufferFuzzer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/BufferFuzzer.java
@@ -234,6 +234,15 @@ public class BufferFuzzer {
   }
 
   @Test
+  public void parallelOrVsBufferedParallelOr() {
+    ThreadLocal<BufferParallelAggregation.AggregationBuffer> buffer =
+            ThreadLocal.withInitial(BufferParallelAggregation::newAggregationBuffer);
+    verifyInvarianceArray(
+            bitmaps -> BufferParallelAggregation.or(bitmaps),
+            bitmaps -> BufferParallelAggregation.bufferedOr(buffer.get(), bitmaps));
+  }
+
+  @Test
   public void parallelXorVsFastXor() {
     verifyInvarianceArray(
             bitmaps -> BufferParallelAggregation.xor(bitmaps),

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/BufferParallelAggregationTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/BufferParallelAggregationTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.stream.IntStream;
 
 import static org.roaringbitmap.RandomisedTestData.TestDataSet.testCase;
+import static org.roaringbitmap.buffer.BufferParallelAggregation.newAggregationBuffer;
 
 public class BufferParallelAggregationTest {
   private static ForkJoinPool POOL;
@@ -33,6 +34,8 @@ public class BufferParallelAggregationTest {
     ImmutableRoaringBitmap two = testCase().withBitmapAt(0).build().toMutableRoaringBitmap();
     ImmutableRoaringBitmap three = testCase().withArrayAt(0).build().toMutableRoaringBitmap();
     Assert.assertEquals(BufferFastAggregation.or(one, two, three), BufferParallelAggregation.or(one, two, three));
+    Assert.assertEquals(BufferParallelAggregation.or(one, two, three),
+            BufferParallelAggregation.bufferedOr(newAggregationBuffer(), one, two, three));
   }
 
   @Test
@@ -41,6 +44,8 @@ public class BufferParallelAggregationTest {
     ImmutableRoaringBitmap two = testCase().withBitmapAt(1).build().toMutableRoaringBitmap();
     ImmutableRoaringBitmap three = testCase().withArrayAt(1).build().toMutableRoaringBitmap();
     Assert.assertEquals(BufferFastAggregation.or(one, two, three), BufferParallelAggregation.or(one, two, three));
+    Assert.assertEquals(BufferParallelAggregation.or(one, two, three),
+            BufferParallelAggregation.bufferedOr(newAggregationBuffer(), one, two, three));
   }
 
   @Test
@@ -49,6 +54,8 @@ public class BufferParallelAggregationTest {
     ImmutableRoaringBitmap two = testCase().withBitmapAt(1).build().toMutableRoaringBitmap();
     ImmutableRoaringBitmap three = testCase().withArrayAt(3).build().toMutableRoaringBitmap();
     Assert.assertEquals(BufferFastAggregation.or(one, two, three), BufferParallelAggregation.or(one, two, three));
+    Assert.assertEquals(BufferParallelAggregation.or(one, two, three),
+            BufferParallelAggregation.bufferedOr(newAggregationBuffer(), one, two, three));
   }
 
   @Test
@@ -60,6 +67,8 @@ public class BufferParallelAggregationTest {
     ImmutableRoaringBitmap three = testCase().withArrayAt(3).withRunAt((1 << 15) | 3).build()
             .toMutableRoaringBitmap();
     Assert.assertEquals(BufferFastAggregation.or(one, two, three), BufferParallelAggregation.or(one, two, three));
+    Assert.assertEquals(BufferParallelAggregation.or(one, two, three),
+            BufferParallelAggregation.bufferedOr(newAggregationBuffer(), one, two, three));
   }
 
   @Test
@@ -68,6 +77,8 @@ public class BufferParallelAggregationTest {
             .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build().toMutableRoaringBitmap())
             .toArray(ImmutableRoaringBitmap[]::new);
     Assert.assertEquals(BufferFastAggregation.or(input), BufferParallelAggregation.or(input));
+    Assert.assertEquals(BufferParallelAggregation.or(input),
+            BufferParallelAggregation.bufferedOr(newAggregationBuffer(), input));
   }
 
   @Test
@@ -76,6 +87,8 @@ public class BufferParallelAggregationTest {
             .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build().toMutableRoaringBitmap())
             .toArray(ImmutableRoaringBitmap[]::new);
     Assert.assertEquals(BufferFastAggregation.or(input), BufferParallelAggregation.or(input));
+    Assert.assertEquals(BufferParallelAggregation.or(input),
+            BufferParallelAggregation.bufferedOr(newAggregationBuffer(), input));
   }
 
 
@@ -85,6 +98,8 @@ public class BufferParallelAggregationTest {
             .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build().toMutableRoaringBitmap())
             .toArray(ImmutableRoaringBitmap[]::new);
     Assert.assertEquals(BufferFastAggregation.or(input), BufferParallelAggregation.or(input));
+    Assert.assertEquals(BufferParallelAggregation.or(input),
+            BufferParallelAggregation.bufferedOr(newAggregationBuffer(), input));
   }
 
   @Test
@@ -93,6 +108,8 @@ public class BufferParallelAggregationTest {
             .mapToObj(i -> testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build().toMutableRoaringBitmap())
             .toArray(ImmutableRoaringBitmap[]::new);
     Assert.assertEquals(BufferFastAggregation.or(input), BufferParallelAggregation.or(input));
+    Assert.assertEquals(BufferParallelAggregation.or(input),
+            BufferParallelAggregation.bufferedOr(newAggregationBuffer(), input));
   }
 
   @Test
@@ -102,6 +119,9 @@ public class BufferParallelAggregationTest {
             .toArray(ImmutableRoaringBitmap[]::new);
     Assert.assertEquals(BufferFastAggregation.or(input),
             NO_PARALLELISM_AVAILABLE.submit(() -> BufferParallelAggregation.or(input)).join());
+    Assert.assertEquals(BufferParallelAggregation.or(input),
+            NO_PARALLELISM_AVAILABLE.submit(() ->
+                    BufferParallelAggregation.bufferedOr(newAggregationBuffer(), input)).join());
   }
 
 
@@ -112,6 +132,9 @@ public class BufferParallelAggregationTest {
             .toArray(ImmutableRoaringBitmap[]::new);
     Assert.assertEquals(BufferFastAggregation.or(input),
             NO_PARALLELISM_AVAILABLE.submit(() -> BufferParallelAggregation.or(input)).join());
+    Assert.assertEquals(BufferParallelAggregation.or(input),
+            NO_PARALLELISM_AVAILABLE.submit(() ->
+                    BufferParallelAggregation.bufferedOr(newAggregationBuffer(), input)).join());
   }
 
   @Test
@@ -121,6 +144,9 @@ public class BufferParallelAggregationTest {
             .toArray(ImmutableRoaringBitmap[]::new);
     Assert.assertEquals(BufferFastAggregation.or(input),
             NO_PARALLELISM_AVAILABLE.submit(() -> BufferParallelAggregation.or(input)).join());
+    Assert.assertEquals(BufferParallelAggregation.or(input),
+            NO_PARALLELISM_AVAILABLE.submit(() ->
+                    BufferParallelAggregation.bufferedOr(newAggregationBuffer(), input)).join());
   }
 
 
@@ -131,6 +157,8 @@ public class BufferParallelAggregationTest {
             .toArray(ImmutableRoaringBitmap[]::new);
     Assert.assertEquals(BufferFastAggregation.or(input),
             POOL.submit(() -> BufferParallelAggregation.or(input)).join());
+    Assert.assertEquals(BufferParallelAggregation.or(input),
+            POOL.submit(() -> BufferParallelAggregation.bufferedOr(newAggregationBuffer(), input)).join());
   }
 
 
@@ -141,6 +169,8 @@ public class BufferParallelAggregationTest {
             .toArray(ImmutableRoaringBitmap[]::new);
     Assert.assertEquals(BufferFastAggregation.or(input),
             POOL.submit(() -> BufferParallelAggregation.or(input)).join());
+    Assert.assertEquals(BufferParallelAggregation.or(input),
+            POOL.submit(() -> BufferParallelAggregation.bufferedOr(newAggregationBuffer(), input)).join());
   }
 
   @Test
@@ -150,6 +180,8 @@ public class BufferParallelAggregationTest {
             .toArray(ImmutableRoaringBitmap[]::new);
     Assert.assertEquals(BufferFastAggregation.or(input),
             POOL.submit(() -> BufferParallelAggregation.or(input)).join());
+    Assert.assertEquals(BufferParallelAggregation.or(input),
+            POOL.submit(() -> BufferParallelAggregation.bufferedOr(newAggregationBuffer(), input)).join());
   }
 
   @Test


### PR DESCRIPTION
This is an experimental implementation of parallel aggregation with a constant memory buffer. The code has similar performance to the current implementation, but in some cases performs much better, the difference is less pronounced in the buffer package implementation. 


Benchmark | (dataset) | Mode | Cnt | Score | Error | Units |  
-- | -- | -- | -- | -- | -- | -- | --
ParallelAggregatorBenchmark.parallelBufferedOr | census-income | avgt | 5 | 305.27 | 7.106 | us/op | 1.017241
ParallelAggregatorBenchmark.parallelBufferedOr | census1881 | avgt | 5 | 464.232 | 17.798 | us/op | 0.987154
ParallelAggregatorBenchmark.parallelBufferedOr | dimension_008 | avgt | 5 | 717.221 | 17.791 | us/op | 0.977833
ParallelAggregatorBenchmark.parallelBufferedOr | dimension_003 | avgt | 5 | 1611.861 | 9.383 | us/op | 0.992073
ParallelAggregatorBenchmark.parallelBufferedOr | dimension_033 | avgt | 5 | 528.302 | 5.711 | us/op | 0.984081
ParallelAggregatorBenchmark.parallelBufferedOr | uscensus2000 | avgt | 5 | 97.302 | 1.456 | us/op | 0.553497
ParallelAggregatorBenchmark.parallelBufferedOr | weather_sept_85 | avgt | 5 | 1001.35 | 67.04 | us/op | 0.997945
ParallelAggregatorBenchmark.parallelBufferedOr | wikileaks-noquotes | avgt | 5 | 179.843 | 2.384 | us/op | 0.965756
ParallelAggregatorBenchmark.parallelBufferedOr | census-income_srt | avgt | 5 | 310.232 | 72.91 | us/op | 0.987707
ParallelAggregatorBenchmark.parallelBufferedOr | census1881_srt | avgt | 5 | 306.642 | 4.839 | us/op | 0.998206
ParallelAggregatorBenchmark.parallelBufferedOr | weather_sept_85_srt | avgt | 5 | 538.886 | 55.667 | us/op | 1.004146
ParallelAggregatorBenchmark.parallelBufferedOr | wikileaks-noquotes_srt | avgt | 5 | 118.015 | 0.982 | us/op | 0.970119
ParallelAggregatorBenchmark.parallelOr | census-income | avgt | 5 | 300.096 | 257.808 | us/op | 1
ParallelAggregatorBenchmark.parallelOr | census1881 | avgt | 5 | 470.273 | 3.376 | us/op | 1
ParallelAggregatorBenchmark.parallelOr | dimension_008 | avgt | 5 | 733.48 | 21.324 | us/op | 1
ParallelAggregatorBenchmark.parallelOr | dimension_003 | avgt | 5 | 1624.74 | 14.239 | us/op | 1
ParallelAggregatorBenchmark.parallelOr | dimension_033 | avgt | 5 | 536.848 | 3.645 | us/op | 1
ParallelAggregatorBenchmark.parallelOr | uscensus2000 | avgt | 5 | 175.795 | 1.41 | us/op | 1
ParallelAggregatorBenchmark.parallelOr | weather_sept_85 | avgt | 5 | 1003.412 | 70.478 | us/op | 1
ParallelAggregatorBenchmark.parallelOr | wikileaks-noquotes | avgt | 5 | 186.22 | 1.985 | us/op | 1
ParallelAggregatorBenchmark.parallelOr | census-income_srt | avgt | 5 | 314.093 | 5.981 | us/op | 1
ParallelAggregatorBenchmark.parallelOr | census1881_srt | avgt | 5 | 307.193 | 4.472 | us/op | 1
ParallelAggregatorBenchmark.parallelOr | weather_sept_85_srt | avgt | 5 | 536.661 | 46.558 | us/op | 1
ParallelAggregatorBenchmark.parallelOr | wikileaks-noquotes_srt | avgt | 5 | 121.65 | 1.921 | us/op | 1
ParallelAggregatorBenchmark.bufferParallelBufferedOr | census-income | avgt | 5 | 336.3 | 20.475 | us/op | 0.941442
ParallelAggregatorBenchmark.bufferParallelBufferedOr | census1881 | avgt | 5 | 488.599 | 7.585 | us/op | 0.981316
ParallelAggregatorBenchmark.bufferParallelBufferedOr | dimension_008 | avgt | 5 | 738.116 | 15.88 | us/op | 0.966632
ParallelAggregatorBenchmark.bufferParallelBufferedOr | dimension_003 | avgt | 5 | 1664.072 | 11.387 | us/op | 1.063949
ParallelAggregatorBenchmark.bufferParallelBufferedOr | dimension_033 | avgt | 5 | 533.78 | 6.297 | us/op | 0.986877
ParallelAggregatorBenchmark.bufferParallelBufferedOr | uscensus2000 | avgt | 5 | 118.546 | 0.846 | us/op | 0.65034
ParallelAggregatorBenchmark.bufferParallelBufferedOr | weather_sept_85 | avgt | 5 | 1008.247 | 87.389 | us/op | 0.995281
ParallelAggregatorBenchmark.bufferParallelBufferedOr | wikileaks-noquotes | avgt | 5 | 186.406 | 2.053 | us/op | 0.990573
ParallelAggregatorBenchmark.bufferParallelBufferedOr | census-income_srt | avgt | 5 | 352.738 | 19.614 | us/op | 1.098985
ParallelAggregatorBenchmark.bufferParallelBufferedOr | census1881_srt | avgt | 5 | 314.406 | 16.776 | us/op | 0.99172
ParallelAggregatorBenchmark.bufferParallelBufferedOr | weather_sept_85_srt | avgt | 5 | 538.724 | 41.775 | us/op | 0.993936
ParallelAggregatorBenchmark.bufferParallelBufferedOr | wikileaks-noquotes_srt | avgt | 5 | 118.025 | 1.213 | us/op | 0.945524
ParallelAggregatorBenchmark.bufferParallelOr | census-income | avgt | 5 | 357.218 | 193.198 | us/op | 1
ParallelAggregatorBenchmark.bufferParallelOr | census1881 | avgt | 5 | 497.902 | 7.878 | us/op | 1
ParallelAggregatorBenchmark.bufferParallelOr | dimension_008 | avgt | 5 | 763.596 | 6.604 | us/op | 1
ParallelAggregatorBenchmark.bufferParallelOr | dimension_003 | avgt | 5 | 1564.053 | 13.016 | us/op | 1
ParallelAggregatorBenchmark.bufferParallelOr | dimension_033 | avgt | 5 | 540.878 | 2.969 | us/op | 1
ParallelAggregatorBenchmark.bufferParallelOr | uscensus2000 | avgt | 5 | 182.283 | 3.309 | us/op | 1
ParallelAggregatorBenchmark.bufferParallelOr | weather_sept_85 | avgt | 5 | 1013.027 | 144.756 | us/op | 1
ParallelAggregatorBenchmark.bufferParallelOr | wikileaks-noquotes | avgt | 5 | 188.18 | 1.447 | us/op | 1
ParallelAggregatorBenchmark.bufferParallelOr | census-income_srt | avgt | 5 | 320.967 | 20.836 | us/op | 1
ParallelAggregatorBenchmark.bufferParallelOr | census1881_srt | avgt | 5 | 317.031 | 12.238 | us/op | 1
ParallelAggregatorBenchmark.bufferParallelOr | weather_sept_85_srt | avgt | 5 | 542.011 | 46.822 | us/op | 1
ParallelAggregatorBenchmark.bufferParallelOr | wikileaks-noquotes_srt | avgt | 5 | 124.825 | 1.068 | us/op | 1





I am making the pull request because I would like to see how the new method `bufferedOr` does on some of the private benchmarks that have been mentioned.