### PR TITLE
Evaluate batch iteration

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayBatchIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayBatchIterator.java
@@ -1,0 +1,29 @@
+package org.roaringbitmap;
+
+import static org.roaringbitmap.Util.toIntUnsigned;
+
+public class ArrayBatchIterator implements ContainerBatchIterator {
+
+  private int index = 0;
+  private final ArrayContainer array;
+
+  public ArrayBatchIterator(ArrayContainer array) {
+    this.array = array;
+  }
+
+  @Override
+  public int next(int key, int[] buffer) {
+    int consumed = 0;
+    short[] data = array.content;
+    while (consumed < buffer.length && index < array.getCardinality()) {
+      buffer[consumed++] = key | toIntUnsigned(data[index++]);
+    }
+    assert consumed <= buffer.length;
+    return consumed;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return index < array.getCardinality();
+  }
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -430,6 +430,11 @@ public final class ArrayContainer extends Container implements Cloneable {
     return new ArrayContainerShortIterator(this);
   }
 
+  @Override
+  public ContainerBatchIterator getBatchIterator() {
+    return new ArrayBatchIterator(this);
+  }
+
 
   @Override
   public int getSizeInBytes() {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/BatchIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BatchIterator.java
@@ -1,0 +1,19 @@
+package org.roaringbitmap;
+
+public interface BatchIterator {
+
+  /**
+   * Writes the next batch of integers onto the buffer,
+   * and returns how many were written. Aims to fill
+   * the buffer.
+   * @param buffer - the target to write onto
+   * @return how many values were written during the call.
+   */
+  int nextBatch(int[] buffer);
+
+  /**
+   * Returns true is there are more values to get.
+   * @return whether the iterator is exhaused or not.
+   */
+  boolean hasNext();
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/BitmapBatchIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BitmapBatchIterator.java
@@ -1,0 +1,37 @@
+package org.roaringbitmap;
+
+import static java.lang.Long.numberOfTrailingZeros;
+
+public class BitmapBatchIterator implements ContainerBatchIterator {
+
+  private int wordIndex = 0;
+  private long word;
+  private final BitmapContainer bitmap;
+
+  public BitmapBatchIterator(BitmapContainer bitmap) {
+    this.bitmap = bitmap;
+    word = bitmap.bitmap[0];
+  }
+
+  @Override
+  public int next(int key, int[] buffer) {
+    int consumed = 0;
+    while (consumed < buffer.length) {
+      while (word == 0) {
+        ++wordIndex;
+        if (wordIndex == 1024) {
+          return consumed;
+        }
+        word = bitmap.bitmap[wordIndex];
+      }
+      buffer[consumed++] = key + (64 * wordIndex) + numberOfTrailingZeros(word);
+      word &= (word - 1);
+    }
+    return consumed;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return wordIndex < 1024;
+  }
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -508,6 +508,11 @@ public final class BitmapContainer extends Container implements Cloneable {
   }
 
   @Override
+  public ContainerBatchIterator getBatchIterator() {
+    return new BitmapBatchIterator(this);
+  }
+
+  @Override
   public int getSizeInBytes() {
     return this.bitmap.length * 8;
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
@@ -322,6 +322,12 @@ public abstract class Container implements Iterable<Short>, Cloneable, Externali
   public abstract PeekableShortIterator getShortIterator();
 
   /**
+   * Gets an iterator to visit the contents of the container in batches
+   * @return iterator
+   */
+  public abstract ContainerBatchIterator getBatchIterator();
+
+  /**
    * Computes an estimate of the memory usage of this container. The estimate is not meant to be
    * exact.
    *

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ContainerBatchIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ContainerBatchIterator.java
@@ -1,0 +1,20 @@
+package org.roaringbitmap;
+
+public interface ContainerBatchIterator {
+
+  /**
+   * Fills the buffer with values prefixed by the key,
+   * and returns how much of the buffer was used.
+   * @param key the prefix of the values
+   * @param buffer the buffer to write values onto
+   * @return how many values were written.
+   */
+  int next(int key, int[] buffer);
+
+  /**
+   * Whether the underlying container is exhausted or not
+   * @return true if there is data remaining
+   */
+  boolean hasNext();
+
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ImmutableBitmapDataProvider.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ImmutableBitmapDataProvider.java
@@ -7,6 +7,7 @@ package org.roaringbitmap;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.NoSuchElementException;
+import java.util.stream.IntStream;
 
 /**
  * Interface representing an immutable bitmap.
@@ -20,7 +21,7 @@ public interface ImmutableBitmapDataProvider {
    * @param x integer value
    * @return whether the integer value is included.
    */
-  public boolean contains(int x);
+  boolean contains(int x);
 
   /**
    * Returns the number of distinct integers added to the bitmap (e.g., number of bits set).
@@ -28,7 +29,7 @@ public interface ImmutableBitmapDataProvider {
    *
    * @return the cardinality
    */
-  public int getCardinality();
+  int getCardinality();
   
   /**
    * Returns the number of distinct integers added to the bitmap (e.g., number of bits set).
@@ -36,7 +37,7 @@ public interface ImmutableBitmapDataProvider {
    *
    * @return the cardinality
    */
-  public long getLongCardinality();
+  long getLongCardinality();
 
   /**
    * Visit all values in the bitmap and pass them to the consumer.
@@ -56,18 +57,24 @@ public interface ImmutableBitmapDataProvider {
    * </pre>
    * @param ic the consumer
    */
-  public void forEach(IntConsumer ic);
+  void forEach(IntConsumer ic);
 
   /**
    * For better performance, consider the Use the {@link #forEach forEach} method.
    * @return a custom iterator over set bits, the bits are traversed in ascending sorted order
    */
-  public PeekableIntIterator getIntIterator();
+  PeekableIntIterator getIntIterator();
 
   /**
    * @return a custom iterator over set bits, the bits are traversed in descending sorted order
    */
-  public IntIterator getReverseIntIterator();
+  IntIterator getReverseIntIterator();
+
+  /**
+   * This iterator may be faster than others
+   * @return iterator which works on batches of data.
+   */
+  BatchIterator getBatchIterator();
 
   /**
    * Estimate of the memory usage of this data structure.
@@ -76,7 +83,7 @@ public interface ImmutableBitmapDataProvider {
    *
    * @return estimated memory usage.
    */
-  public int getSizeInBytes();
+  int getSizeInBytes();
   
   /**
    * Estimate of the memory usage of this data structure. Provides
@@ -84,14 +91,14 @@ public interface ImmutableBitmapDataProvider {
    *
    * @return estimated memory usage.
    */
-  public long getLongSizeInBytes();
+  long getLongSizeInBytes();
 
   /**
    * Checks whether the bitmap is empty.
    *
    * @return true if this bitmap contains no set bit
    */
-  public boolean isEmpty();
+  boolean isEmpty();
 
   /**
    * Create a new bitmap of the same class, containing at most maxcardinality integers.
@@ -99,7 +106,7 @@ public interface ImmutableBitmapDataProvider {
    * @param x maximal cardinality
    * @return a new bitmap with cardinality no more than maxcardinality
    */
-  public ImmutableBitmapDataProvider limit(int x);
+  ImmutableBitmapDataProvider limit(int x);
 
   /**
    * Rank returns the number of integers that are smaller or equal to x (rank(infinity) would be
@@ -112,7 +119,7 @@ public interface ImmutableBitmapDataProvider {
    * @return the rank
    * @see <a href="https://en.wikipedia.org/wiki/Ranking#Ranking_in_statistics">Ranking in statistics</a> 
    */
-  public int rank(int x);
+  int rank(int x);
   
   /**
    * Rank returns the number of integers that are smaller or equal to x (rankLong(infinity) would be
@@ -124,7 +131,7 @@ public interface ImmutableBitmapDataProvider {
    * @return the rank
    * @see <a href="https://en.wikipedia.org/wiki/Ranking#Ranking_in_statistics">Ranking in statistics</a> 
    */
-  public long rankLong(int x);
+  long rankLong(int x);
 
   /**
    * Return the jth value stored in this bitmap. The provided value 
@@ -137,7 +144,7 @@ public interface ImmutableBitmapDataProvider {
    * @return the value
    * @see <a href="https://en.wikipedia.org/wiki/Selection_algorithm">Selection algorithm</a> 
    */
-  public int select(int j);
+  int select(int j);
 
   /**
    * Get the first (smallest) integer in this RoaringBitmap,
@@ -145,7 +152,7 @@ public interface ImmutableBitmapDataProvider {
    * @return the first (smallest) integer
    * @throws NoSuchElementException if empty
    */
-  public int first();
+  int first();
 
   /**
    * Get the last (largest) integer in this RoaringBitmap,
@@ -153,7 +160,7 @@ public interface ImmutableBitmapDataProvider {
    * @return the last (largest) integer
    * @throws NoSuchElementException if empty
    */
-  public int last();
+  int last();
 
   /**
    * Serialize this bitmap.
@@ -163,7 +170,7 @@ public interface ImmutableBitmapDataProvider {
    * @param out the DataOutput stream
    * @throws IOException Signals that an I/O exception has occurred.
    */
-  public void serialize(DataOutput out) throws IOException;
+  void serialize(DataOutput out) throws IOException;
 
   /**
    * Report the number of bytes required to serialize this bitmap. This is the number of bytes
@@ -172,13 +179,13 @@ public interface ImmutableBitmapDataProvider {
    *
    * @return the size in bytes
    */
-  public int serializedSizeInBytes();
+  int serializedSizeInBytes();
 
   /**
    * Return the set values as an array. The integer values are in sorted order.
    *
    * @return array representing the set values.
    */
-  public int[] toArray();
+  int[] toArray();
 
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBatchIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBatchIterator.java
@@ -1,0 +1,44 @@
+package org.roaringbitmap;
+
+public class RoaringBatchIterator implements BatchIterator {
+
+  private final RoaringArray highLowContainer;
+  int index = 0;
+  int key;
+  ContainerBatchIterator iterator;
+
+  public RoaringBatchIterator(RoaringArray highLowContainer) {
+    this.highLowContainer = highLowContainer;
+    nextIterator();
+  }
+
+  @Override
+  public int nextBatch(int[] buffer) {
+    int consumed = 0;
+    if (iterator.hasNext()) {
+      consumed += iterator.next(key, buffer);
+    } else {
+      ++index;
+      nextIterator();
+      if (null != iterator) {
+        return nextBatch(buffer);
+      }
+    }
+    assert consumed <= buffer.length;
+    return consumed;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return null != iterator;
+  }
+
+  private void nextIterator() {
+    if (index < highLowContainer.size()) {
+      iterator = highLowContainer.getContainerAtIndex(index).getBatchIterator();
+      key = highLowContainer.getKeyAtIndex(index) << 16;
+    } else {
+      iterator = null;
+    }
+  }
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -13,6 +13,7 @@ import java.io.ObjectOutput;
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.stream.IntStream;
 
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MappeableContainerPointer;
@@ -1560,6 +1561,12 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
   @Override
   public IntIterator getReverseIntIterator() {
     return new RoaringReverseIntIterator();
+  }
+
+
+  @Override
+  public RoaringBatchIterator getBatchIterator() {
+    return new RoaringBatchIterator(highLowContainer);
   }
 
   /**

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RunBatchIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RunBatchIterator.java
@@ -1,0 +1,43 @@
+package org.roaringbitmap;
+
+import static org.roaringbitmap.Util.toIntUnsigned;
+
+public class RunBatchIterator implements ContainerBatchIterator {
+
+  private final RunContainer runs;
+  private int run = 0;
+  private int cursor = 0;
+
+  public RunBatchIterator(RunContainer runs) {
+    this.runs = runs;
+  }
+
+  @Override
+  public int next(int key, int[] buffer) {
+    int consumed = 0;
+    do {
+      int runStart = toIntUnsigned(runs.getValue(run));
+      int runLength = toIntUnsigned(runs.getLength(run));
+      int chunkStart = runStart + cursor;
+      int chunkEnd = chunkStart + Math.min(runLength - cursor, buffer.length - consumed - 1);
+      int chunk = chunkEnd - chunkStart + 1;
+      for (int i = 0; i < chunk; ++i) {
+        assert runs.contains((short)(chunkStart + i));
+        buffer[consumed + i] = key + chunkStart + i;
+      }
+      consumed += chunk;
+      if (runStart + runLength == chunkEnd) {
+        ++run;
+        cursor = 0;
+      } else {
+        cursor += chunk;
+      }
+    } while (consumed < buffer.length && run != runs.numberOfRuns());
+    return consumed;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return run < runs.numberOfRuns();
+  }
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -1058,6 +1058,11 @@ public final class RunContainer extends Container implements Cloneable {
   }
 
   @Override
+  public ContainerBatchIterator getBatchIterator() {
+    return new RunBatchIterator(this);
+  }
+
+  @Override
   public int getSizeInBytes() {
     return this.nbrruns * 4 + 4;
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.stream.IntStream;
 
 import org.roaringbitmap.*;
 
@@ -1220,6 +1221,11 @@ public class ImmutableRoaringBitmap
   @Override
   public IntIterator getReverseIntIterator() {
     return new ImmutableRoaringReverseIntIterator();
+  }
+
+  @Override
+  public BatchIterator getBatchIterator() {
+    throw new RuntimeException();
   }
 
   /**

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
@@ -4,11 +4,7 @@
 
 package org.roaringbitmap.buffer;
 
-import org.roaringbitmap.BitmapDataProvider;
-import org.roaringbitmap.ContainerPointer;
-import org.roaringbitmap.RoaringBitmap;
-import org.roaringbitmap.ShortIterator;
-import org.roaringbitmap.Util;
+import org.roaringbitmap.*;
 
 import java.io.*;
 import java.util.Iterator;
@@ -1486,5 +1482,10 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
    */
   public static long maximumSerializedSize(int cardinality, int universe_size) {
     return RoaringBitmap.maximumSerializedSize(cardinality, universe_size);
+  }
+
+  @Override
+  public BatchIterator getBatchIterator() {
+    throw new RuntimeException();
   }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/ContainerBatchIteratorTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/ContainerBatchIteratorTest.java
@@ -1,0 +1,159 @@
+package org.roaringbitmap;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
+
+import static java.util.Arrays.copyOfRange;
+
+
+@RunWith(Parameterized.class)
+public class ContainerBatchIteratorTest {
+
+
+    @Parameterized.Parameters
+    public static Object[][] params() {
+        return new Object[][] {
+                {IntStream.range(0, 20000).toArray()},
+                {IntStream.range(0, 1 << 16).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> i < 500 || i > 2000).filter(i -> i < (1 << 15) || i > ((1 << 15) | (1 << 8))).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> ((i >>> 12) & 1) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> ((i >>> 11) & 1) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> ((i >>> 10) & 1) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> ((i >>> 9) & 1) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> ((i >>> 8) & 1) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> ((i >>> 7) & 1) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> ((i >>> 6) & 1) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> ((i >>> 5) & 1) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> ((i >>> 4) & 1) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> ((i >>> 3) & 1) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> ((i >>> 2) & 1) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> ((i >>> 1) & 1) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> (i & 1) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> (i & 1) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> (i % 3) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> (i % 5) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> (i % 7) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> (i % 9) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> (i % 271) == 0).toArray()},
+                {IntStream.range(0, 1 << 16).filter(i -> (i % 1000) == 0).toArray()},
+                {IntStream.empty().toArray()},
+                {RandomisedTestData.sparseRegion().toArray()},
+                {RandomisedTestData.sparseRegion().toArray()},
+                {RandomisedTestData.sparseRegion().toArray()},
+                {RandomisedTestData.sparseRegion().toArray()},
+                {RandomisedTestData.sparseRegion().toArray()},
+                {RandomisedTestData.sparseRegion().toArray()},
+                {RandomisedTestData.sparseRegion().toArray()},
+                {RandomisedTestData.sparseRegion().toArray()},
+                {RandomisedTestData.sparseRegion().toArray()},
+                {RandomisedTestData.sparseRegion().toArray()},
+                {RandomisedTestData.sparseRegion().toArray()},
+                {RandomisedTestData.sparseRegion().toArray()},
+                {RandomisedTestData.sparseRegion().toArray()},
+                {RandomisedTestData.sparseRegion().toArray()},
+                {RandomisedTestData.sparseRegion().toArray()},
+                {RandomisedTestData.denseRegion().toArray()},
+                {RandomisedTestData.denseRegion().toArray()},
+                {RandomisedTestData.denseRegion().toArray()},
+                {RandomisedTestData.denseRegion().toArray()},
+                {RandomisedTestData.denseRegion().toArray()},
+                {RandomisedTestData.denseRegion().toArray()},
+                {RandomisedTestData.denseRegion().toArray()},
+                {RandomisedTestData.denseRegion().toArray()},
+                {RandomisedTestData.denseRegion().toArray()},
+                {RandomisedTestData.denseRegion().toArray()},
+                {RandomisedTestData.denseRegion().toArray()},
+                {RandomisedTestData.denseRegion().toArray()},
+                {RandomisedTestData.denseRegion().toArray()},
+                {RandomisedTestData.denseRegion().toArray()},
+                {RandomisedTestData.denseRegion().toArray()},
+                {RandomisedTestData.rleRegion().toArray()},
+                {RandomisedTestData.rleRegion().toArray()},
+                {RandomisedTestData.rleRegion().toArray()},
+                {RandomisedTestData.rleRegion().toArray()},
+                {RandomisedTestData.rleRegion().toArray()},
+                {RandomisedTestData.rleRegion().toArray()},
+                {RandomisedTestData.rleRegion().toArray()},
+                {RandomisedTestData.rleRegion().toArray()},
+                {RandomisedTestData.rleRegion().toArray()},
+                {RandomisedTestData.rleRegion().toArray()},
+                {RandomisedTestData.rleRegion().toArray()},
+                {RandomisedTestData.rleRegion().toArray()},
+                {RandomisedTestData.rleRegion().toArray()},
+                {RandomisedTestData.rleRegion().toArray()},
+                {RandomisedTestData.rleRegion().toArray()},
+        };
+    }
+
+
+    private final int[] expectedValues;
+
+    public ContainerBatchIteratorTest(int[] expectedValues) {
+        this.expectedValues = expectedValues;
+    }
+
+    @Test
+    public void shouldRecoverValues512() {
+        test(512);
+    }
+
+    @Test
+    public void shouldRecoverValues1024() {
+        test(1024);
+    }
+
+    @Test
+    public void shouldRecoverValues2048() {
+        test(2048);
+    }
+
+    @Test
+    public void shouldRecoverValues4096() {
+        test(4096);
+    }
+
+    @Test
+    public void shouldRecoverValues8192() {
+        test(8192);
+    }
+
+    @Test
+    public void shouldRecoverValues65536() {
+        test(65536);
+    }
+
+
+    @Test
+    public void shouldRecoverValuesRandomBatchSizes() {
+        IntStream.range(0, 100)
+                .forEach(i -> test(ThreadLocalRandom.current().nextInt(1, 65536)));
+    }
+
+
+    private void test(int batchSize) {
+        int[] buffer = new int[batchSize];
+        Container container = createContainer();
+        ContainerBatchIterator it = container.getBatchIterator();
+        int cardinality = 0;
+        while (it.hasNext()) {
+            int from = cardinality;
+            cardinality += it.next(0, buffer);
+            Assert.assertArrayEquals("Failure with batch size " + batchSize,
+                    copyOfRange(expectedValues, from, cardinality), copyOfRange(buffer, 0, cardinality - from));
+        }
+        Assert.assertEquals(expectedValues.length, cardinality);
+    }
+
+    private Container createContainer() {
+        Container container = new ArrayContainer();
+        for (int value : expectedValues) {
+            container = container.add((short) value);
+        }
+        return container.runOptimize();
+    }
+}

--- a/roaringbitmap/src/test/java/org/roaringbitmap/Fuzzer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/Fuzzer.java
@@ -3,9 +3,7 @@ package org.roaringbitmap;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Iterator;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
@@ -86,8 +84,8 @@ public class Fuzzer {
                                           Function<RoaringBitmap, T> left,
                                           Function<RoaringBitmap, T> right) {
     IntStream.range(0, count)
-            .parallel()
-            .mapToObj(i -> randomBitmap(maxKeys))
+           // .parallel()
+            .mapToObj(i -> randomBitmap(maxKeys, 1, 0))
             .filter(validity)
             .forEach(bitmap -> Assert.assertEquals(left.apply(bitmap), right.apply(bitmap)));
   }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/RandomisedTestData.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/RandomisedTestData.java
@@ -10,10 +10,8 @@ public class RandomisedTestData {
 
   private static final ThreadLocal<long[]> bits = ThreadLocal.withInitial(() -> new long[1 << 10]);
 
-  public static RoaringBitmap randomBitmap(int maxKeys) {
+  public static RoaringBitmap randomBitmap(int maxKeys, double rleLimit, double denseLimit) {
     int[] keys = createSorted16BitInts(ThreadLocalRandom.current().nextInt(1, maxKeys));
-    double rleLimit = ThreadLocalRandom.current().nextDouble();
-    double denseLimit = ThreadLocalRandom.current().nextDouble(rleLimit, 1D);
     OrderedWriter writer = new OrderedWriter();
     IntStream.of(keys)
             .forEach(key -> {
@@ -30,6 +28,12 @@ public class RandomisedTestData {
             });
     writer.flush();
     return writer.getUnderlying();
+  }
+
+  public static RoaringBitmap randomBitmap(int maxKeys) {
+    double rleLimit = ThreadLocalRandom.current().nextDouble();
+    double denseLimit = ThreadLocalRandom.current().nextDouble(rleLimit, 1D);
+    return randomBitmap(maxKeys, rleLimit, denseLimit);
   }
 
   public static IntStream rleRegion() {

--- a/roaringbitmap/src/test/java/org/roaringbitmap/RoaringBitmapBatchIteratorTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/RoaringBitmapBatchIteratorTest.java
@@ -1,0 +1,85 @@
+package org.roaringbitmap;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
+
+import static org.roaringbitmap.RandomisedTestData.TestDataSet.testCase;
+
+@RunWith(Parameterized.class)
+public class RoaringBitmapBatchIteratorTest {
+
+    @Parameterized.Parameters
+    public static Object[][] params() {
+        return new Object[][] {
+                {testCase().withArrayAt(0).withArrayAt(2).withArrayAt(4).withArrayAt((1 << 15) | (1 << 14)).build()},
+                {testCase().withRunAt(0).withRunAt(2).withRunAt(4).withRunAt((1 << 15) | (1 << 14)).build()},
+                {testCase().withBitmapAt(0).withRunAt(2).withBitmapAt(4).withBitmapAt((1 << 15) | (1 << 14)).build()},
+                {testCase().withArrayAt(0).withBitmapAt(2).withRunAt(4).withBitmapAt((1 << 15) | (1 << 14)).build()},
+                {testCase().withRunAt(0).withArrayAt(2).withBitmapAt(4).withRunAt((1 << 15) | (1 << 14)).build()},
+                {testCase().withBitmapAt(0).withRunAt(2).withArrayAt(4).withBitmapAt((1 << 15) | (1 << 14)).build()},
+                {testCase().withArrayAt(0).withBitmapAt(2).withRunAt(4).withArrayAt((1 << 15) | (1 << 14)).build()},
+                {testCase().withBitmapAt(0).withArrayAt(2).withBitmapAt(4).withRunAt((1 << 15) | (1 << 14)).build()},
+                {testCase().withRunAt((1 << 15) | (1 << 11)).withBitmapAt((1 << 15) | (1 << 12)).withArrayAt((1 << 15) | (1 << 13)).withBitmapAt((1 << 15) | (1 << 14)).build()},
+                {RoaringBitmap.bitmapOf(IntStream.range(1 << 10, 1 << 26).filter(i -> (i & 1) == 0).toArray())},
+                {RoaringBitmap.bitmapOf(IntStream.range(1 << 10, 1 << 25).filter(i -> ((i >>> 8) & 1) == 0).toArray())},
+                {new RoaringBitmap()}
+        };
+    }
+
+    private final RoaringBitmap bitmap;
+
+    public RoaringBitmapBatchIteratorTest(RoaringBitmap bitmap) {
+        this.bitmap = bitmap;
+    }
+
+    @Test
+    public void testBatchIterator256() {
+        test(256);
+    }
+
+
+    @Test
+    public void testBatchIterator1024() {
+        test(1024);
+    }
+
+
+    @Test
+    public void testBatchIterator65536() {
+        test(65536);
+    }
+
+
+    @Test
+    public void testBatchIterator8192() {
+        test(8192);
+    }
+
+    @Test
+    public void testBatchIteratorRandom() {
+        IntStream.range(0, 10).map(i -> ThreadLocalRandom.current().nextInt(0, 1 << 16))
+                .forEach(this::test);
+    }
+
+    private void test(int batchSize) {
+        int[] buffer = new int[batchSize];
+        RoaringBitmap result = new RoaringBitmap();
+        RoaringBatchIterator it = bitmap.getBatchIterator();
+        int cardinality = 0;
+        while (it.hasNext()) {
+            int batch = it.nextBatch(buffer);
+            for (int i = 0; i < batch; ++i) {
+                result.add(buffer[i]);
+            }
+            cardinality += batch;
+        }
+        Assert.assertEquals(bitmap, result);
+        Assert.assertEquals(bitmap.getCardinality(), cardinality);
+    }
+
+}


### PR DESCRIPTION
I have implemented a similar pattern to the go library for batch iteration. I will probably port this to the buffer package later this week. I would be interested in seeing benchmark results for this implementation.