### PR TITLE
support contains on RoaringBitmapWriter without flushing

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -294,10 +294,7 @@ public final class BitmapContainer extends Container implements Cloneable {
    * Recomputes the cardinality of the bitmap.
    */
   protected void computeCardinality() {
-    this.cardinality = 0;
-    for (int k = 0; k < this.bitmap.length; k++) {
-      this.cardinality += Long.bitCount(this.bitmap[k]);
-    }
+    this.cardinality = Util.computeCardinality(bitmap);
   }
 
   protected int cardinalityInRange(int start, int end) {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ConstantMemoryContainerAppender.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ConstantMemoryContainerAppender.java
@@ -118,6 +118,16 @@ public class ConstantMemoryContainerAppender<T extends BitmapDataProvider
   }
 
   @Override
+  public boolean contains(int value) {
+    if (currentKey == value >>> 16) {
+      int low = toIntUnsigned(lowbits(value));
+      return (bitmap[(low >>> 6)] & (1L << low)) != 0;
+    } else {
+      return underlying.contains(value);
+    }
+  }
+
+  @Override
   public void reset() {
     currentKey = 0;
     underlying = newUnderlying.get();

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ConstantMemoryContainerAppender.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ConstantMemoryContainerAppender.java
@@ -132,7 +132,27 @@ public class ConstantMemoryContainerAppender<T extends BitmapDataProvider
 
   @Override
   public int getCardinality() {
-    return (int) (underlying.getLongCardinality() + computeCardinality(bitmap));
+    return (int) getLongCardinality();
+  }
+
+  @Override
+  public long getLongCardinality() {
+    return underlying.getLongCardinality() + computeCardinality(bitmap);
+  }
+
+  @Override
+  public void remove(int x) {
+    if (currentKey == x >>> 16) {
+      int low = x & 0xFFFF;
+      bitmap[low >>> 6] &= ~ (1L << low);
+    } else {
+      underlying.remove(x);
+    }
+  }
+
+  @Override
+  public void trim() {
+    underlying.trim();
   }
 
   @Override

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ContainerAppender.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ContainerAppender.java
@@ -81,10 +81,7 @@ public class ContainerAppender<C extends WordStorage<C>,
         currentKey = key;
       }
     }
-    C tmp = container.add(lowbits(value));
-    if (tmp != container) {
-      container = tmp;
-    }
+    setIfDifferent(container.add(lowbits(value)));
   }
 
   @Override
@@ -130,6 +127,25 @@ public class ContainerAppender<C extends WordStorage<C>,
   }
 
   @Override
+  public long getLongCardinality() {
+    return underlying.getLongCardinality() + container.getCardinality();
+  }
+
+  @Override
+  public void remove(int x) {
+    if (currentKey == x >>> 16) {
+      setIfDifferent(container.remove(lowbits(x)));
+    } else {
+      underlying.remove(x);
+    }
+  }
+
+  @Override
+  public void trim() {
+    underlying.trim();
+  }
+
+  @Override
   public boolean isEmpty() {
     return underlying.isEmpty() && container.isEmpty();
   }
@@ -165,5 +181,11 @@ public class ContainerAppender<C extends WordStorage<C>,
       return 1;
     }
     return 0;
+  }
+
+  private void setIfDifferent(C newContainer) {
+    if (newContainer != container) {
+      container = newContainer;
+    }
   }
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ContainerAppender.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ContainerAppender.java
@@ -125,6 +125,32 @@ public class ContainerAppender<C extends WordStorage<C>,
   }
 
   @Override
+  public int getCardinality() {
+    return (int) (underlying.getLongCardinality() + container.getCardinality());
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return underlying.isEmpty() && container.isEmpty();
+  }
+
+  @Override
+  public int first() {
+    if (underlying.isEmpty()) {
+      return (currentKey << 16) | container.first();
+    }
+    return underlying.first();
+  }
+
+  @Override
+  public int last() {
+    if (container.isEmpty()) {
+      return underlying.last();
+    }
+    return (currentKey << 16) | container.last();
+  }
+
+  @Override
   public void reset() {
     currentKey = 0;
     container = newContainer.get();

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ContainerAppender.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ContainerAppender.java
@@ -116,6 +116,15 @@ public class ContainerAppender<C extends WordStorage<C>,
   }
 
   @Override
