### PR TITLE
implement nextSetBit

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -1142,6 +1142,13 @@ public final class ArrayContainer extends Container implements Cloneable {
   }
 
   @Override
+  public int nextSetBit(short fromValue) {
+    int index = Util.advanceUntil(content, -1, cardinality, fromValue);
+    int effectiveIndex = index >= 0 ? index : -index - 1;
+    return effectiveIndex >= cardinality ? -1 : Util.toIntUnsigned(content[effectiveIndex]);
+  }
+
+  @Override
   public int first() {
     assertNonEmpty(cardinality == 0);
     return Util.toIntUnsigned(content[0]);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -971,29 +971,6 @@ public final class BitmapContainer extends Container implements Cloneable {
     return -1;
   }
 
-  /**
-   * Find the index of the next unset bit greater or equal to i, returns -1 if none found.
-   *
-   * @param i starting index
-   * @return index of the next unset bit
-   */
-  public short nextUnsetBit(final int i) {
-    int x = i / 64;
-    long w = ~bitmap[x];
-    w >>>= i;
-    if (w != 0) {
-      return (short) (i + numberOfTrailingZeros(w));
-    }
-    ++x;
-    for (; x < bitmap.length; ++x) {
-      if (bitmap[x] != ~0L) {
-        return (short) (x * 64 + numberOfTrailingZeros(~bitmap[x]));
-      }
-    }
-    return -1;
-  }
-
-
 
   @Override
   public Container not(final int firstOfRange, final int lastOfRange) {
@@ -1364,6 +1341,11 @@ public final class BitmapContainer extends Container implements Cloneable {
   @Override
   public BitmapContainer toBitmapContainer() {
     return this;
+  }
+
+  @Override
+  public int nextSetBit(short fromValue) {
+    return nextSetBit(Util.toIntUnsigned(fromValue));
   }
 
   @Override

--- a/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
@@ -877,6 +877,13 @@ public abstract class Container implements Iterable<Short>, Cloneable, Externali
   public abstract BitmapContainer toBitmapContainer();
 
   /**
+   * Gets the next set bit after the value, or -1 if no such bit exists.
+   * @param fromValue the value to search after (inclusive)
+   * @return the next set bit after fromValue
+   */
+  public abstract int nextSetBit(short fromValue);
+
+  /**
    * Get the first integer held in the container
    * @return the first integer in the container
    * @throws NoSuchElementException if empty

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -2529,6 +2529,26 @@ public final class RunContainer extends Container implements Cloneable {
   }
 
   @Override
+  public int nextSetBit(short fromValue) {
+    int index = unsignedInterleavedBinarySearch(valueslength, 0, nbrruns, fromValue);
+    int effectiveIndex = index >= 0 ? index : -index - 2;
+    if (effectiveIndex == -1) {
+      return first();
+    }
+    int startValue = toIntUnsigned(getValue(effectiveIndex));
+    int value = toIntUnsigned(fromValue);
+    int offset = value - startValue;
+    int le = toIntUnsigned(getLength(effectiveIndex));
+    if (offset <= le) {
+      return value;
+    }
+    if (effectiveIndex + 1 < numberOfRuns()) {
+      return toIntUnsigned(getValue(effectiveIndex + 1));
+    }
+    return -1;
+  }
+
+  @Override
   public int first() {
     assertNonEmpty(numberOfRuns() == 0);
     return toIntUnsigned(valueslength[0]);

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestArrayContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestArrayContainer.java
@@ -470,6 +470,26 @@ public class TestArrayContainer {
         assertFalse(ac.contains(1 << 8 | 1 << 15 | 1, 1 << 16));
     }
 
+    @Test
+    public void testNextSetBitBeforeStart() {
+        ArrayContainer container = new ArrayContainer(new short[] { 10, 20, 30});
+        assertEquals(10, container.nextSetBit((short)5));
+    }
+
+    @Test
+    public void testNextSetBit() {
+        ArrayContainer container = new ArrayContainer(new short[] { 10, 20, 30});
+        assertEquals(10, container.nextSetBit((short)10));
+        assertEquals(20, container.nextSetBit((short)11));
+        assertEquals(30, container.nextSetBit((short)30));
+    }
+
+    @Test
+    public void testNextSetBitAfterEnd() {
+        ArrayContainer container = new ArrayContainer(new short[] { 10, 20, 30});
+        assertEquals(-1, container.nextSetBit((short)31));
+    }
+
     private static int lower16Bits(int x) {
         return ((short)x) & 0xFFFF;
     }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestBitmapContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestBitmapContainer.java
@@ -775,6 +775,31 @@ public class TestBitmapContainer {
     assertTrue(container.contains(64 * 1023 + 1, 64 * 1023 + 2));
   }
 
+  @Test
+  public void testNextSetBit() {
+    BitmapContainer container = new BitmapContainer(oddBits(), 1 << 15);
+    assertEquals(0, container.nextSetBit(0));
+    assertEquals(2, container.nextSetBit(1));
+    assertEquals(2, container.nextSetBit(2));
+    assertEquals(4, container.nextSetBit(3));
+  }
+
+  @Test
+  public void testNextSetBitAfterEnd() {
+    BitmapContainer container = new BitmapContainer(oddBits(), 1 << 15);
+    container.bitmap[1023] = 0L;
+    container.cardinality -= 32;
+    assertEquals(-1, container.nextSetBit((64 * 1023) + 5));
+  }
+
+  @Test
+  public void testNextSetBitBeforeStart() {
+    BitmapContainer container = new BitmapContainer(oddBits(), 1 << 15);
+    container.bitmap[0] = 0L;
+    container.cardinality -= 32;
+    assertEquals(64, container.nextSetBit(1));
+  }
+
   private static long[] oddBits() {
     long[] bitmap = new long[1 << 10];
     Arrays.fill(bitmap, 0x5555555555555555L);

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -4691,4 +4691,26 @@ public class TestRoaringBitmap {
     }
   }
 
+  @Test
+  public void testNextSetBit() {
+    RoaringBitmap bitmap = RandomisedTestData.TestDataSet.testCase()
+            .withRunAt(0)
+            .withBitmapAt(1)
+            .withArrayAt(2)
+            .withRunAt(3)
+            .withBitmapAt(4)
+            .withArrayAt(5)
+            .build();
+
+    BitSet bitset = new BitSet();
+    bitmap.forEach((IntConsumer) bitset::set);
+    long b1 = 0;
+    int b2 = 0;
+    while (b1 >= 0 && b2 >= 0) {
+      b1 = bitmap.nextSetBit((int)b1 + 1);
+      b2 = bitset.nextSetBit(b2 + 1);
+      assertEquals(b1, b2);
+    }
+  }
+
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
@@ -3437,6 +3437,27 @@ public class TestRunContainer {
     assertFalse(rc.contains(9999, 10001));
   }
 
+  @Test
+  public void testNextSetBit() {
+    RunContainer container = new RunContainer(new short[] { 64, 64 }, 1);
+    assertEquals(64, container.nextSetBit((short)0));
+    assertEquals(64, container.nextSetBit((short)64));
+    assertEquals(65, container.nextSetBit((short)65));
+    assertEquals(128, container.nextSetBit((short)128));
+    assertEquals(-1, container.nextSetBit((short)129));
+  }
+
+  @Test
+  public void testNextSetBitBetweenRuns() {
+    RunContainer container = new RunContainer(new short[] { 64, 64, 256, 64 }, 2);
+    assertEquals(64, container.nextSetBit((short)0));
+    assertEquals(64, container.nextSetBit((short)64));
+    assertEquals(65, container.nextSetBit((short)65));
+    assertEquals(128, container.nextSetBit((short)128));
+    assertEquals(256, container.nextSetBit((short)129));
+    assertEquals(-1, container.nextSetBit((short)512));
+  }
+
   private static int lower16Bits(int x) {
     return ((short)x) & 0xFFFF;
   }


### PR DESCRIPTION
This implements similar functionality to `java.util.BitSet.nextSetBit`, except the next bit is returned as a long, since RoaringBitmaps can contain all 32 bits.