### PR TITLE
Add RoaringBitmap.add with offset and length arguments

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -446,7 +446,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
    * @param dat set values
    */
   public void add(final int... dat) {
-    this.add(dat, 0, dat.length);
+    this.addN(dat, 0, dat.length);
   }
 
   /**
@@ -457,14 +457,14 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
    *
    * @param dat set values
    * @param offset from which index the values should be set to true
-   * @param length how many values should be set to true
+   * @param n how many values should be set to true
    */
-  public void add(final int[] dat, final int offset, final int length) {
+  public void addN(final int[] dat, final int offset, final int n) {
     Container currentcont = null;
     short currenthb = 0;
     int currentcontainerindex = 0;
     int j = 0;
-    if(j < length) {
+    if(j < n) {
       int val = dat[j + offset];
       currenthb = Util.highbits(val);
       currentcontainerindex = highLowContainer.getIndex(currenthb);
@@ -483,7 +483,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
       }
       j++;
     }
-    for( ; j < length; ++j) {
+    for( ; j < n; ++j) {
       int val = dat[j + offset];
       short newhb = Util.highbits(val);
       if(currenthb == newhb) {// easy case

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -436,8 +436,9 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     }
     return answer;
   }
+
   /**
-   * Set all the specified values  to true. This can be expected to be slightly
+   * Set all the specified values to true. This can be expected to be slightly
    * faster than calling "add" repeatedly. The provided integers values don't
    * have to be in sorted order, but it may be preferable to sort them from a performance point of
    * view.
@@ -445,12 +446,26 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
    * @param dat set values
    */
   public void add(final int... dat) {
+    this.add(dat, 0, dat.length);
+  }
+
+  /**
+   * Set the specified values to true, within given boundaries. This can be expected to be slightly
+   * faster than calling "add" repeatedly. The provided integers values don't
+   * have to be in sorted order, but it may be preferable to sort them from a performance point of
+   * view.
+   *
+   * @param dat set values
+   * @param offset from which index the values should be set to true
+   * @param length how many values should be set to true
+   */
+  public void add(final int[] dat, final int offset, final int length) {
     Container currentcont = null;
     short currenthb = 0;
     int currentcontainerindex = 0;
     int j = 0;
-    if(j < dat.length) {
-      int val = dat[j];
+    if(j < length) {
+      int val = dat[j + offset];
       currenthb = Util.highbits(val);
       currentcontainerindex = highLowContainer.getIndex(currenthb);
       if (currentcontainerindex >= 0) {
@@ -468,8 +483,8 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
       }
       j++;
     }
-    for( ; j < dat.length; ++j) {
-      int val = dat[j];
+    for( ; j < length; ++j) {
+      int val = dat[j + offset];
       short newhb = Util.highbits(val);
       if(currenthb == newhb) {// easy case
         // this could be quite frequent

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
@@ -289,8 +289,9 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
     }
     return answer;
   }
+
   /**
-   * Set all the specified values  to true. This can be expected to be slightly
+   * Set all the specified values to true. This can be expected to be slightly
    * faster than calling "add" repeatedly. The provided integers values don't
    * have to be in sorted order, but it may be preferable to sort them from a performance point of
    * view.
@@ -298,13 +299,27 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
    * @param dat set values
    */
   public void add(final int... dat) {
+    this.addN(dat, 0, dat.length);
+  }
+
+  /**
+   * Set the specified values to true, within given boundaries. This can be expected to be slightly
+   * faster than calling "add" repeatedly. The provided integers values don't
+   * have to be in sorted order, but it may be preferable to sort them from a performance point of
+   * view.
+   *
+   * @param dat set values
+   * @param offset from which index the values should be set to true
+   * @param n how many values should be set to true
+   */
+  public void addN(final int[] dat, final int offset, final int n) {
     MutableRoaringArray mra = (MutableRoaringArray) highLowContainer;
     MappeableContainer currentcont = null;
     short currenthb = 0;
     int currentcontainerindex = 0;
     int j = 0;
-    if(j < dat.length) {
-      int val = dat[j];
+    if(j < n) {
+      int val = dat[j + offset];
       currenthb = BufferUtil.highbits(val);
       currentcontainerindex = highLowContainer.getIndex(currenthb);
       if (currentcontainerindex >= 0) {
@@ -322,8 +337,8 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
       }
       j++;
     }
-    for( ; j < dat.length; ++j) {
-      int val = dat[j];
+    for( ; j < n; ++j) {
+      int val = dat[j + offset];
       short newhb = BufferUtil.highbits(val);
       if(currenthb == newhb) {// easy case
         // this could be quite frequent

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -42,7 +42,7 @@ public class TestRoaringBitmap {
     bitmap.addN(new int[]{1, 2, 3, 4, 5}, 1, 3);
     Assert.assertEquals("{2,3,4}",bitmap.toString());
   }
-s
+
 	@Test
 	public void testStringer() {
 	    RoaringBitmap bitmap = new RoaringBitmap();

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -26,17 +26,23 @@ import java.util.stream.IntStream;
 @SuppressWarnings({"static-method"})
 public class TestRoaringBitmap {
 
-	@Test
-	public void testMultipleAdd() {
-	    RoaringBitmap bitmap = new RoaringBitmap();
-	    bitmap.add(1);
-            bitmap.add(1, 2, 3);
-	    bitmap.add(0xFFFFFFFF);
-	    bitmap.add(0xFFFFFFFE,0xFFFFFFFF );
-            Assert.assertEquals("{1,2,3,4294967294,4294967295}",bitmap.toString());
-	}
+  @Test
+  public void testMultipleAdd() {
+    RoaringBitmap bitmap = new RoaringBitmap();
+    bitmap.add(1);
+    bitmap.add(1, 2, 3);
+    bitmap.add(0xFFFFFFFF);
+    bitmap.add(0xFFFFFFFE,0xFFFFFFFF );
+    Assert.assertEquals("{1,2,3,4294967294,4294967295}",bitmap.toString());
+  }
 
-
+  @Test
+  public void testAddN() {
+    RoaringBitmap bitmap = new RoaringBitmap();
+    bitmap.addN(new int[]{1, 2, 3, 4, 5}, 1, 3);
+    Assert.assertEquals("{2,3,4}",bitmap.toString());
+  }
+s
 	@Test
 	public void testStringer() {
 	    RoaringBitmap bitmap = new RoaringBitmap();


### PR DESCRIPTION
Adds `RoaringBitmap.addN` method, to allow adding multiple values to RoaringBitmap while respecting some boundaries.

This is useful when the user wants to reuse large preallocated `int[]` instances to create multiple RoaringBitmaps. Without it, the user needs to create array copies: `roaringBitmap.add(Arrays.copyOf(arr, len))`