### PR TITLE
externalise buffer to allow reuse

### DIFF
--- a/jmh/src/main/java/org/roaringbitmap/iteration/BatchIteratorBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/iteration/BatchIteratorBenchmark.java
@@ -59,7 +59,7 @@ public class BatchIteratorBenchmark {
   @Benchmark
   public int batchIterateAsIntIterator() {
     int blackhole = 0;
-    IntIterator it = bitmap.getBatchIterator().asIntIterator(bufferSize);
+    IntIterator it = bitmap.getBatchIterator().asIntIterator(buffer);
     while (it.hasNext()) {
       blackhole ^= it.next();
     }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/BatchIntIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BatchIntIterator.java
@@ -19,9 +19,10 @@ public class BatchIntIterator implements IntIterator {
   /**
    * Wraps the batch iterator.
    * @param delegate the batch iterator to do the actual iteration
+   * @param buffer the buffer
    */
-  BatchIntIterator(BatchIterator delegate, int batchSize) {
-    this(delegate, 0, -1, new int[batchSize]);
+  BatchIntIterator(BatchIterator delegate, int[] buffer) {
+    this(delegate, 0, -1, buffer);
   }
 
   @Override

--- a/roaringbitmap/src/main/java/org/roaringbitmap/BatchIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BatchIterator.java
@@ -26,11 +26,11 @@ public interface BatchIterator extends Cloneable {
 
   /**
    * Creates a wrapper around the iterator so it behaves like an IntIterator
-   * @param batchSize - the size of the batch (128-256 should be best).
+   * @param buffer - array to buffer bits into (size 128-256 should be best).
    * @return the wrapper
    */
-  default IntIterator asIntIterator(int batchSize) {
-    return new BatchIntIterator(this, batchSize);
+  default IntIterator asIntIterator(int[] buffer) {
+    return new BatchIntIterator(this, buffer);
   }
 
 

--- a/roaringbitmap/src/test/java/org/roaringbitmap/RoaringBitmapBatchIteratorTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/RoaringBitmapBatchIteratorTest.java
@@ -69,7 +69,7 @@ public class RoaringBitmapBatchIteratorTest {
 
     @Test
     public void testBatchIteratorAsIntIterator() {
-        IntIterator it = bitmap.getBatchIterator().asIntIterator(128);
+        IntIterator it = bitmap.getBatchIterator().asIntIterator(new int[128]);
         RoaringBitmapWriter<RoaringBitmap> w = writer().constantMemory()
                 .initialCapacity(bitmap.highLowContainer.size).get();
         while (it.hasNext()) {

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/ImmutableRoaringBitmapBatchIteratorTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/ImmutableRoaringBitmapBatchIteratorTest.java
@@ -72,7 +72,7 @@ public class ImmutableRoaringBitmapBatchIteratorTest {
 
     @Test
     public void testBatchIteratorAsIntIterator() {
-        IntIterator it = bitmap.getBatchIterator().asIntIterator(128);
+        IntIterator it = bitmap.getBatchIterator().asIntIterator(new int[128]);
         RoaringBitmapWriter<MutableRoaringBitmap> w = bufferWriter().constantMemory()
                 .initialCapacity(bitmap.highLowContainer.size()).get();
         while (it.hasNext()) {


### PR DESCRIPTION
Sorry I meant to push this earlier. Reusing the buffer makes quite a big difference in preventing the TLAB filling up. 