### PR TITLE
Fast rank-peekable iterators

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -425,6 +425,12 @@ public final class ArrayContainer extends Container implements Cloneable {
   }
 
   @Override
+  public PeekableShortRankIterator getShortRankIterator() {
+    // for ArrayContainer there is no additional work, pos is known in advance
+    return new ArrayContainerShortIterator(this);
+  }
+
+  @Override
   public ContainerBatchIterator getBatchIterator() {
     return new ArrayBatchIterator(this);
   }
@@ -1295,7 +1301,7 @@ public final class ArrayContainer extends Container implements Cloneable {
 }
 
 
-final class ArrayContainerShortIterator implements PeekableShortIterator {
+final class ArrayContainerShortIterator implements PeekableShortRankIterator {
   int pos;
   ArrayContainer parent;
 
@@ -1310,11 +1316,15 @@ final class ArrayContainerShortIterator implements PeekableShortIterator {
     pos = Util.advanceUntil(parent.content, pos - 1, parent.cardinality, minval);
   }
 
+  @Override
+  public short peekNextRank() {
+    return (short) (pos + 1);
+  }
 
   @Override
-  public PeekableShortIterator clone() {
+  public PeekableShortRankIterator clone() {
     try {
-      return (PeekableShortIterator) super.clone();
+      return (PeekableShortRankIterator) super.clone();
     } catch (CloneNotSupportedException e) {
       return null;// will not happen
     }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
@@ -322,6 +322,13 @@ public abstract class Container implements Iterable<Short>, Cloneable, Externali
   public abstract PeekableShortIterator getShortIterator();
 
   /**
+   * Iterator to visit the short values in container and pre-compute ranks
+   *
+   * @return iterator
+   */
+  public abstract PeekableShortRankIterator getShortRankIterator();
+
+  /**
    * Gets an iterator to visit the contents of the container in batches
    * @return iterator
    */

--- a/roaringbitmap/src/main/java/org/roaringbitmap/PeekableIntRankIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/PeekableIntRankIterator.java
@@ -1,0 +1,18 @@
+package org.roaringbitmap;
+
+/**
+ * PeekableIntIterator that calculates the next value rank during iteration
+ */
+public interface PeekableIntRankIterator extends PeekableIntIterator {
+  /**
+   * Look at rank of the next value without advancing
+   *
+   * @return rank of next value
+   */
+  int peekNextRank();
+
+  @Override
+  PeekableIntRankIterator clone();
+}
+
+

--- a/roaringbitmap/src/main/java/org/roaringbitmap/PeekableShortRankIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/PeekableShortRankIterator.java
@@ -1,0 +1,16 @@
+package org.roaringbitmap;
+
+/**
+ * PeekableShortIterator that calculates the next value rank during iteration
+ */
+public interface PeekableShortRankIterator extends PeekableShortIterator {
+
+  /**
+   * peek in-container rank of the next value
+   * @return rank of the next value
+   */
+  short peekNextRank();
+
+  @Override
+  PeekableShortRankIterator clone();
+}

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIterator.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIterator.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -44,10 +45,16 @@ public class TestRankIterator {
 
   @Test
   public void testAdvance() {
+    long start = System.nanoTime();
     if (advance == 0) {
       testBitmapRanksOnNext(bitmap);
+      long ms = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+      System.out.println("next: " + ms + "ms");
     } else {
       testBitmapRanksOnAdvance(bitmap, advance);
+      long end = System.nanoTime();
+      long ms = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+      System.out.println("advance by " + advance + ": " + ms + "ms");
     }
   }
 

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIterator.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIterator.java
@@ -1,23 +1,23 @@
 package org.roaringbitmap;
 
+import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@RunWith(Parameterized.class)
 public class TestRankIterator {
-  private void testBitmapRanksOnNext(FastRankRoaringBitmap bm) {
-    PeekableIntRankIterator iterator = bm.getIntRankIterator();
-    while (iterator.hasNext()) {
-      int bit = iterator.peekNext();
-      int rank = iterator.peekNextRank();
-      int slowRank = bm.rank(bit);
-      Assert.assertEquals(slowRank, rank);
 
-      iterator.next();
-    }
-  }
-
-  @Test
-  public void randomizedTest() {
+  @Parameterized.Parameters(name = "{index}: advance by {1}")
+  public static Collection<Object[]> parameters() {
     RoaringBitmap bm = RandomisedTestData.randomBitmap(1 << 12);
     FastRankRoaringBitmap fast = new FastRankRoaringBitmap();
     fast.or(bm);
@@ -25,6 +25,57 @@ public class TestRankIterator {
 
     Assert.assertTrue(fast.isCacheDismissed());
 
-    testBitmapRanksOnNext(fast);
+    List<Integer> primes = Arrays.asList(0, 1, 3, 5, 7, 11);
+    List<Integer> powers = IntStream.range(0, 18).mapToObj(i -> 1 << i).collect(Collectors.toList());
+
+    List<Integer> advances = Lists.cartesianProduct(primes, powers).stream()
+                                  .map(l -> l.get(0) * l.get(1))
+                                  .distinct().sorted()
+                                  .collect(Collectors.toList());
+
+    return Lists.cartesianProduct(Collections.singletonList(fast), advances)
+                .stream().map(List::toArray).collect(Collectors.toList());
+  }
+
+  @Parameterized.Parameter
+  public FastRankRoaringBitmap bitmap;
+  @Parameterized.Parameter(1)
+  public Integer advance;
+
+  @Test
+  public void testAdvance() {
+    if (advance == 0) {
+      testBitmapRanksOnNext(bitmap);
+    } else {
+      testBitmapRanksOnAdvance(bitmap, advance);
+    }
+  }
+
+  private void testBitmapRanksOnNext(FastRankRoaringBitmap bm) {
+    PeekableIntRankIterator iterator = bm.getIntRankIterator();
+    long iterations = 0;
+    while (iterator.hasNext()) {
+      ++iterations;
+      int rank = iterator.peekNextRank();
+      Assert.assertEquals(iterations, Util.toUnsignedLong(rank));
+
+      iterator.next();
+    }
+  }
+
+  private void testBitmapRanksOnAdvance(FastRankRoaringBitmap bm, int advance) {
+    PeekableIntRankIterator iterator = bm.getIntRankIterator();
+    while (iterator.hasNext()) {
+      int bit = iterator.peekNext();
+      int rank = iterator.peekNextRank();
+
+      Assert.assertEquals(bm.rank(bit), rank);
+
+      if ((Util.toUnsignedLong(bit) + advance) < 0xffffffffL) {
+        iterator.advanceIfNeeded(bit + advance);
+      } else {
+        break;
+      }
+    }
   }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIterator.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIterator.java
@@ -1,0 +1,30 @@
+package org.roaringbitmap;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestRankIterator {
+  private void testBitmapRanksOnNext(FastRankRoaringBitmap bm) {
+    PeekableIntRankIterator iterator = bm.getIntRankIterator();
+    while (iterator.hasNext()) {
+      int bit = iterator.peekNext();
+      int rank = iterator.peekNextRank();
+      int slowRank = bm.rank(bit);
+      Assert.assertEquals(slowRank, rank);
+
+      iterator.next();
+    }
+  }
+
+  @Test
+  public void randomizedTest() {
+    RoaringBitmap bm = RandomisedTestData.randomBitmap(1 << 12);
+    FastRankRoaringBitmap fast = new FastRankRoaringBitmap();
+    fast.or(bm);
+    fast.runOptimize();
+
+    Assert.assertTrue(fast.isCacheDismissed());
+
+    testBitmapRanksOnNext(fast);
+  }
+}

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIteratorsOfContainers.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIteratorsOfContainers.java
@@ -12,7 +12,7 @@ public class TestRankIteratorsOfContainers {
       short bit = iterator.peekNext();
       short rank = iterator.peekNextRank();
 
-      Assert.assertEquals(c.rank(bit), rank);
+      Assert.assertEquals((short) c.rank(bit), rank);
 
       iterator.next();
     }
@@ -24,7 +24,7 @@ public class TestRankIteratorsOfContainers {
       short bit = iterator.peekNext();
       short rank = iterator.peekNextRank();
 
-      Assert.assertEquals(c.rank(bit), rank);
+      Assert.assertEquals((short) c.rank(bit), rank);
 
       iterator.nextAsInt();
     }
@@ -37,7 +37,7 @@ public class TestRankIteratorsOfContainers {
       bit = iterator.peekNext();
       short rank = iterator.peekNextRank();
 
-      Assert.assertEquals("" + advance, c.rank(bit), rank);
+      Assert.assertEquals((short) c.rank(bit), rank);
 
       if ((Util.toIntUnsigned(bit) + advance < 65536)) {
         iterator.advanceIfNeeded((short) (bit + advance));
@@ -47,10 +47,10 @@ public class TestRankIteratorsOfContainers {
     }
   }
 
-  private void testContainer(Container container) {
+  private void testContainerIterators(Container container) {
     testContainerRanksOnNext(container);
     testContainerRanksOnNextAsInt(container);
-    for(int j = 1; j <= 8; ++j) {
+    for (int j = 1; j <= 16; ++j) {
       testContainerRanksOnAdvance(container, j);
       testContainerRanksOnAdvance(container, j * 3);
       testContainerRanksOnAdvance(container, j * 5);
@@ -65,6 +65,8 @@ public class TestRankIteratorsOfContainers {
   }
 
   private void fillRandom(Container container, Random rnd) {
+    Container empty = container;
+
     for (int i = 0; i < 1024; ++i) {
       container.add((short) rnd.nextInt(1 << 10));
     }
@@ -76,12 +78,23 @@ public class TestRankIteratorsOfContainers {
     for (int i = 0; i < 1024; ++i) {
       container.add((short) (16384 + rnd.nextInt(1 << 10)));
     }
+
+    Assert.assertSame("bad test -- container was changed", empty, container);
+  }
+
+  private void fillRange(Container container, int begin, int end) {
+    Container empty = container;
+
+    container.iadd(begin, end);
+
+    Assert.assertSame("bad test -- container was changed", empty, container);
   }
 
   @Test
   public void testBitmapContainer1() {
     BitmapContainer container = new BitmapContainer();
     container.add((short) 123);
+    container.add((short) 65535);
 
     testContainerRanksOnNext(container);
   }
@@ -93,7 +106,26 @@ public class TestRankIteratorsOfContainers {
 
     fillRandom(container, rnd);
 
-    testContainer(container);
+    testContainerIterators(container);
+  }
+
+  @Test
+  public void testBitmapContainer3() {
+    BitmapContainer container = new BitmapContainer();
+    fillRange(container, 0, 65535);
+
+    testContainerIterators(container);
+  }
+
+
+  @Test
+  public void testBitmapContainer4() {
+    BitmapContainer container = new BitmapContainer();
+    fillRange(container, 1024, 2048);
+    fillRange(container, 8192 + 7, 24576 - 7);
+    fillRange(container, 65534, 65535);
+
+    testContainerIterators(container);
   }
 
   @Test
@@ -111,14 +143,22 @@ public class TestRankIteratorsOfContainers {
 
     fillRandom(container, rnd);
 
-    testContainer(container);
+    testContainerIterators(container);
+  }
+
+  @Test
+  public void testArrayContainer3() {
+    ArrayContainer container = new ArrayContainer();
+    fillRange(container, 0, 1024);
+    fillRange(container, 2048, 4096);
+    fillRange(container, 65535 - 7, 65535 - 5);
   }
 
   @Test
   public void testRunContainer1() {
     RunContainer container = new RunContainer();
     container.add((short) 123);
-    testContainer(container);
+    testContainerIterators(container);
   }
 
   @Test
@@ -127,6 +167,16 @@ public class TestRankIteratorsOfContainers {
     Random rnd = new Random(0);
 
     fillRandom(container, rnd);
-    testContainer(container);
+    testContainerIterators(container);
+  }
+
+  @Test
+  public void testRunContainer3() {
+    RunContainer container = new RunContainer();
+    fillRange(container, 0, 1024);
+
+    fillRange(container, 1024 + 3, 1024 + 5);
+    fillRange(container, 1024 + 30, 1024 + 37);
+    fillRange(container, 65535 - 7, 65535 - 5);
   }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIteratorsOfContainers.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIteratorsOfContainers.java
@@ -1,0 +1,132 @@
+package org.roaringbitmap;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Random;
+
+public class TestRankIteratorsOfContainers {
+  private void testContainerRanksOnNext(Container c) {
+    PeekableShortRankIterator iterator = c.getShortRankIterator();
+    while (iterator.hasNext()) {
+      short bit = iterator.peekNext();
+      short rank = iterator.peekNextRank();
+
+      Assert.assertEquals(c.rank(bit), rank);
+
+      iterator.next();
+    }
+  }
+
+  private void testContainerRanksOnNextAsInt(Container c) {
+    PeekableShortRankIterator iterator = c.getShortRankIterator();
+    while (iterator.hasNext()) {
+      short bit = iterator.peekNext();
+      short rank = iterator.peekNextRank();
+
+      Assert.assertEquals(c.rank(bit), rank);
+
+      iterator.nextAsInt();
+    }
+  }
+
+  private void testContainerRanksOnAdvance(Container c, int advance) {
+    PeekableShortRankIterator iterator = c.getShortRankIterator();
+    short bit;
+    while (iterator.hasNext()) {
+      bit = iterator.peekNext();
+      short rank = iterator.peekNextRank();
+
+      Assert.assertEquals("" + advance, c.rank(bit), rank);
+
+      if ((Util.toIntUnsigned(bit) + advance < 65536)) {
+        iterator.advanceIfNeeded((short) (bit + advance));
+      } else {
+        iterator.next();
+      }
+    }
+  }
+
+  private void testContainer(Container container) {
+    testContainerRanksOnNext(container);
+    testContainerRanksOnNextAsInt(container);
+    for(int j = 1; j <= 8; ++j) {
+      testContainerRanksOnAdvance(container, j);
+      testContainerRanksOnAdvance(container, j * 3);
+      testContainerRanksOnAdvance(container, j * 5);
+      testContainerRanksOnAdvance(container, j * 7);
+      testContainerRanksOnAdvance(container, j * 11);
+      testContainerRanksOnAdvance(container, j * 64);
+      testContainerRanksOnAdvance(container, j * 128);
+      testContainerRanksOnAdvance(container, j * 256);
+      testContainerRanksOnAdvance(container, j * 512);
+      testContainerRanksOnAdvance(container, j * 1024);
+    }
+  }
+
+  private void fillRandom(Container container, Random rnd) {
+    for (int i = 0; i < 1024; ++i) {
+      container.add((short) rnd.nextInt(1 << 10));
+    }
+
+    for (int i = 0; i < 1024; ++i) {
+      container.add((short) (8192 + rnd.nextInt(1 << 10)));
+    }
+
+    for (int i = 0; i < 1024; ++i) {
+      container.add((short) (16384 + rnd.nextInt(1 << 10)));
+    }
+  }
+
+  @Test
+  public void testBitmapContainer1() {
+    BitmapContainer container = new BitmapContainer();
+    container.add((short) 123);
+
+    testContainerRanksOnNext(container);
+  }
+
+  @Test
+  public void testBitmapContainer2() {
+    BitmapContainer container = new BitmapContainer();
+    Random rnd = new Random(0);
+
+    fillRandom(container, rnd);
+
+    testContainer(container);
+  }
+
+  @Test
+  public void testArrayContainer1() {
+    ArrayContainer container = new ArrayContainer();
+    container.add((short) 123);
+
+    testContainerRanksOnNext(container);
+  }
+
+  @Test
+  public void testArrayContainer2() {
+    ArrayContainer container = new ArrayContainer();
+    Random rnd = new Random(0);
+
+    fillRandom(container, rnd);
+
+    testContainer(container);
+  }
+
+  @Test
+  public void testRunContainer1() {
+    RunContainer container = new RunContainer();
+    container.add((short) 123);
+    testContainer(container);
+  }
+
+  @Test
+  public void testRunContainer2() {
+    RunContainer container = new RunContainer();
+    Random rnd = new Random(0);
+
+    fillRandom(container, rnd);
+    testContainer(container);
+  }
+}


### PR DESCRIPTION
Follow-up #191/#192.

Current FastRankRoaringBitmap implementation holds a cache of containers’ cardinalities and drastically improves rank calculation in case of random access.

I propose an enhancement for sequential access case — next/advanceIfNeed followed by obtaining rank of found position.

My original case is a very sparse column implemented as bitmap and array using rank as non-empty value position.

Another example (cc #72): two sparse vectors can be implemented as bitmap-array pair and dot product of them can be calculated by intersection via advanceIfNeed and extracting values using match ranks.

I have to make a separate family of rank iterators because rank processing will reduce performance for classical usecases (except of ArrayContainerShortIterator -- getting it's sub-rank is trivial).
