### PR TITLE
simplify and fix signedness issues in contains methods

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -295,17 +295,11 @@ public final class ArrayContainer extends Container implements Cloneable {
     if (runContainer.getCardinality() > cardinality) {
       return false;
     }
-    int startPos, stopPos = -1;
+
     for (int i = 0; i < runContainer.numberOfRuns(); ++i) {
-      short start = runContainer.getValue(i);
-      int stop = Util.toIntUnsigned(start) + Util.toIntUnsigned(runContainer.getLength(i));
-      startPos = Util.advanceUntil(content, stopPos, cardinality, start);
-      stopPos = Util.advanceUntil(content, stopPos, cardinality, (short)stop);
-      if(startPos == cardinality) {
-        return false;
-      } else if(stopPos - startPos != stop - start
-                || content[startPos] != start
-                || content[stopPos] != stop) {
+      int start = Util.toIntUnsigned(runContainer.getValue(i));
+      int length = Util.toIntUnsigned(runContainer.getLength(i));
+      if (!contains(start, start + length)) {
         return false;
       }
     }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -373,12 +373,10 @@ public final class BitmapContainer extends Container implements Cloneable {
       }
     }
     for (int i = 0; i < runContainer.numberOfRuns(); ++i) {
-      short runStart = runContainer.getValue(i);
-      int le = Util.toIntUnsigned(runContainer.getLength(i));
-      for (short j = runStart; j <= runStart + le; ++j) {
-        if (!contains(j)) {
-          return false;
-        }
+      int start = Util.toIntUnsigned(runContainer.getValue(i));
+      int length = Util.toIntUnsigned(runContainer.getLength(i));
+      if (!contains(start, start + length)) {
+        return false;
       }
     }
     return true;

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -833,7 +833,7 @@ public final class RunContainer extends Container implements Cloneable {
     while(ib < bitmapContainer.bitmap.length && ir < runCount) {
       long w = bitmapContainer.bitmap[ib];
       while (w != 0 && ir < runCount) {
-        short start = getValue(ir);
+        int start = Util.toIntUnsigned(getValue(ir));
         int stop = start+ toIntUnsigned(getLength(ir));
         long t = w & -w;
         long r = ib * 64 + Long.numberOfTrailingZeros(w);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -1627,17 +1627,11 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     if (runContainer.getCardinality() > cardinality) {
       return false;
     }
-    int startPos, stopPos = -1;
+
     for (int i = 0; i < runContainer.numberOfRuns(); ++i) {
-      short start = runContainer.getValue(i);
-      int stop = toIntUnsigned(start) + toIntUnsigned(runContainer.getLength(i));
-      startPos = BufferUtil.advanceUntil(content, stopPos, cardinality, start);
-      stopPos = BufferUtil.advanceUntil(content, stopPos, cardinality, (short)stop);
-      if(startPos == cardinality) {
-        return false;
-      } else if(stopPos - startPos != stop - start
-                || content.get(startPos) != start
-                || content.get(stopPos) != stop) {
+      int start = toIntUnsigned(runContainer.getValue(i));
+      int length = toIntUnsigned(runContainer.getLength(i));
+      if (!contains(start, start + length)) {
         return false;
       }
     }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -2018,12 +2018,10 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
       }
     }
     for (int i = 0; i < runContainer.numberOfRuns(); ++i) {
-      short runStart = runContainer.getValue(i);
-      int le = BufferUtil.toIntUnsigned(runContainer.getLength(i));
-      for (short j = runStart; j <= runStart + le; ++j) {
-        if (!contains(j)) {
-          return false;
-        }
+      int start = BufferUtil.toIntUnsigned(runContainer.getValue(i));
+      int length = BufferUtil.toIntUnsigned(runContainer.getLength(i));
+      if (!contains(start, start + length)) {
+        return false;
       }
     }
     return true;

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -2619,18 +2619,19 @@ public final class MappeableRunContainer extends MappeableContainer implements C
       return false;
     }
     int ia = 0, ir = 0;
-    while(ia < arrayContainer.getCardinality() && ir <= runCount) {
-      int start = getValue(ir);
+    while(ia < arrayContainer.getCardinality() && ir < runCount) {
+      int start = toIntUnsigned(getValue(ir));
       int stop = start + toIntUnsigned(getLength(ir));
-      if(arrayContainer.content.get(ia) < start) {
+      int value = toIntUnsigned(arrayContainer.content.get(ia));
+      if(value < start) {
         return false;
-      } else if (arrayContainer.content.get(ia) > stop) {
+      } else if (value > stop) {
         ++ir;
       } else {
         ++ia;
       }
     }
-    return ia <= cardinality && ir <= runCount;
+    return ia == arrayContainer.getCardinality();
   }
 
   @Override
@@ -2644,7 +2645,7 @@ public final class MappeableRunContainer extends MappeableContainer implements C
     while(ib < MappeableBitmapContainer.MAX_CAPACITY / 64 && ir < runCount) {
       long w = bitmapContainer.bitmap.get(ib);
       while (w != 0 && ir < runCount) {
-        short start = getValue(ir);
+        int start = toIntUnsigned(getValue(ir));
         int stop = start+ toIntUnsigned(getLength(ir));
         long t = w & -w;
         long r = ib * 64 + Long.numberOfTrailingZeros(w);


### PR DESCRIPTION
There are a few opportunities to reduce duplication between the `Container::contains(Container)` methods and `Container.contains(int min, int sup)` methods, and this fixes some errors where signed values should be treated as unsigned. 

These changes have been made specifically to avoid any merge conflicts with #255.