### PR TITLE
Rank iterator short overflow bugfix

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -1326,8 +1326,8 @@ final class ArrayContainerShortIterator implements PeekableShortRankIterator {
   }
 
   @Override
-  public short peekNextRank() {
-    return (short) (pos + 1);
+  public int peekNextRank() {
+    return pos + 1;
   }
 
   @Override

--- a/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -1471,14 +1471,14 @@ class BitmapContainerShortIterator implements PeekableShortIterator {
 
 final class BitmapContainerShortRankIterator extends BitmapContainerShortIterator
     implements PeekableShortRankIterator {
-  short nextRank = 1;
+  int nextRank = 1;
 
   public BitmapContainerShortRankIterator(long[] p) {
     super(p);
   }
 
   @Override
-  public short peekNextRank() {
+  public int peekNextRank() {
     return nextRank;
   }
 

--- a/roaringbitmap/src/main/java/org/roaringbitmap/FastRankRoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/FastRankRoaringBitmap.java
@@ -294,7 +294,7 @@ public class FastRankRoaringBitmap extends RoaringBitmap {
 
     @Override
     public int peekNextRank() {
-      int iterRank = Util.toIntUnsigned(iter.peekNextRank());
+      int iterRank = iter.peekNextRank();
       if (pos > 0) {
         return FastRankRoaringBitmap.this.highToCumulatedCardinality[pos - 1] + iterRank;
       } else {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/PeekableShortRankIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/PeekableShortRankIterator.java
@@ -7,9 +7,13 @@ public interface PeekableShortRankIterator extends PeekableShortIterator {
 
   /**
    * peek in-container rank of the next value
+   *
+   * Uses integer because internal representation of rank is int
+   * and in-container rank lies in range 1-65536
+   *
    * @return rank of the next value
    */
-  short peekNextRank();
+  int peekNextRank();
 
   @Override
   PeekableShortRankIterator clone();

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -2693,7 +2693,7 @@ class RunContainerShortIterator implements PeekableShortIterator {
 class RunContainerShortRankIterator extends RunContainerShortIterator
     implements PeekableShortRankIterator {
 
-  short nextRank = 1;
+  int nextRank = 1;
 
   public RunContainerShortRankIterator(RunContainer p) {
     super(p);
@@ -2736,7 +2736,7 @@ class RunContainerShortRankIterator extends RunContainerShortIterator
   }
 
   @Override
-  public short peekNextRank() {
+  public int peekNextRank() {
     return nextRank;
   }
 

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIterator.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIterator.java
@@ -6,8 +6,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -22,10 +22,13 @@ public class TestRankIterator {
 
   @SuppressWarnings("unchecked")
 @Parameterized.Parameters(name = "{index}: advance by {1}")
-  public static Collection<Object[]> parameters() {
+  public static Collection<Object[]> parameters() throws CloneNotSupportedException {
     FastRankRoaringBitmap fast = getBitmap();
+    FastRankRoaringBitmap withFull = new FastRankRoaringBitmap(fast.highLowContainer.clone());
+    withFull.add(0L, 262144L);
+
     Assert.assertTrue(fast.isCacheDismissed());
-    return Lists.cartesianProduct(Collections.singletonList(fast), computeAdvances())
+    return Lists.cartesianProduct(Arrays.asList(fast, withFull), computeAdvances())
                 .stream().map(List::toArray).collect(Collectors.toList());
   }
 

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIterator.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIterator.java
@@ -21,7 +21,7 @@ import static org.roaringbitmap.RoaringBitmapWriter.writer;
 public class TestRankIterator {
 
   @SuppressWarnings("unchecked")
-@Parameterized.Parameters(name = "{index}: advance by {1}")
+  @Parameterized.Parameters(name = "{index}: advance by {1}")
   public static Collection<Object[]> parameters() throws CloneNotSupportedException {
     FastRankRoaringBitmap fast = getBitmap();
     FastRankRoaringBitmap withFull = new FastRankRoaringBitmap(fast.highLowContainer.clone());

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIteratorsOfContainers.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIteratorsOfContainers.java
@@ -178,6 +178,7 @@ public class TestRankIteratorsOfContainers {
     fillRange(container, 1024 + 3, 1024 + 5);
     fillRange(container, 1024 + 30, 1024 + 37);
     fillRange(container, 65535 - 7, 65535 - 5);
+    testContainerIterators(container);
   }
 
   @Test

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIteratorsOfContainers.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIteratorsOfContainers.java
@@ -179,4 +179,25 @@ public class TestRankIteratorsOfContainers {
     fillRange(container, 1024 + 30, 1024 + 37);
     fillRange(container, 65535 - 7, 65535 - 5);
   }
+
+  @Test
+  public void testOverflow() {
+    testContainerOverflow(new ArrayContainer(), false); // -- will be converted to BitmapContainer
+    testContainerOverflow(new BitmapContainer(), true);
+    testContainerOverflow(new RunContainer(), true);
+  }
+
+  private void testContainerOverflow(Container container, boolean checkSame) {
+    Container c1 = container.iadd(0, 65536);
+
+    if (checkSame) {
+      Assert.assertSame("bad test -- container was changed", container, c1);
+    }
+
+    PeekableShortRankIterator iterator = container.getShortRankIterator();
+    while (iterator.hasNext()) {
+      Assert.assertEquals(Util.toIntUnsigned(iterator.peekNext()) + 1, Util.toIntUnsigned(iterator.peekNextRank()));
+      iterator.next();
+    }
+  }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIteratorsOfContainers.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRankIteratorsOfContainers.java
@@ -10,9 +10,9 @@ public class TestRankIteratorsOfContainers {
     PeekableShortRankIterator iterator = c.getShortRankIterator();
     while (iterator.hasNext()) {
       short bit = iterator.peekNext();
-      short rank = iterator.peekNextRank();
+      int rank = iterator.peekNextRank();
 
-      Assert.assertEquals((short) c.rank(bit), rank);
+      Assert.assertEquals(c.rank(bit), rank);
 
       iterator.next();
     }
@@ -22,9 +22,9 @@ public class TestRankIteratorsOfContainers {
     PeekableShortRankIterator iterator = c.getShortRankIterator();
     while (iterator.hasNext()) {
       short bit = iterator.peekNext();
-      short rank = iterator.peekNextRank();
+      int rank = iterator.peekNextRank();
 
-      Assert.assertEquals((short) c.rank(bit), rank);
+      Assert.assertEquals(c.rank(bit), rank);
 
       iterator.nextAsInt();
     }
@@ -35,9 +35,9 @@ public class TestRankIteratorsOfContainers {
     short bit;
     while (iterator.hasNext()) {
       bit = iterator.peekNext();
-      short rank = iterator.peekNextRank();
+      int rank = iterator.peekNextRank();
 
-      Assert.assertEquals((short) c.rank(bit), rank);
+      Assert.assertEquals(c.rank(bit), rank);
 
       if ((Util.toIntUnsigned(bit) + advance < 65536)) {
         iterator.advanceIfNeeded((short) (bit + advance));
@@ -196,7 +196,7 @@ public class TestRankIteratorsOfContainers {
 
     PeekableShortRankIterator iterator = container.getShortRankIterator();
     while (iterator.hasNext()) {
-      Assert.assertEquals(Util.toIntUnsigned(iterator.peekNext()) + 1, Util.toIntUnsigned(iterator.peekNextRank()));
+      Assert.assertEquals(Util.toIntUnsigned(iterator.peekNext()) + 1, iterator.peekNextRank());
       iterator.next();
     }
   }


### PR DESCRIPTION
Unfortunately, I was introduced a very stupid bug in #263 for rank iterators.

Rank range is 1-65536, not 0-65535, so a short overflow happens for full containers.

There is a fix w/ regression tests.