### PR TITLE
Groundwork to demonstrate FlyWeight transient memory consumption

### DIFF
--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestIteratorMemory.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestIteratorMemory.java
@@ -15,151 +15,147 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestIteratorMemory {
-	final IntIteratorFlyweight flyweightIterator = new IntIteratorFlyweight();
+  final IntIteratorFlyweight flyweightIterator = new IntIteratorFlyweight();
 
-	final ReverseIntIteratorFlyweight flyweightReverseIterator = new ReverseIntIteratorFlyweight();
+  final ReverseIntIteratorFlyweight flyweightReverseIterator = new ReverseIntIteratorFlyweight();
 
-	// See org.roaringbitmap.iteration.IteratorsBenchmark32.BenchmarkState
-	final RoaringBitmap bitmap_a;
-	final RoaringBitmap bitmap_b;
-	final RoaringBitmap bitmap_c;
-	{
+  // See org.roaringbitmap.iteration.IteratorsBenchmark32.BenchmarkState
+  final RoaringBitmap bitmap_a;
+  final RoaringBitmap bitmap_b;
+  final RoaringBitmap bitmap_c;
+  {
 
-		final int[] data = takeSortedAndDistinct(new Random(0xcb000a2b9b5bdfb6l), 100000);
-		bitmap_a = RoaringBitmap.bitmapOf(data);
+    final int[] data = takeSortedAndDistinct(new Random(0xcb000a2b9b5bdfb6l), 100000);
+    bitmap_a = RoaringBitmap.bitmapOf(data);
 
-		bitmap_b = new RoaringBitmap();
-		for (int k = 0; k < (1 << 30); k += 32)
-			bitmap_b.add(k);
+    bitmap_b = new RoaringBitmap();
+    for (int k = 0; k < (1 << 30); k += 32)
+      bitmap_b.add(k);
 
-		bitmap_c = new RoaringBitmap();
-		for (int k = 0; k < (1 << 30); k += 3)
-			bitmap_c.add(k);
+    bitmap_c = new RoaringBitmap();
+    for (int k = 0; k < (1 << 30); k += 3)
+      bitmap_c.add(k);
 
-	}
+  }
 
-	private int[] takeSortedAndDistinct(Random source, int count) {
+  private int[] takeSortedAndDistinct(Random source, int count) {
 
-		LinkedHashSet<Integer> ints = new LinkedHashSet<Integer>(count);
+    LinkedHashSet<Integer> ints = new LinkedHashSet<Integer>(count);
 
-		for (int size = 0; size < count; size++) {
-			int next;
-			do {
-				next = Math.abs(source.nextInt());
-			} while (!ints.add(next));
-		}
+    for (int size = 0; size < count; size++) {
+      int next;
+      do {
+        next = Math.abs(source.nextInt());
+      } while (!ints.add(next));
+    }
 
-		int[] unboxed = toArray(ints);
-		Arrays.sort(unboxed);
-		return unboxed;
-	}
+    int[] unboxed = toArray(ints);
+    Arrays.sort(unboxed);
+    return unboxed;
+  }
 
-	private int[] toArray(LinkedHashSet<Integer> integers) {
-		int[] ints = new int[integers.size()];
-		int i = 0;
-		for (Integer n : integers) {
-			ints[i++] = n;
-		}
-		return ints;
-	}
+  private int[] toArray(LinkedHashSet<Integer> integers) {
+    int[] ints = new int[integers.size()];
+    int i = 0;
+    for (Integer n : integers) {
+      ints[i++] = n;
+    }
+    return ints;
+  }
 
-	protected static final ThreadMXBean THREAD_MBEAN = ManagementFactory.getThreadMXBean();
+  protected static final ThreadMXBean THREAD_MBEAN = ManagementFactory.getThreadMXBean();
 
-	public static boolean isThreadAllocatedMemorySupported(ThreadMXBean threadMbean) {
-		if (threadMbean != null && Stream.of(threadMbean.getClass().getInterfaces())
-				.filter(c -> c.getName().equals("com.sun.management.ThreadMXBean"))
-				.findAny()
-				.isPresent()) {
-			try {
-				return (Boolean) Class.forName("com.sun.management.ThreadMXBean")
-						.getMethod("isThreadAllocatedMemorySupported")
-						.invoke(threadMbean);
-			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException
-					| NoSuchMethodException | SecurityException | ClassNotFoundException e) {
-				return false;
-			}
-		} else {
-			return false;
-		}
-	}
+  public static boolean isThreadAllocatedMemorySupported(ThreadMXBean threadMbean) {
+    if (threadMbean != null && Stream.of(threadMbean.getClass().getInterfaces())
+        .filter(c -> c.getName().equals("com.sun.management.ThreadMXBean")).findAny().isPresent()) {
+      try {
+        return (Boolean) Class.forName("com.sun.management.ThreadMXBean")
+            .getMethod("isThreadAllocatedMemorySupported").invoke(threadMbean);
+      } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException
+          | NoSuchMethodException | SecurityException | ClassNotFoundException e) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
 
-	public static long getThreadAllocatedBytes(ThreadMXBean threadMbean, long l) {
-		if (isThreadAllocatedMemorySupported(threadMbean)) {
-			try {
-				return (Long) Class.forName("com.sun.management.ThreadMXBean")
-						.getMethod("getThreadAllocatedBytes", long.class)
-						.invoke(threadMbean, l);
-			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException
-					| NoSuchMethodException | SecurityException | ClassNotFoundException e) {
-				return -1L;
-			}
-		} else {
-			return -1L;
-		}
-	}
+  public static long getThreadAllocatedBytes(ThreadMXBean threadMbean, long l) {
+    if (isThreadAllocatedMemorySupported(threadMbean)) {
+      try {
+        return (Long) Class.forName("com.sun.management.ThreadMXBean")
+            .getMethod("getThreadAllocatedBytes", long.class).invoke(threadMbean, l);
+      } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException
+          | NoSuchMethodException | SecurityException | ClassNotFoundException e) {
+        return -1L;
+      }
+    } else {
+      return -1L;
+    }
+  }
 
-	@BeforeClass
-	public static void checkMemoryTrackingIsOK() {
-		Assume.assumeTrue(isThreadAllocatedMemorySupported(THREAD_MBEAN));
-	}
+  @BeforeClass
+  public static void checkMemoryTrackingIsOK() {
+    Assume.assumeTrue(isThreadAllocatedMemorySupported(THREAD_MBEAN));
+  }
 
-	@Test
-	public void measureBoxedIterationAllocation() {
-		if (isThreadAllocatedMemorySupported(THREAD_MBEAN)) {
-			long before = getThreadAllocatedBytes(THREAD_MBEAN, Thread.currentThread().getId());
+  @Test
+  public void measureBoxedIterationAllocation() {
+    if (isThreadAllocatedMemorySupported(THREAD_MBEAN)) {
+      long before = getThreadAllocatedBytes(THREAD_MBEAN, Thread.currentThread().getId());
 
-			Iterator<Integer> intIterator = bitmap_a.iterator();
-			long result = 0;
-			while (intIterator.hasNext()) {
-				result += intIterator.next();
+      Iterator<Integer> intIterator = bitmap_a.iterator();
+      long result = 0;
+      while (intIterator.hasNext()) {
+        result += intIterator.next();
 
-			}
-			// A small check for iterator consistency
-			Assert.assertEquals(407, result % 1024);
+      }
+      // A small check for iterator consistency
+      Assert.assertEquals(407, result % 1024);
 
-			long after = getThreadAllocatedBytes(THREAD_MBEAN, Thread.currentThread().getId());
-			System.out.println("Boxed Iteration allocated: " + (after - before));
-		}
-	}
+      long after = getThreadAllocatedBytes(THREAD_MBEAN, Thread.currentThread().getId());
+      System.out.println("Boxed Iteration allocated: " + (after - before));
+    }
+  }
 
-	@Test
-	public void measureStandardIterationAllocation() {
-		if (isThreadAllocatedMemorySupported(THREAD_MBEAN)) {
-			long before = getThreadAllocatedBytes(THREAD_MBEAN, Thread.currentThread().getId());
+  @Test
+  public void measureStandardIterationAllocation() {
+    if (isThreadAllocatedMemorySupported(THREAD_MBEAN)) {
+      long before = getThreadAllocatedBytes(THREAD_MBEAN, Thread.currentThread().getId());
 
-			IntIterator intIterator = bitmap_a.getIntIterator();
-			long result = 0;
-			while (intIterator.hasNext()) {
-				result += intIterator.next();
+      IntIterator intIterator = bitmap_a.getIntIterator();
+      long result = 0;
+      while (intIterator.hasNext()) {
+        result += intIterator.next();
 
-			}
-			// A small check for iterator consistency
-			Assert.assertEquals(407, result % 1024);
+      }
+      // A small check for iterator consistency
+      Assert.assertEquals(407, result % 1024);
 
-			long after = getThreadAllocatedBytes(THREAD_MBEAN, Thread.currentThread().getId());
-			System.out.println("Standard Iteration allocated: " + (after - before));
-		}
-	}
+      long after = getThreadAllocatedBytes(THREAD_MBEAN, Thread.currentThread().getId());
+      System.out.println("Standard Iteration allocated: " + (after - before));
+    }
+  }
 
-	@Test
-	public void measureFlyWeightIterationAllocation() {
-		if (isThreadAllocatedMemorySupported(THREAD_MBEAN)) {
-			long before = getThreadAllocatedBytes(THREAD_MBEAN, Thread.currentThread().getId());
+  @Test
+  public void measureFlyWeightIterationAllocation() {
+    if (isThreadAllocatedMemorySupported(THREAD_MBEAN)) {
+      long before = getThreadAllocatedBytes(THREAD_MBEAN, Thread.currentThread().getId());
 
-			IntIteratorFlyweight intIterator = new IntIteratorFlyweight();
-			intIterator.wrap(bitmap_a);
+      IntIteratorFlyweight intIterator = new IntIteratorFlyweight();
+      intIterator.wrap(bitmap_a);
 
-			long result = 0;
-			while (intIterator.hasNext()) {
-				result += intIterator.next();
+      long result = 0;
+      while (intIterator.hasNext()) {
+        result += intIterator.next();
 
-			}
-			// A small check for iterator consistency
-			Assert.assertEquals(407, result % 1024);
+      }
+      // A small check for iterator consistency
+      Assert.assertEquals(407, result % 1024);
 
-			long after = getThreadAllocatedBytes(THREAD_MBEAN, Thread.currentThread().getId());
-			System.out.println("FlyWeight Iteration allocated: " + (after - before));
-		}
-	}
+      long after = getThreadAllocatedBytes(THREAD_MBEAN, Thread.currentThread().getId());
+      System.out.println("FlyWeight Iteration allocated: " + (after - before));
+    }
+  }
 
 }


### PR DESCRIPTION
This follows the work done in https://github.com/RoaringBitmap/RoaringBitmap/pull/243 and the discussion in https://github.com/RoaringBitmap/RoaringBitmap/issues/244.

This first commit introduces a test class (TestIteratorMemory) based on IteratorsBenchmark32 but to provide some transient memory allocation measures. It typically gives:

    Standard Iteration allocated: 765872
    FlyWeight Iteration allocated: 904
    Boxed Iteration allocated: 2364816

It shall provide figures only under Oracle JVM (as it relies on com.sun.management.ThreadMXBean), but the tests should remain green/not-throwing in other JVMs.