### PR TITLE
Fix Java 8 compatibility issue

### DIFF
--- a/fuzz-tests/pom.xml
+++ b/fuzz-tests/pom.xml
@@ -43,8 +43,7 @@
                         <version>3.6.0</version>
                         <configuration>
                             <compilerVersion>${javac.target}</compilerVersion>
-                            <source>${javac.target}</source>
-                            <target>${javac.target}</target>
+                            <release>${javac.release}</release>
                             <verbose>true</verbose>
                             <fork>true</fork>
                             <showDeprecation>true</showDeprecation>

--- a/fuzz-tests/pom.xml
+++ b/fuzz-tests/pom.xml
@@ -43,7 +43,8 @@
                         <version>3.6.0</version>
                         <configuration>
                             <compilerVersion>${javac.target}</compilerVersion>
-                            <release>${javac.release}</release>
+                            <source>${javac.target}</source>
+                            <target>${javac.target}</target>
                             <verbose>true</verbose>
                             <fork>true</fork>
                             <showDeprecation>true</showDeprecation>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javac.target>1.8</javac.target>
+        <javac.release>8</javac.release>
 
         <!-- This location is OK for main module but not sub-modules -->
         <checkstyle.configLocation>${basedir}/roaringbitmap/style/roaring_google_checks.xml</checkstyle.configLocation>
@@ -163,8 +164,7 @@
                 <version>3.6.0</version>
                 <configuration>
                     <compilerVersion>${javac.target}</compilerVersion>
-                    <source>${javac.target}</source>
-                    <target>${javac.target}</target>
+                    <release>${javac.release}</release>
                     <verbose>true</verbose>
                     <fork>true</fork>
                     <showDeprecation>true</showDeprecation>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,9 @@
             <!-- Activated only in 'mvn release:perform' step (and not 'mvn release:prepare' step) -->
             <id>allModules</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!release</name>
+                </property>
             </activation>
 
             <!-- By default we want all modules to be visible, it is not true in 'mvn release:perform' step -->
@@ -137,6 +139,18 @@
                 <module>jmh</module>
                 <module>fuzz-tests</module>
             </modules>
+        </profile>
+
+        <!-- once java 8 support is dropped, this should be removed -->
+        <!-- along with <source> and <target> compiler options in favor of <release>-->
+        <profile>
+            <id>targetJava8NewerJdk</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>${javac.release}</maven.compiler.release>
+            </properties>
         </profile>
     </profiles>
 
@@ -164,7 +178,8 @@
                 <version>3.6.0</version>
                 <configuration>
                     <compilerVersion>${javac.target}</compilerVersion>
-                    <release>${javac.release}</release>
+                    <source>${javac.target}</source>
+                    <target>${javac.target}</target>
                     <verbose>true</verbose>
                     <fork>true</fork>
                     <showDeprecation>true</showDeprecation>


### PR DESCRIPTION
Fixes issue using artifacts built with jdk 9+ when run on java 8, which produces errors of the form:

```
java.lang.NoSuchMethodError: java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuffer;
	at org.roaringbitmap.buffer.ImmutableRoaringArray.<init>(ImmutableRoaringArray.java:51)
	at org.roaringbitmap.buffer.ImmutableRoaringBitmap.<init>(ImmutableRoaringBitmap.java:968)
...
```

This is due to changes to several `ByteBuffer` methods in java 9+ resulting in bytecode generated that includes mismatched return types when built with jdk 9 or newer, [as described in this issue](https://jira.mongodb.org/browse/JAVA-2559).

This PR fixes this issue by adding the `release` compiler flag, described in [JEP 247](http://openjdk.java.net/jeps/247). This is done by adding an additional maven profile that activates if jdk version used to build is 9 or greater which sets the property `maven.compiler.release` adding `--release=8` to the compiler flags.The `allModules` profile activation has been changed to be always applied unless the `release` profile is in use, since `activeByDefault` only applies a profile if no others are active.