### PR TITLE
fix termination condition bug in BatchIntIterator

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/BatchIntIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BatchIntIterator.java
@@ -30,10 +30,9 @@ public class BatchIntIterator implements IntIterator {
     if (i < mark) {
       return true;
     }
-    if (!delegate.hasNext()) {
+    if (!delegate.hasNext() || (mark = delegate.nextBatch(buffer)) == 0) {
       return false;
     }
-    mark = delegate.nextBatch(buffer);
     i = 0;
     return true;
   }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/RoaringBitmapBatchIteratorTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/RoaringBitmapBatchIteratorTest.java
@@ -28,6 +28,9 @@ public class RoaringBitmapBatchIteratorTest {
                 {testCase().withRunAt((1 << 15) | (1 << 11)).withBitmapAt((1 << 15) | (1 << 12)).withArrayAt((1 << 15) | (1 << 13)).withBitmapAt((1 << 15) | (1 << 14)).build()},
                 {RoaringBitmap.bitmapOf(IntStream.range(1 << 10, 1 << 26).filter(i -> (i & 1) == 0).toArray())},
                 {RoaringBitmap.bitmapOf(IntStream.range(1 << 10, 1 << 25).filter(i -> ((i >>> 8) & 1) == 0).toArray())},
+                {RoaringBitmap.bitmapOf(IntStream.range(0,127).toArray())},
+                {RoaringBitmap.bitmapOf(IntStream.range(0,1024).toArray())},
+                {RoaringBitmap.bitmapOf(IntStream.concat(IntStream.range(0,256), IntStream.range(1 << 16, (1 << 16) | 256)).toArray())},
                 {new RoaringBitmap()}
         };
     }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/ImmutableRoaringBitmapBatchIteratorTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/ImmutableRoaringBitmapBatchIteratorTest.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.roaringbitmap.BatchIterator;
 import org.roaringbitmap.IntIterator;
+import org.roaringbitmap.RoaringBitmap;
 import org.roaringbitmap.RoaringBitmapWriter;
 
 import java.util.concurrent.ThreadLocalRandom;
@@ -31,6 +32,10 @@ public class ImmutableRoaringBitmapBatchIteratorTest {
                 {testCase().withRunAt((1 << 15) | (1 << 11)).withBitmapAt((1 << 15) | (1 << 12)).withArrayAt((1 << 15) | (1 << 13)).withBitmapAt((1 << 15) | (1 << 14)).build().toMutableRoaringBitmap()},
                 {ImmutableRoaringBitmap.bitmapOf(IntStream.range(1 << 10, 1 << 26).filter(i -> (i & 1) == 0).toArray()).toMutableRoaringBitmap()},
                 {ImmutableRoaringBitmap.bitmapOf(IntStream.range(1 << 10, 1 << 25).filter(i -> ((i >>> 8) & 1) == 0).toArray()).toMutableRoaringBitmap()},
+                {ImmutableRoaringBitmap.bitmapOf(IntStream.range(0,128).toArray())},
+                {ImmutableRoaringBitmap.bitmapOf(IntStream.range(0,256).toArray())},
+                {ImmutableRoaringBitmap.bitmapOf(IntStream.range(0,1024).toArray())},
+                {ImmutableRoaringBitmap.bitmapOf(IntStream.concat(IntStream.range(0,256), IntStream.range(1 << 16, (1 << 16) | 256)).toArray())},
                 {new MutableRoaringBitmap()}
         };
     }


### PR DESCRIPTION
I introduced a bug in `BatchIntIterator`, this fixes it.