### PR TITLE
Introduce implemententation for Roaring64NavigableMap.getLongSizeInBy…

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/FastRankRoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/FastRankRoaringBitmap.java
@@ -252,6 +252,16 @@ public class FastRankRoaringBitmap extends RoaringBitmap {
 
     return value;
   }
+  
+  @Override
+  public long getLongSizeInBytes() {
+    long size = 8;
+    size += super.getLongSizeInBytes();
+    if (highToCumulatedCardinality != null) {
+      size += 4 * highToCumulatedCardinality.length;
+    }
+    return size;
+  }
 
   /**
    * Get a special iterator that allows .peekNextRank efficiently

--- a/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
@@ -1071,6 +1071,10 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
 
     // Size of (boxed) Integers used as keys
     size += 16 * highToBitmap.size();
+
+    // The cache impacts the size in heap
+    size += 8 * sortedCumulatedCardinality.length;
+    size += 4 * sortedHighs.length;
     
     return size;
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
@@ -1060,7 +1060,19 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
 
   @Override
   public long getLongSizeInBytes() {
-    throw new UnsupportedOperationException("TODO");
+    long size = 8;
+      
+    // Size of containers
+    size += highToBitmap.values().stream().mapToLong(p -> p.getLongSizeInBytes()).sum();
+    
+    // Size of Map data-structure: we consider each TreeMap entry costs 40 bytes
+    // http://java-performance.info/memory-consumption-of-java-data-types-2/
+    size += 8 + 40 * highToBitmap.size();
+
+    // Size of (boxed) Integers used as keys
+    size += 16 * highToBitmap.size();
+    
+    return size;
   }
 
   @Override

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap_FastRank.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap_FastRank.java
@@ -484,4 +484,24 @@ public class TestRoaringBitmap_FastRank {
     Assert.assertTrue(fast.isCacheDismissed());
   }
 
+  @Test
+  public void testLongSizeInBytes() {
+    FastRankRoaringBitmap fast = new FastRankRoaringBitmap();
+
+    // Check when empty
+    Assert.assertEquals(16, fast.getLongSizeInBytes());
+    
+    fast.add(0);
+    fast.add(1024);
+    fast.add(Integer.MAX_VALUE);
+
+    Assert.assertEquals(34, fast.getLongSizeInBytes());
+    
+    // Compute a rank: the cache is allocated
+    fast.rank(1024);
+    
+    // Check the size is bigger once the cache is allocated
+    Assert.assertEquals(42, fast.getLongSizeInBytes());
+  }
+
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
@@ -1447,4 +1447,22 @@ public class TestRoaring64NavigableMap {
     }
     Assert.assertTrue(map.isEmpty());
   }
+
+  @Test
+  public void testLongSizeInBytes() {
+    Roaring64NavigableMap map = newSignedBuffered();
+
+    // Size when empty
+    Assert.assertEquals(16, map.getLongSizeInBytes());
+
+    // Add values so that the underlying Map holds multiple entries
+    map.add(0);
+    map.add(2L * Integer.MAX_VALUE);
+    map.add(8L * Integer.MAX_VALUE, 8L * Integer.MAX_VALUE + 1024);
+    
+    Assert.assertEquals(3, map.getHighToBitmap().size());
+
+    // Size with multiple entries
+    Assert.assertEquals(228, map.getLongSizeInBytes());
+  }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
@@ -1464,5 +1464,9 @@ public class TestRoaring64NavigableMap {
 
     // Size with multiple entries
     Assert.assertEquals(228, map.getLongSizeInBytes());
+    
+    // Select does allocate some cache
+    map.select(16);
+    Assert.assertEquals(264, map.getLongSizeInBytes());
   }
 }


### PR DESCRIPTION
https://github.com/RoaringBitmap/RoaringBitmap/issues/266

This method was not initially implemented because I was unconfortable with estimating the usage of a TreeMap. Here is an implementation which sounds reasonnable.