### PR TITLE
Bitmap statistics & naive writer heuristics recommendation

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/insights/BitmapAnalyser.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/insights/BitmapAnalyser.java
@@ -1,0 +1,46 @@
+package org.roaringbitmap.insights;
+
+import org.roaringbitmap.ContainerPointer;
+import org.roaringbitmap.RoaringBitmap;
+
+import java.util.Collection;
+
+public class BitmapAnalyser {
+
+  /**
+   * Analyse the internal representation of bitmap
+   */
+  public static BitmapStatistics analyse(RoaringBitmap r) {
+    int acCount = 0;
+    int acCardinalitySum = 0;
+    int bcCount = 0;
+    int rcCount = 0;
+    ContainerPointer cp = r.getContainerPointer();
+    while (cp.getContainer() != null) {
+      if (cp.isBitmapContainer()) {
+        bcCount += 1;
+      } else if (cp.isRunContainer()) {
+        rcCount += 1;
+      } else {
+        acCount += 1;
+        acCardinalitySum += cp.getCardinality();
+      }
+      cp.advance();
+    }
+    BitmapStatistics.ArrayContainersStats acStats =
+        new BitmapStatistics.ArrayContainersStats(acCount, acCardinalitySum);
+    return new BitmapStatistics(acStats, bcCount, rcCount);
+  }
+
+  /**
+   * Analyse the internal representation of bitmaps
+   */
+  public static BitmapStatistics analyse(Collection<? extends RoaringBitmap> bitmaps) {
+    return bitmaps
+      .stream()
+      .reduce(
+        BitmapStatistics.empty,
+        (acc, r) -> acc.merge(BitmapAnalyser.analyse(r)),
+        BitmapStatistics::merge);
+  }
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/insights/BitmapStatistics.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/insights/BitmapStatistics.java
@@ -3,12 +3,12 @@ package org.roaringbitmap.insights;
 import java.util.Objects;
 
 public class BitmapStatistics {
-  final int bitmapsCount;
-  final ArrayContainersStats arrayContainersStats;
-  final int bitmapContainerCount;
-  final int runContainerCount;
+  private final int bitmapsCount;
+  private final ArrayContainersStats arrayContainersStats;
+  private final int bitmapContainerCount;
+  private final int runContainerCount;
 
-  public BitmapStatistics(
+  BitmapStatistics(
       ArrayContainersStats arrayContainersStats,
       int bitmapContainerCount,
       int runContainerCount) {
@@ -89,9 +89,30 @@ public class BitmapStatistics {
     return Objects.hash(bitmapsCount, bitmapContainerCount, runContainerCount);
   }
 
+  public int getBitmapsCount() {
+    return bitmapsCount;
+  }
+
+  public int getBitmapContainerCount() {
+    return bitmapContainerCount;
+  }
+
+  public int getRunContainerCount() {
+    return runContainerCount;
+  }
+
   public static class ArrayContainersStats {
-    final int containersCount;
-    final int cardinalitySum;
+    private final int containersCount;
+
+    public int getContainersCount() {
+      return containersCount;
+    }
+
+    public int getCardinalitySum() {
+      return cardinalitySum;
+    }
+
+    private final int cardinalitySum;
 
 
     ArrayContainersStats(int containersCount, int cardinalitySum) {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/insights/BitmapStatistics.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/insights/BitmapStatistics.java
@@ -3,24 +3,24 @@ package org.roaringbitmap.insights;
 import java.util.Objects;
 
 public class BitmapStatistics {
-  private final int bitmapsCount;
+  private final long bitmapsCount;
   private final ArrayContainersStats arrayContainersStats;
-  private final int bitmapContainerCount;
-  private final int runContainerCount;
+  private final long bitmapContainerCount;
+  private final long runContainerCount;
 
   BitmapStatistics(
       ArrayContainersStats arrayContainersStats,
-      int bitmapContainerCount,
-      int runContainerCount) {
+      long bitmapContainerCount,
+      long runContainerCount) {
 
     this(arrayContainersStats, bitmapContainerCount, runContainerCount, 1);
   }
 
   BitmapStatistics(
       ArrayContainersStats arrayContainersStats,
-      int bitmapContainerCount,
-      int runContainerCount,
-      int bitmapsCount) {
+      long bitmapContainerCount,
+      long runContainerCount,
+      long bitmapsCount) {
 
     this.arrayContainersStats = arrayContainersStats;
     this.bitmapContainerCount = bitmapContainerCount;
@@ -32,7 +32,7 @@ public class BitmapStatistics {
   /**
    * Calculates what fraction of all containers is the `containerTypeCount`
    */
-  public double containerFraction(int containerTypeCount) {
+  public double containerFraction(long containerTypeCount) {
     if (containerCount() == 0) {
       return Double.NaN;
     } else {
@@ -54,7 +54,7 @@ public class BitmapStatistics {
       + '}';
   }
 
-  public int containerCount() {
+  public long containerCount() {
     return arrayContainersStats.containersCount + bitmapContainerCount + runContainerCount;
   }
 
@@ -89,33 +89,32 @@ public class BitmapStatistics {
     return Objects.hash(bitmapsCount, bitmapContainerCount, runContainerCount);
   }
 
-  public int getBitmapsCount() {
+  public long getBitmapsCount() {
     return bitmapsCount;
   }
 
-  public int getBitmapContainerCount() {
+  public long getBitmapContainerCount() {
     return bitmapContainerCount;
   }
 
-  public int getRunContainerCount() {
+  public long getRunContainerCount() {
     return runContainerCount;
   }
 
   public static class ArrayContainersStats {
-    private final int containersCount;
+    private final long containersCount;
 
-    public int getContainersCount() {
+    private final long cardinalitySum;
+
+    public long getContainersCount() {
       return containersCount;
     }
 
-    public int getCardinalitySum() {
+    public long getCardinalitySum() {
       return cardinalitySum;
     }
 
-    private final int cardinalitySum;
-
-
-    ArrayContainersStats(int containersCount, int cardinalitySum) {
+    ArrayContainersStats(long containersCount, long cardinalitySum) {
       this.containersCount = containersCount;
       this.cardinalitySum = cardinalitySum;
     }
@@ -129,9 +128,9 @@ public class BitmapStatistics {
     /**
      * Average cardinality of ArrayContainers
      */
-    public int averageCardinality() {
+    public long averageCardinality() {
       if (containersCount == 0) {
-        return Integer.MAX_VALUE;
+        return Long.MAX_VALUE;
       } else {
         return cardinalitySum / containersCount;
       }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/insights/BitmapStatistics.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/insights/BitmapStatistics.java
@@ -1,0 +1,150 @@
+package org.roaringbitmap.insights;
+
+import java.util.Objects;
+
+public class BitmapStatistics {
+  final int bitmapsCount;
+  final ArrayContainersStats arrayContainersStats;
+  final int bitmapContainerCount;
+  final int runContainerCount;
+
+  public BitmapStatistics(
+      ArrayContainersStats arrayContainersStats,
+      int bitmapContainerCount,
+      int runContainerCount) {
+
+    this(arrayContainersStats, bitmapContainerCount, runContainerCount, 1);
+  }
+
+  BitmapStatistics(
+      ArrayContainersStats arrayContainersStats,
+      int bitmapContainerCount,
+      int runContainerCount,
+      int bitmapsCount) {
+
+    this.arrayContainersStats = arrayContainersStats;
+    this.bitmapContainerCount = bitmapContainerCount;
+    this.runContainerCount = runContainerCount;
+    this.bitmapsCount = bitmapsCount;
+  }
+
+
+  /**
+   * Calculates what fraction of all containers is the `containerTypeCount`
+   */
+  public double containerFraction(int containerTypeCount) {
+    if (containerCount() == 0) {
+      return Double.NaN;
+    } else {
+      return ((double) containerTypeCount) / containerCount();
+    }
+  }
+
+  public ArrayContainersStats getArrayContainersStats() {
+    return arrayContainersStats;
+  }
+
+  @Override
+  public String toString() {
+    return "BitmapStatistics{"
+      + "bitmapsCount=" + bitmapsCount
+      + ", arrayContainersStats=" + arrayContainersStats
+      + ", bitmapContainerCount=" + bitmapContainerCount
+      + ", runContainerCount=" + runContainerCount
+      + '}';
+  }
+
+  public int containerCount() {
+    return arrayContainersStats.containersCount + bitmapContainerCount + runContainerCount;
+  }
+
+  BitmapStatistics merge(BitmapStatistics other) {
+    return new BitmapStatistics(
+      arrayContainersStats.merge(other.arrayContainersStats),
+      bitmapContainerCount + other.bitmapContainerCount,
+      runContainerCount + other.runContainerCount,
+      bitmapsCount + other.bitmapsCount);
+  }
+
+  public final static BitmapStatistics empty = new BitmapStatistics(
+      ArrayContainersStats.empty, 0, 0, 0);
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    BitmapStatistics that = (BitmapStatistics) o;
+    return bitmapsCount == that.bitmapsCount
+      && bitmapContainerCount == that.bitmapContainerCount
+      && runContainerCount == that.runContainerCount
+      && Objects.equals(arrayContainersStats, that.arrayContainersStats);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(bitmapsCount, bitmapContainerCount, runContainerCount);
+  }
+
+  public static class ArrayContainersStats {
+    final int containersCount;
+    final int cardinalitySum;
+
+
+    ArrayContainersStats(int containersCount, int cardinalitySum) {
+      this.containersCount = containersCount;
+      this.cardinalitySum = cardinalitySum;
+    }
+
+    ArrayContainersStats merge(ArrayContainersStats other) {
+      return new ArrayContainersStats(
+        containersCount + other.containersCount,
+        cardinalitySum + other.cardinalitySum);
+    }
+
+    /**
+     * Average cardinality of ArrayContainers
+     */
+    public int averageCardinality() {
+      if (containersCount == 0) {
+        return Integer.MAX_VALUE;
+      } else {
+        return cardinalitySum / containersCount;
+      }
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ArrayContainersStats that = (ArrayContainersStats) o;
+      return containersCount == that.containersCount
+        && cardinalitySum == that.cardinalitySum;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(containersCount, cardinalitySum);
+    }
+
+    @Override
+    public String toString() {
+      return "ArrayContainersStats{"
+        + "containersCount=" + containersCount
+        + ", cardinalitySum=" + cardinalitySum
+        + '}';
+    }
+
+    public final static ArrayContainersStats empty = new ArrayContainersStats(0, 0);
+  }
+
+
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/insights/NaiveWriterRecommender.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/insights/NaiveWriterRecommender.java
@@ -15,15 +15,15 @@ public class NaiveWriterRecommender {
     }
     StringBuilder sb = new StringBuilder();
     containerCountRecommendations(s, sb);
-    double acFraction = s.containerFraction(s.getArrayContainersStats().containersCount);
+    double acFraction = s.containerFraction(s.getArrayContainersStats().getContainersCount());
     if (acFraction > ArrayContainersDomination) {
-      if (s.arrayContainersStats.averageCardinality() < WorthUsingArraysCardinalityThreshold) {
+      if (s.getArrayContainersStats().averageCardinality() < WorthUsingArraysCardinalityThreshold) {
         arrayContainerRecommendations(s, sb);
       } else {
         denseArrayWarning(sb);
         constantMemoryRecommendation(s, sb);
       }
-    } else if (s.containerFraction(s.runContainerCount) > RunContainersDomination) {
+    } else if (s.containerFraction(s.getRunContainerCount()) > RunContainersDomination) {
       runContainerRecommendations(sb);
     } else {
       constantMemoryRecommendation(s, sb);
@@ -33,9 +33,9 @@ public class NaiveWriterRecommender {
 
   private static void denseArrayWarning(StringBuilder sb) {
     sb
-      .append("Most of your containers are array containers")
-      .append(", but with quite significant cardinality.\n")
-      .append("It should be better to start with .constantMemory()")
+      .append("Most of your containers are array containers, ")
+      .append("but with quite significant cardinality.\n")
+      .append("It should be better to start with .constantMemory() ")
       .append("that can scale down to ArrayContainer anyway.");
   }
 
@@ -49,7 +49,7 @@ public class NaiveWriterRecommender {
   }
 
   private static void constantMemoryRecommendation(BitmapStatistics s, StringBuilder sb) {
-    long buffersSizeBytes = s.bitmapsCount * Long.BYTES * 1024L;
+    long buffersSizeBytes = s.getBitmapsCount() * Long.BYTES * 1024L;
     long bufferSizeMiB = buffersSizeBytes / (1024 * 1024);
     sb
       .append(".constantMemory() is sensible default for most use cases.\n")
@@ -59,7 +59,7 @@ public class NaiveWriterRecommender {
   }
 
   private static void arrayContainerRecommendations(BitmapStatistics s, StringBuilder sb) {
-    double acFraction = s.containerFraction(s.getArrayContainersStats().containersCount);
+    double acFraction = s.containerFraction(s.getArrayContainersStats().getContainersCount());
     sb.append(".optimiseForArrays(), because fraction of ArrayContainers ")
       .append(acFraction)
       .append(" is over arbitrary threshold ")
@@ -71,7 +71,7 @@ public class NaiveWriterRecommender {
   }
 
   private static void containerCountRecommendations(BitmapStatistics basedOn, StringBuilder sb) {
-    int averageContainersCount = basedOn.containerCount() / basedOn.bitmapsCount;
+    int averageContainersCount = basedOn.containerCount() / basedOn.getBitmapsCount();
     sb.append(".initialCapacity(")
       .append(averageContainersCount)
       .append("), because on average each bitmap has ")

--- a/roaringbitmap/src/main/java/org/roaringbitmap/insights/NaiveWriterRecommender.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/insights/NaiveWriterRecommender.java
@@ -71,7 +71,7 @@ public class NaiveWriterRecommender {
   }
 
   private static void containerCountRecommendations(BitmapStatistics basedOn, StringBuilder sb) {
-    int averageContainersCount = basedOn.containerCount() / basedOn.getBitmapsCount();
+    long averageContainersCount = basedOn.containerCount() / basedOn.getBitmapsCount();
     sb.append(".initialCapacity(")
       .append(averageContainersCount)
       .append("), because on average each bitmap has ")

--- a/roaringbitmap/src/main/java/org/roaringbitmap/insights/NaiveWriterRecommender.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/insights/NaiveWriterRecommender.java
@@ -1,0 +1,86 @@
+package org.roaringbitmap.insights;
+
+/**
+ * The purpose of this class it to help user decide
+ * which {@link org.roaringbitmap.RoaringBitmapWriter} heuristic to use.
+ */
+public class NaiveWriterRecommender {
+  /**
+   * Based on the statistics it applies expert rules
+   * to help tuning the {@link org.roaringbitmap.RoaringBitmapWriter}
+   */
+  public static String recommend(BitmapStatistics s) {
+    if (s.containerCount() == 0) {
+      return "Empty statistics, cannot recommend.";
+    }
+    StringBuilder sb = new StringBuilder();
+    containerCountRecommendations(s, sb);
+    double acFraction = s.containerFraction(s.getArrayContainersStats().containersCount);
+    if (acFraction > ArrayContainersDomination) {
+      if (s.arrayContainersStats.averageCardinality() < WorthUsingArraysCardinalityThreshold) {
+        arrayContainerRecommendations(s, sb);
+      } else {
+        denseArrayWarning(sb);
+        constantMemoryRecommendation(s, sb);
+      }
+    } else if (s.containerFraction(s.runContainerCount) > RunContainersDomination) {
+      runContainerRecommendations(sb);
+    } else {
+      constantMemoryRecommendation(s, sb);
+    }
+    return sb.toString();
+  }
+
+  private static void denseArrayWarning(StringBuilder sb) {
+    sb
+      .append("Most of your containers are array containers")
+      .append(", but with quite significant cardinality.\n")
+      .append("It should be better to start with .constantMemory()")
+      .append("that can scale down to ArrayContainer anyway.");
+  }
+
+  private static void runContainerRecommendations(StringBuilder sb) {
+    sb
+      .append(".optimiseForRuns(), because over ")
+      .append(RunContainersDomination)
+      .append(" containers are of type RunContainer.\n")
+      .append("Make sure to try .constantMemory()")
+      .append("as inserting to RunContainers might not be that efficient.");
+  }
+
+  private static void constantMemoryRecommendation(BitmapStatistics s, StringBuilder sb) {
+    long buffersSizeBytes = s.bitmapsCount * Long.BYTES * 1024L;
+    long bufferSizeMiB = buffersSizeBytes / (1024 * 1024);
+    sb
+      .append(".constantMemory() is sensible default for most use cases.\n")
+      .append("Be prepared to allocate on heap ")
+      .append(bufferSizeMiB)
+      .append(" [MiB] just for buffers if you have them open at the same time.");
+  }
+
+  private static void arrayContainerRecommendations(BitmapStatistics s, StringBuilder sb) {
+    double acFraction = s.containerFraction(s.getArrayContainersStats().containersCount);
+    sb.append(".optimiseForArrays(), because fraction of ArrayContainers ")
+      .append(acFraction)
+      .append(" is over arbitrary threshold ")
+      .append(ArrayContainersDomination)
+      .append("\n")
+      .append(".expectedContainerSize(")
+      .append(s.getArrayContainersStats().averageCardinality())
+      .append(") to preallocate array containers for average number of elements.\n");
+  }
+
+  private static void containerCountRecommendations(BitmapStatistics basedOn, StringBuilder sb) {
+    int averageContainersCount = basedOn.containerCount() / basedOn.bitmapsCount;
+    sb.append(".initialCapacity(")
+      .append(averageContainersCount)
+      .append("), because on average each bitmap has ")
+      .append(averageContainersCount)
+      .append(" containers.\n");
+  }
+
+  private static double ArrayContainersDomination = 0.75;
+  private static int WorthUsingArraysCardinalityThreshold = 4096 / 2;
+  private static double RunContainersDomination = 0.8;
+
+}

--- a/roaringbitmap/src/test/java/org/roaringbitmap/RandomisedTestData.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/RandomisedTestData.java
@@ -25,7 +25,7 @@ public class RandomisedTestData {
               final IntStream stream;
               if (choice < rleLimit) {
                 stream = rleRegion();
-              } else if (choice < denseLimit) {
+              } else if (choice < rleLimit+ denseLimit) {
                 stream = denseRegion();
               } else {
                 stream = sparseRegion();

--- a/roaringbitmap/src/test/java/org/roaringbitmap/RandomisedTestData.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/RandomisedTestData.java
@@ -25,7 +25,7 @@ public class RandomisedTestData {
               final IntStream stream;
               if (choice < rleLimit) {
                 stream = rleRegion();
-              } else if (choice < rleLimit+ denseLimit) {
+              } else if (choice < denseLimit) {
                 stream = denseRegion();
               } else {
                 stream = sparseRegion();

--- a/roaringbitmap/src/test/java/org/roaringbitmap/insights/BitmapAnalyserTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/insights/BitmapAnalyserTest.java
@@ -1,0 +1,38 @@
+package org.roaringbitmap.insights;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.roaringbitmap.RandomisedTestData;
+import org.roaringbitmap.RoaringBitmap;
+
+import static org.junit.Assert.assertEquals;
+
+public class BitmapAnalyserTest {
+
+  @Test
+  public void analyseSingleBitmap() {
+    RoaringBitmap rb = new RoaringBitmap();
+    rb.add(1, 3, 6, 26, 110, 1024);
+    rb.add(70000L, 80000L);
+    for (int i = (5 << 16); i < (6 << 16); i++) {
+      rb.add(i);
+    }
+    BitmapStatistics result = BitmapAnalyser.analyse(rb);
+    BitmapStatistics expected = new BitmapStatistics(new BitmapStatistics.ArrayContainersStats(1, 7), 1, 1);
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void analyseRandomBitmap() {
+    double delta = 0.05;
+    double rleLimit = 0.1;
+    double denseLimit = 0.2;
+    double sparseLimit = 1 - rleLimit - denseLimit;
+    RoaringBitmap rb = RandomisedTestData.randomBitmap(1000, rleLimit, denseLimit);
+    BitmapStatistics result = BitmapAnalyser.analyse(rb);
+
+    Assert.assertTrue(Math.abs(rleLimit - result.containerFraction(result.runContainerCount)) < delta);
+    Assert.assertTrue(Math.abs(denseLimit - result.containerFraction(result.bitmapContainerCount)) < delta);
+    Assert.assertTrue(Math.abs(sparseLimit - result.containerFraction(result.arrayContainersStats.containersCount)) < delta);
+  }
+}

--- a/roaringbitmap/src/test/java/org/roaringbitmap/insights/BitmapAnalyserTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/insights/BitmapAnalyserTest.java
@@ -18,7 +18,7 @@ public class BitmapAnalyserTest {
       rb.add(i);
     }
     BitmapStatistics result = BitmapAnalyser.analyse(rb);
-    BitmapStatistics expected = new BitmapStatistics(new BitmapStatistics.ArrayContainersStats(1, 7), 1, 1);
+    BitmapStatistics expected = new BitmapStatistics(new BitmapStatistics.ArrayContainersStats(1, 6), 1, 1);
     assertEquals(expected, result);
   }
 

--- a/roaringbitmap/src/test/java/org/roaringbitmap/insights/BitmapAnalyserTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/insights/BitmapAnalyserTest.java
@@ -27,7 +27,7 @@ public class BitmapAnalyserTest {
 
   @Test
   public void analyseRandomBitmap() {
-    double delta = 0.05;
+    double delta = 0.1;
     double runFraction = 0.1;
     double bitmapFraction = 0.2;
     double denseLimit = runFraction + bitmapFraction;
@@ -35,14 +35,14 @@ public class BitmapAnalyserTest {
     RoaringBitmap rb = RandomisedTestData.randomBitmap(1000, runFraction, denseLimit);
     BitmapStatistics result = BitmapAnalyser.analyse(rb);
 
-    Assert.assertTrue(Math.abs(runFraction - result.containerFraction(result.getRunContainerCount())) < delta);
-    Assert.assertTrue(Math.abs(bitmapFraction - result.containerFraction(result.getBitmapContainerCount())) < delta);
-    Assert.assertTrue(Math.abs(arrayFraction - result.containerFraction(result.getArrayContainersStats().getContainersCount())) < delta);
+    Assert.assertEquals(runFraction, result.containerFraction(result.getRunContainerCount()), delta);
+    Assert.assertEquals(bitmapFraction, result.containerFraction(result.getBitmapContainerCount()), delta);
+    Assert.assertEquals(arrayFraction, result.containerFraction(result.getArrayContainersStats().getContainersCount()), delta);
   }
 
   @Test
   public void analyseRandomBitmaps() {
-    double delta = 0.05;
+    double delta = 0.1;
     double runFraction = 0.05;
     double bitmapFraction = 0.5;
     double denseLimit = runFraction + bitmapFraction;
@@ -56,9 +56,9 @@ public class BitmapAnalyserTest {
 
     BitmapStatistics result = BitmapAnalyser.analyse(bitmaps);
 
-    Assert.assertTrue(Math.abs(runFraction - result.containerFraction(result.getRunContainerCount())) < delta);
-    Assert.assertTrue(Math.abs(bitmapFraction - result.containerFraction(result.getBitmapContainerCount())) < delta);
-    Assert.assertTrue(Math.abs(arrayFraction - result.containerFraction(result.getArrayContainersStats().getContainersCount())) < delta);
+    Assert.assertEquals(runFraction, result.containerFraction(result.getRunContainerCount()), delta);
+    Assert.assertEquals(bitmapFraction, result.containerFraction(result.getBitmapContainerCount()), delta);
+    Assert.assertEquals(arrayFraction, result.containerFraction(result.getArrayContainersStats().getContainersCount()), delta);
     Assert.assertEquals(totalBitmaps, result.getBitmapsCount());
   }
 

--- a/roaringbitmap/src/test/java/org/roaringbitmap/insights/BitmapAnalyserTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/insights/BitmapAnalyserTest.java
@@ -5,6 +5,9 @@ import org.junit.Test;
 import org.roaringbitmap.RandomisedTestData;
 import org.roaringbitmap.RoaringBitmap;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 public class BitmapAnalyserTest {
@@ -25,14 +28,38 @@ public class BitmapAnalyserTest {
   @Test
   public void analyseRandomBitmap() {
     double delta = 0.05;
-    double rleLimit = 0.1;
-    double denseLimit = 0.2;
-    double sparseLimit = 1 - rleLimit - denseLimit;
-    RoaringBitmap rb = RandomisedTestData.randomBitmap(1000, rleLimit, denseLimit);
+    double runFraction = 0.1;
+    double bitmapFraction = 0.2;
+    double denseLimit = runFraction + bitmapFraction;
+    double arrayFraction = 1 - denseLimit;
+    RoaringBitmap rb = RandomisedTestData.randomBitmap(1000, runFraction, denseLimit);
     BitmapStatistics result = BitmapAnalyser.analyse(rb);
 
-    Assert.assertTrue(Math.abs(rleLimit - result.containerFraction(result.runContainerCount)) < delta);
-    Assert.assertTrue(Math.abs(denseLimit - result.containerFraction(result.bitmapContainerCount)) < delta);
-    Assert.assertTrue(Math.abs(sparseLimit - result.containerFraction(result.arrayContainersStats.containersCount)) < delta);
+    Assert.assertTrue(Math.abs(runFraction - result.containerFraction(result.getRunContainerCount())) < delta);
+    Assert.assertTrue(Math.abs(bitmapFraction - result.containerFraction(result.getBitmapContainerCount())) < delta);
+    Assert.assertTrue(Math.abs(arrayFraction - result.containerFraction(result.getArrayContainersStats().getContainersCount())) < delta);
   }
+
+  @Test
+  public void analyseRandomBitmaps() {
+    double delta = 0.05;
+    double runFraction = 0.05;
+    double bitmapFraction = 0.5;
+    double denseLimit = runFraction + bitmapFraction;
+    double arrayFraction = 1 - denseLimit;
+    List<RoaringBitmap> bitmaps = new ArrayList<>();
+    int totalBitmaps = 60;
+    for (int i = 0; i < totalBitmaps; i++) {
+      RoaringBitmap rb = RandomisedTestData.randomBitmap(80, runFraction, denseLimit);
+      bitmaps.add(rb);
+    }
+
+    BitmapStatistics result = BitmapAnalyser.analyse(bitmaps);
+
+    Assert.assertTrue(Math.abs(runFraction - result.containerFraction(result.getRunContainerCount())) < delta);
+    Assert.assertTrue(Math.abs(bitmapFraction - result.containerFraction(result.getBitmapContainerCount())) < delta);
+    Assert.assertTrue(Math.abs(arrayFraction - result.containerFraction(result.getArrayContainersStats().getContainersCount())) < delta);
+    Assert.assertEquals(totalBitmaps, result.getBitmapsCount());
+  }
+
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/insights/BitmapStatisticsTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/insights/BitmapStatisticsTest.java
@@ -1,0 +1,29 @@
+package org.roaringbitmap.insights;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BitmapStatisticsTest {
+
+  @Test
+  public void toStringWorks() {
+    BitmapStatistics statistics = new BitmapStatistics(
+      new BitmapStatistics.ArrayContainersStats(10, 50),
+      2,
+      1);
+
+    String string = statistics.toString();
+
+    Assert.assertTrue(string.contains(BitmapStatistics.class.getSimpleName()));
+  }
+
+  @Test
+  public void statsForEmpty() {
+    BitmapStatistics statistics = BitmapStatistics.empty;
+
+    double bitmapFraction = statistics.containerFraction(statistics.getBitmapContainerCount());
+    Assert.assertTrue(Double.isNaN(bitmapFraction));
+    long averageArraysCardinality = statistics.getArrayContainersStats().averageCardinality();
+    Assert.assertEquals(Long.MAX_VALUE, averageArraysCardinality);
+  }
+}

--- a/roaringbitmap/src/test/java/org/roaringbitmap/insights/NaiveWriterRecommenderTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/insights/NaiveWriterRecommenderTest.java
@@ -27,6 +27,24 @@ public class NaiveWriterRecommenderTest {
   }
 
   @Test
+  public void recommendForDenseArrays() {
+    int arrayContainerCount = 20000;
+    int denseAveragePerArrayContaier = 2500;
+    int bitmapContainerCount = 2;
+    int runContainerCount = 50;
+    int bitmapsCount = 10;
+    BitmapStatistics stats = new BitmapStatistics(
+      new BitmapStatistics.ArrayContainersStats(arrayContainerCount, arrayContainerCount * denseAveragePerArrayContaier),
+      bitmapContainerCount,
+      runContainerCount,
+      bitmapsCount);
+
+    String recommendation = NaiveWriterRecommender.recommend(stats);
+
+    Assert.assertTrue(recommendation.contains(".constantMemory()"));
+  }
+
+    @Test
   public void recommendForRuns() {
     int arrayContainerCount = 100;
     int averagePerArrayContaier = 10;
@@ -82,6 +100,12 @@ public class NaiveWriterRecommenderTest {
 
     Assert.assertTrue(recommendation.contains(".initialCapacity(526)"));
     Assert.assertTrue(recommendation.contains(".constantMemory()"));
+  }
+
+  @Test
+  public void notRecommendForEmptyStats(){
+    String recommendation = NaiveWriterRecommender.recommend(BitmapStatistics.empty);
+    Assert.assertFalse(recommendation.contains(".initialCapacity"));
   }
 
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/insights/NaiveWriterRecommenderTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/insights/NaiveWriterRecommenderTest.java
@@ -1,0 +1,87 @@
+package org.roaringbitmap.insights;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NaiveWriterRecommenderTest {
+
+  @Test
+  public void recommendForArrays() {
+    int arrayContainerCount = 20000;
+    int averagePerArrayContaier = 10;
+    int bitmapContainerCount = 2;
+    int runContainerCount = 50;
+    int bitmapsCount = 10;
+    BitmapStatistics stats = new BitmapStatistics(
+      new BitmapStatistics.ArrayContainersStats(arrayContainerCount, arrayContainerCount * averagePerArrayContaier),
+      bitmapContainerCount,
+      runContainerCount,
+      bitmapsCount);
+
+    String recommendation = NaiveWriterRecommender.recommend(stats);
+
+    //System.out.println(recommendation);
+    Assert.assertTrue(recommendation.contains(".initialCapacity(2005)"));
+    Assert.assertTrue(recommendation.contains(".optimiseForArrays()"));
+    Assert.assertTrue(recommendation.contains(".expectedContainerSize(10)"));
+  }
+
+  @Test
+  public void recommendForRuns() {
+    int arrayContainerCount = 100;
+    int averagePerArrayContaier = 10;
+    int bitmapContainerCount = 200;
+    int runContainerCount = 50000;
+    int bitmapsCount = 70;
+    BitmapStatistics stats = new BitmapStatistics(
+      new BitmapStatistics.ArrayContainersStats(arrayContainerCount, arrayContainerCount * averagePerArrayContaier),
+      bitmapContainerCount,
+      runContainerCount,
+      bitmapsCount);
+
+    String recommendation = NaiveWriterRecommender.recommend(stats);
+
+    Assert.assertTrue(recommendation.contains(".initialCapacity(718)"));
+    Assert.assertTrue(recommendation.contains(".optimiseForRuns()"));
+  }
+
+
+  @Test
+  public void recommendForUniform() {
+    int arrayContainerCount = 10000;
+    int averagePerArrayContaier = 10;
+    int bitmapContainerCount = 10000;
+    int runContainerCount = 10000;
+    int bitmapsCount = 120;
+    BitmapStatistics stats = new BitmapStatistics(
+      new BitmapStatistics.ArrayContainersStats(arrayContainerCount, arrayContainerCount * averagePerArrayContaier),
+      bitmapContainerCount,
+      runContainerCount,
+      bitmapsCount);
+
+    String recommendation = NaiveWriterRecommender.recommend(stats);
+
+    Assert.assertTrue(recommendation.contains(".initialCapacity(250)"));
+    Assert.assertTrue(recommendation.contains(".constantMemory()"));
+  }
+
+  @Test
+  public void recommendForBitmaps() {
+    int arrayContainerCount = 7;
+    int averagePerArrayContaier = 10;
+    int bitmapContainerCount = 100000;
+    int runContainerCount = 40;
+    int bitmapsCount = 190;
+    BitmapStatistics stats = new BitmapStatistics(
+      new BitmapStatistics.ArrayContainersStats(arrayContainerCount, arrayContainerCount * averagePerArrayContaier),
+      bitmapContainerCount,
+      runContainerCount,
+      bitmapsCount);
+
+    String recommendation = NaiveWriterRecommender.recommend(stats);
+
+    Assert.assertTrue(recommendation.contains(".initialCapacity(526)"));
+    Assert.assertTrue(recommendation.contains(".constantMemory()"));
+  }
+
+}


### PR DESCRIPTION
The method to gather statistics on internal representation of bitmap or bitmaps. 
They best express things like total count of containers and average capacity, so they may lead to false conclusions.

The statistics are used by naive version of Writer recommender.
I'd definitely need something like this for my bitmap builders use cases.