+  public boolean contains(int value) {
+    if (currentKey == value >>> 16) {
+      return container.contains(lowbits(value));
+    } else {
+      return underlying.contains(value);
+    }
+  }
+
+  @Override
   public void reset() {
     currentKey = 0;
     container = newContainer.get();

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmapWriter.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmapWriter.java
@@ -262,6 +262,13 @@ public interface RoaringBitmapWriter<T extends BitmapDataProvider> extends Suppl
   }
 
   /**
+   * Returns true if the supplied value has been encountered
+   * @param value the value to check
+   * @return true if the value has been encountered
+   */
+  boolean contains(int value);
+
+  /**
    * Resets the writer so it can be reused, must release the reference to the underlying bitmap
    */
   void reset();

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmapWriter.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmapWriter.java
@@ -275,6 +275,26 @@ public interface RoaringBitmapWriter<T extends BitmapDataProvider> extends Suppl
   int getCardinality();
 
   /**
+   * Returns the number of distinct integers added to the bitmap (e.g., number of bits set).
+   * This returns a full 64-bit result.
+   *
+   * @return the cardinality
+   */
+  long getLongCardinality();
+
+  /**
+   * If present remove the specified integers (effectively, sets its bit value to false)
+   *
+   * @param x integer value representing the index in a bitmap
+   */
+  void remove(int x);
+
+  /**
+   * Recover allocated but unused memory.
+   */
+  void trim();
+
+  /**
    * Returns if the writer is currently empty
    * (i.e. if it has never been written to or has been reset)
    * @return true if the writer is empty

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmapWriter.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmapWriter.java
@@ -228,19 +228,6 @@ public interface RoaringBitmapWriter<T extends BitmapDataProvider> extends Suppl
   T getUnderlying();
 
   /**
-   * buffers a value to be added to the bitmap.
-   * @param value the value
-   */
-  void add(int value);
-
-  /**
-   * Add a range to the bitmap
-   * @param min the inclusive min value
-   * @param max the exclusive max value
-   */
-  void add(long min, long max);
-
-  /**
    * Adds many values to the bitmap.
    * @param values the values to add
    *
@@ -260,6 +247,27 @@ public interface RoaringBitmapWriter<T extends BitmapDataProvider> extends Suppl
     flush();
     return getUnderlying();
   }
+  /**
+   * Resets the writer so it can be reused, must release the reference to the underlying bitmap
+   */
+  void reset();
+
+
+  // TODO drop these and replace with extends BitmapDataProvider once feature parity is reached
+
+  /**
+   * buffers a value to be added to the bitmap.
+   * @param value the value
+   */
+  void add(int value);
+
+  /**
+   * Add a range to the bitmap
+   * @param min the inclusive min value
+   * @param max the exclusive max value
+   */
+  void add(long min, long max);
+
 
   /**
    * Returns true if the supplied value has been encountered
@@ -314,7 +322,57 @@ public interface RoaringBitmapWriter<T extends BitmapDataProvider> extends Suppl
   int last();
 
   /**
-   * Resets the writer so it can be reused, must release the reference to the underlying bitmap
+   * Estimate of the memory usage of this data structure.
+   *
+   * Internally, this is computed as a 64-bit counter.
+   *
+   * @return estimated memory usage.
    */
