### PR TITLE
avoid potentially costly write barrier

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/ContainerAppender.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ContainerAppender.java
@@ -81,7 +81,10 @@ public class ContainerAppender<C extends WordStorage<C>,
         currentKey = key;
       }
     }
-    container = container.add(lowbits(value));
+    C tmp = container.add(lowbits(value));
+    if (tmp != container) {
+      container = tmp;
+    }
   }
 
   @Override


### PR DESCRIPTION
This is a micro-optimisation (not reassigning a reference to itself, avoiding GC book-keeping code) which can make quite a big difference with G1. Here are some results (contrived so that container transitions actually happen, using G1 and a 4G heap) with the check:

```
Benchmark                                    (randomness)  (scenario)    (size)  Mode  Cnt      Score      Error  Units
WriteSequential.incrementalUseOrderedWriter           0.1      SPARSE    100000  avgt    5    626.854 ±    5.466  us/op
WriteSequential.incrementalUseOrderedWriter           0.1      SPARSE   1000000  avgt    5   5883.839 ±   12.712  us/op
WriteSequential.incrementalUseOrderedWriter           0.1      SPARSE  10000000  avgt    5  59593.382 ± 4854.011  us/op
WriteSequential.incrementalUseOrderedWriter           0.5      SPARSE    100000  avgt    5    616.751 ±   64.337  us/op
WriteSequential.incrementalUseOrderedWriter           0.5      SPARSE   1000000  avgt    5   6641.683 ± 2814.159  us/op
WriteSequential.incrementalUseOrderedWriter           0.5      SPARSE  10000000  avgt    5  59132.392 ±  650.023  us/op
```

And without the check as on master:

```
Benchmark                                    (randomness)  (scenario)    (size)  Mode  Cnt      Score       Error  Units
WriteSequential.incrementalUseOrderedWriter           0.1      SPARSE    100000  avgt    5    666.122 ±   269.082  us/op
WriteSequential.incrementalUseOrderedWriter           0.1      SPARSE   1000000  avgt    5   6781.537 ±    46.319  us/op
WriteSequential.incrementalUseOrderedWriter           0.1      SPARSE  10000000  avgt    5  69004.184 ±  1042.140  us/op
WriteSequential.incrementalUseOrderedWriter           0.5      SPARSE    100000  avgt    5    665.427 ±    33.605  us/op
WriteSequential.incrementalUseOrderedWriter           0.5      SPARSE   1000000  avgt    5   6925.019 ±   787.832  us/op
WriteSequential.incrementalUseOrderedWriter           0.5      SPARSE  10000000  avgt    5  76849.266 ± 19290.334  us/op

```