-  void reset();
+  default int getSizeInBytes() {
+    return (int) getLongSizeInBytes();
+  }
+
+  /**
+   * Estimate of the memory usage of this data structure. Provides
+   * full 64-bit number.
+   *
+   * @return estimated memory usage.
+   */
+  long getLongSizeInBytes();
+
+  /**
+   * Create a new bitmap of the same class, containing at most maxcardinality integers.
+   *
+   * @param x maximal cardinality
+   * @return a new bitmap with cardinality no more than maxcardinality
+   */
+  ImmutableBitmapDataProvider limit(int x);
+
+  /**
+   * Rank returns the number of integers that are smaller or equal to x (rank(infinity) would be
+   * getCardinality()).
+   *
+   * The value is internally computed as a 64-bit number.
+   *
+   * @param x upper limit
+   *
+   * @return the rank
+   * @see <a href="https://en.wikipedia.org/wiki/Ranking#Ranking_in_statistics">Ranking in statistics</a>
+   */
+  default int rank(int x) {
+    return (int)rankLong(x);
+  }
+
+  /**
+   * Rank returns the number of integers that are smaller or equal to x (rankLong(infinity) would be
+   * getLongCardinality()).
+   * Same as "rank" but produces a full 64-bit value.
+   *
+   * @param x upper limit
+   *
+   * @return the rank
+   * @see <a href="https://en.wikipedia.org/wiki/Ranking#Ranking_in_statistics">Ranking in statistics</a>
+   */
+  long rankLong(int x);
+
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmapWriter.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmapWriter.java
@@ -269,6 +269,31 @@ public interface RoaringBitmapWriter<T extends BitmapDataProvider> extends Suppl
   boolean contains(int value);
 
   /**
+   * Gets the (unsigned) cardinality of every bit added
+   * @return the cardinality
+   */
+  int getCardinality();
+
+  /**
+   * Returns if the writer is currently empty
+   * (i.e. if it has never been written to or has been reset)
+   * @return true if the writer is empty
+   */
+  boolean isEmpty();
+
+  /**
+   * Returns the first element
+   * @return the first element
+   */
+  int first();
+
+  /**
+   * Returns the last element
+   * @return the last element
+   */
+  int last();
+
+  /**
    * Resets the writer so it can be reused, must release the reference to the underlying bitmap
    */
   void reset();

--- a/roaringbitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/Util.java
@@ -575,6 +575,15 @@ public final class Util {
     return x & 0xFFFF;
   }
 
+
+  static int computeCardinality(long[] bitmap) {
+    int cardinality = 0;
+    for (long w : bitmap) {
+      cardinality += Long.bitCount(w);
+    }
+    return cardinality;
+  }
+
   /**
    * Look for value k in array in the range [begin,end). If the value is found, return its index. If
    * not, return -(i+1) where i is the index where the value would be inserted. The array is assumed

--- a/roaringbitmap/src/main/java/org/roaringbitmap/WordStorage.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/WordStorage.java
@@ -18,4 +18,8 @@ public interface WordStorage<T> {
 
   T remove(short value);
 
+  int getSizeInBytes();
+
+  int rank(short lowbits);
+
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/WordStorage.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/WordStorage.java
@@ -16,4 +16,6 @@ public interface WordStorage<T> {
 
   int last();
 
+  T remove(short value);
+
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/WordStorage.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/WordStorage.java
@@ -8,6 +8,12 @@ public interface WordStorage<T> {
 
   boolean isEmpty();
 
+  int getCardinality();
+
   T runOptimize();
+
+  int first();
+
+  int last();
 
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/WordStorage.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/WordStorage.java
@@ -4,6 +4,8 @@ public interface WordStorage<T> {
 
   T add(short value);
 
+  boolean contains(short value);
+
   boolean isEmpty();
 
   T runOptimize();

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmapWriter.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmapWriter.java
@@ -159,6 +159,43 @@ public class TestRoaringBitmapWriter {
   }
 
   @Test
+  public void testGetLongCardinality() {
+    RoaringBitmapWriter<? extends BitmapDataProvider> writer = supplier.get();
+    assertEquals(0L, writer.getLongCardinality());
+    writer.add(1);
+    assertEquals(1L, writer.getLongCardinality());
+    writer.add(100000);
+    assertEquals(2L, writer.getLongCardinality());
+    writer.flush();
+    assertEquals(2L, writer.getLongCardinality());
+    writer.add(10L, Integer.MAX_VALUE + 10L);
+    assertEquals(0x80000000L, writer.getLongCardinality());
+  }
+
+  @Test
+  public void testRemove() {
+    RoaringBitmapWriter<? extends BitmapDataProvider> writer = supplier.get();
+    assertEquals(0, writer.getCardinality());
+    writer.add(1);
+    writer.remove(1);
+    assertEquals(0, writer.getCardinality());
+    writer.add(100000);
+    writer.remove(100000);
+    assertEquals(0, writer.getCardinality());
+    writer.add(10L, 100010L);
+    writer.remove(11);
+    assertEquals(99999, writer.getCardinality());
+  }
+
+  @Test
+  public void testTrim() {
+    RoaringBitmapWriter<? extends BitmapDataProvider> writer = supplier.get();
+    writer.addMany(10, 5, 13, 100000);
+    writer.trim();
+    assertEquals(4, writer.getCardinality());
+  }
+
+  @Test
   public void bitmapShouldContainAllValuesAfterFlush() {
     RoaringBitmapWriter<? extends BitmapDataProvider> writer = supplier.get();
     writer.add(0);

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmapWriter.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmapWriter.java
@@ -9,6 +9,8 @@ import java.util.function.Supplier;
 
 import static java.lang.Integer.*;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.roaringbitmap.RoaringBitmapWriter.bufferWriter;
 import static org.roaringbitmap.RoaringBitmapWriter.writer;
 
@@ -84,6 +86,23 @@ public class TestRoaringBitmapWriter {
     writer.add(0);
     writer.flush();
     assertArrayEquals(RoaringBitmap.bitmapOf(0, 1 << 17).toArray(), writer.getUnderlying().toArray());
+  }
+
+  @Test
+  public void testContains() {
+    RoaringBitmapWriter<? extends BitmapDataProvider> writer = supplier.get();
+    writer.add(10);
+    writer.addMany(11, 20000, 65000);
+    assertTrue(writer.contains(10));
+    assertTrue(writer.contains(11));
+    assertTrue(writer.contains(20000));
+    assertTrue(writer.contains(65000));
+    assertFalse(writer.contains(12));
+    writer.add(100000, 101000);
+    assertTrue(writer.contains(100010));
+    assertFalse(writer.contains(101000));
+    writer.add(200000);
+    assertTrue(writer.contains(200000));
   }
 
   @Test

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmapWriter.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmapWriter.java
@@ -5,12 +5,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.util.NoSuchElementException;
 import java.util.function.Supplier;
 
 import static java.lang.Integer.*;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.roaringbitmap.RoaringBitmapWriter.bufferWriter;
 import static org.roaringbitmap.RoaringBitmapWriter.writer;
 
@@ -103,6 +102,60 @@ public class TestRoaringBitmapWriter {
     assertFalse(writer.contains(101000));
     writer.add(200000);
     assertTrue(writer.contains(200000));
+  }
+
+  @Test
+  public void testIsEmpty() {
+    RoaringBitmapWriter<? extends BitmapDataProvider> writer = supplier.get();
+    assertTrue(writer.isEmpty());
+    writer.add(1);
+    assertFalse(writer.isEmpty());
+    writer.add(100000);
+    assertFalse(writer.isEmpty());
+  }
+
+  @Test(expected = NoSuchElementException.class)
+  public void testFirstThrowsWhenEmpty() {
+    supplier.get().first();
+  }
+
+  @Test
+  public void testFirst() {
+    RoaringBitmapWriter<? extends BitmapDataProvider> writer = supplier.get();
+    writer.add(1);
+    assertEquals(1, writer.first());
+    writer.add(100000);
+    assertEquals(1, writer.first());
+    writer.flush();
+    assertEquals(1, writer.first());
+  }
+
+  @Test(expected = NoSuchElementException.class)
+  public void testLastThrowsWhenEmpty() {
+    supplier.get().last();
+  }
+
+  @Test
+  public void testLast() {
+    RoaringBitmapWriter<? extends BitmapDataProvider> writer = supplier.get();
+    writer.add(1);
+    assertEquals(1, writer.last());
+    writer.add(100000);
+    assertEquals(100000, writer.last());
+    writer.flush();
+    assertEquals(100000, writer.last());
+  }
+
+  @Test
+  public void testGetCardinality() {
+    RoaringBitmapWriter<? extends BitmapDataProvider> writer = supplier.get();
+    assertEquals(0, writer.getCardinality());
+    writer.add(1);
+    assertEquals(1, writer.getCardinality());
+    writer.add(100000);
+    assertEquals(2, writer.getCardinality());
+    writer.flush();
+    assertEquals(2, writer.getCardinality());
   }
 
   @Test


### PR DESCRIPTION
This enables a contains query on a bitmap being appended to without enforcing a flush, which improves subsequent insertion performance.