### PR TITLE
output failed fuzz tests to a JSON file with context about the cause …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ branches:
   only:
     - master
 
-script: 
-  - mvn javadoc:javadoc 
+script:
   - mvn checkstyle:check 
   - mvn test jacoco:report  -Dgpg.skip=true -DBITMAP_TYPES=ROARING_ONLY
 

--- a/fuzz-tests/pom.xml
+++ b/fuzz-tests/pom.xml
@@ -30,6 +30,18 @@
             <artifactId>RoaringBitmap</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.8</version>
+        </dependency>
+
     </dependencies>
 
     <profiles>

--- a/fuzz-tests/src/test/java/org/roaringbitmap/BufferFuzzer.java
+++ b/fuzz-tests/src/test/java/org/roaringbitmap/BufferFuzzer.java
@@ -1,5 +1,6 @@
 package org.roaringbitmap;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
 import org.junit.Test;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
@@ -13,7 +14,6 @@ import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
 import static org.roaringbitmap.RandomisedTestData.ITERATIONS;
-import static org.roaringbitmap.RandomisedTestData.randomBitmap;
 import static org.roaringbitmap.Util.toUnsignedLong;
 
 public class BufferFuzzer {
@@ -23,17 +23,12 @@ public class BufferFuzzer {
     boolean test(int index, MutableRoaringBitmap bitmap);
   }
 
-  public static <T> void verifyInvarianceArray(Function<ImmutableRoaringBitmap[], T> left,
-                                               Function<ImmutableRoaringBitmap[], T> right) {
-    verifyInvarianceArray(ITERATIONS, 1 << 5, 96, left, right);
-  }
-
   @FunctionalInterface
   interface RangeBitmapPredicate {
     boolean test(long min, long max, ImmutableRoaringBitmap bitmap);
   }
 
-  public static void verifyInvariance(int maxKeys, RangeBitmapPredicate pred) {
+  public static void verifyInvariance(String testName, int maxKeys, RangeBitmapPredicate pred) {
     ThreadLocalRandom random = ThreadLocalRandom.current();
     IntStream.range(0, ITERATIONS)
             .parallel()
@@ -41,34 +36,24 @@ public class BufferFuzzer {
             .forEach(bitmap -> {
               long min = random.nextLong(1L << 32);
               long max = random.nextLong(min,1L << 32);
-              Assert.assertTrue(pred.test(min, max, bitmap));
+              try {
+                Assert.assertTrue(pred.test(min, max, bitmap));
+              } catch (Throwable t) {
+                Reporter.report(testName, ImmutableMap.of("min", min, "max", max), t, bitmap);
+                throw t;
+              }
             });
   }
 
-  public static <T> void verifyInvarianceArray(int count,
-                                               int maxKeys,
-                                               int setSize,
-                                               Function<ImmutableRoaringBitmap[], T> left,
-                                               Function<ImmutableRoaringBitmap[], T> right) {
-    IntStream.range(0, count)
-            .parallel()
-            .mapToObj(i -> IntStream.range(0, setSize)
-                    .mapToObj(j -> randomBitmap(maxKeys))
-                    .toArray(ImmutableRoaringBitmap[]::new))
-            .forEach(bitmap -> Assert.assertEquals(left.apply(bitmap), right.apply(bitmap)));
-  }
-
-  public static <T> void verifyInvariance(Function<MutableRoaringBitmap, T> left, Function<MutableRoaringBitmap, T> right) {
-    verifyInvariance(ITERATIONS, 1 << 8, rb -> true, left, right);
-  }
-
-  public static <T> void verifyInvariance(Predicate<MutableRoaringBitmap> validity,
+  public static <T> void verifyInvariance(String testName,
+                                          Predicate<MutableRoaringBitmap> validity,
                                           Function<MutableRoaringBitmap, T> left,
                                           Function<MutableRoaringBitmap, T> right) {
-    verifyInvariance(ITERATIONS, 1 << 8, validity, left, right);
+    verifyInvariance(testName, ITERATIONS, 1 << 8, validity, left, right);
   }
 
-  public static <T> void verifyInvariance(int count,
+  public static <T> void verifyInvariance(String testName,
+                                          int count,
                                           int maxKeys,
                                           Predicate<MutableRoaringBitmap> validity,
                                           Function<MutableRoaringBitmap, T> left,
@@ -77,29 +62,40 @@ public class BufferFuzzer {
             .parallel()
             .mapToObj(i -> randomBitmap(maxKeys))
             .filter(validity)
-            .forEach(bitmap -> Assert.assertEquals(left.apply(bitmap), right.apply(bitmap)));
+            .forEach(bitmap -> {
+              try {
+                Assert.assertEquals(left.apply(bitmap), right.apply(bitmap));
+              } catch (Throwable t) {
+                Reporter.report(testName, ImmutableMap.of(), t, bitmap);
+                throw t;
+              }
+            });
   }
 
-  public static <T> void verifyInvariance(BiFunction<MutableRoaringBitmap, MutableRoaringBitmap, T> left,
-                                          BiFunction<MutableRoaringBitmap, MutableRoaringBitmap, T> right) {
-    verifyInvariance(ITERATIONS, 1 << 8, left, right);
-  }
-
-  public static <T> void verifyInvariance(BiPredicate<MutableRoaringBitmap, MutableRoaringBitmap> validity,
+  public static <T> void verifyInvariance(String testName,
                                           BiFunction<MutableRoaringBitmap, MutableRoaringBitmap, T> left,
                                           BiFunction<MutableRoaringBitmap, MutableRoaringBitmap, T> right) {
-    verifyInvariance(validity,ITERATIONS, 1 << 8, left, right);
+    verifyInvariance(testName, ITERATIONS, 1 << 8, left, right);
+  }
+
+  public static <T> void verifyInvariance(String testName,
+                                          BiPredicate<MutableRoaringBitmap, MutableRoaringBitmap> validity,
+                                          BiFunction<MutableRoaringBitmap, MutableRoaringBitmap, T> left,
+                                          BiFunction<MutableRoaringBitmap, MutableRoaringBitmap, T> right) {
+    verifyInvariance(testName, validity, ITERATIONS, 1 << 8, left, right);
   }
 
 
-  public static <T> void verifyInvariance(int count,
+  public static <T> void verifyInvariance(String testName,
+                                          int count,
                                           int maxKeys,
                                           BiFunction<MutableRoaringBitmap, MutableRoaringBitmap, T> left,
                                           BiFunction<MutableRoaringBitmap, MutableRoaringBitmap, T> right) {
-    verifyInvariance((l, r) -> true, count, maxKeys, left, right);
+    verifyInvariance(testName, (l, r) -> true, count, maxKeys, left, right);
   }
 
-  public static <T> void verifyInvariance(BiPredicate<MutableRoaringBitmap, MutableRoaringBitmap> validity,
+  public static <T> void verifyInvariance(String testName,
+                                          BiPredicate<MutableRoaringBitmap, MutableRoaringBitmap> validity,
                                           int count,
                                           int maxKeys,
                                           BiFunction<MutableRoaringBitmap, MutableRoaringBitmap, T> left,
@@ -110,21 +106,24 @@ public class BufferFuzzer {
               MutableRoaringBitmap one = randomBitmap(maxKeys);
               MutableRoaringBitmap two = randomBitmap(maxKeys);
               if (validity.test(one, two)) {
-                Assert.assertEquals(left.apply(one, two), right.apply(one, two));
+                try {
+                  Assert.assertEquals(left.apply(one, two), right.apply(one, two));
+                } catch (Throwable t) {
+                  Reporter.report(testName, ImmutableMap.of(), t, one, two);
+                  throw t;
+                }
               }
             });
   }
 
-  public static void verifyInvariance(IntBitmapPredicate predicate) {
-    verifyInvariance(rb -> true, predicate);
-  }
-
-  public static void verifyInvariance(Predicate<MutableRoaringBitmap> validity,
+  public static void verifyInvariance(String testName,
+                                      Predicate<MutableRoaringBitmap> validity,
                                       IntBitmapPredicate predicate) {
-    verifyInvariance(validity, ITERATIONS, 1 << 3, predicate);
+    verifyInvariance(testName, validity, ITERATIONS, 1 << 3, predicate);
   }
 
-  public static void verifyInvariance(Predicate<MutableRoaringBitmap> validity,
+  public static void verifyInvariance(String testName,
+                                      Predicate<MutableRoaringBitmap> validity,
                                       int count,
                                       int maxKeys,
                                       IntBitmapPredicate predicate) {
@@ -134,144 +133,165 @@ public class BufferFuzzer {
             .filter(validity)
             .forEach(bitmap -> {
               for (int i = 0; i < bitmap.getCardinality(); ++i) {
-                Assert.assertTrue(predicate.test(i, bitmap));
+                try {
+                  Assert.assertTrue(predicate.test(i, bitmap));
+                } catch (Throwable t) {
+                  Reporter.report(testName, ImmutableMap.of(), t, bitmap);
+                  throw t;
+                }
               }
             });
   }
 
-  public static <T> void verifyInvariance(T value, Function<MutableRoaringBitmap, T> func) {
-    verifyInvariance(ITERATIONS, 1 << 9, value, func);
+  public static <T> void verifyInvariance(String testName, T value, Function<MutableRoaringBitmap, T> func) {
+    verifyInvariance(testName, ITERATIONS, 1 << 9, value, func);
   }
 
-  public static <T> void verifyInvariance(int count,
+  public static <T> void verifyInvariance(String testName,
+                                          int count,
                                           int maxKeys,
                                           T value,
                                           Function<MutableRoaringBitmap, T> func) {
     IntStream.range(0, count)
             .parallel()
             .mapToObj(i -> randomBitmap(maxKeys))
-            .forEach(bitmap -> Assert.assertEquals(value, func.apply(bitmap)));
+            .forEach(bitmap -> {
+              try {
+                Assert.assertEquals(value, func.apply(bitmap));
+              } catch (Throwable t) {
+                Reporter.report(testName, ImmutableMap.of("value", value), t, bitmap);
+                throw t;
+              }
+            });
   }
 
   @Test
   public void rankSelectInvariance() {
-    verifyInvariance(bitmap -> !bitmap.isEmpty(), (i, rb) -> rb.rank(rb.select(i)) == i + 1);
+    verifyInvariance("rankSelectInvariance", bitmap -> !bitmap.isEmpty(), (i, rb) -> rb.rank(rb.select(i)) == i + 1);
   }
 
   @Test
   public void selectContainsInvariance() {
-    verifyInvariance(bitmap -> !bitmap.isEmpty(), (i, rb) -> rb.contains(rb.select(i)));
+    verifyInvariance("selectContainsInvariance", bitmap -> !bitmap.isEmpty(), (i, rb) -> rb.contains(rb.select(i)));
   }
 
   @Test
   public void firstSelect0Invariance() {
-    verifyInvariance(bitmap -> !bitmap.isEmpty(),
+    verifyInvariance("firstSelect0Invariance",
+            bitmap -> !bitmap.isEmpty(),
                      bitmap -> bitmap.first(),
                      bitmap -> bitmap.select(0));
   }
 
   @Test
   public void lastSelectCardinalityInvariance() {
-    verifyInvariance(bitmap -> !bitmap.isEmpty(),
+    verifyInvariance("lastSelectCardinalityInvariance",
+            bitmap -> !bitmap.isEmpty(),
                      bitmap -> bitmap.last(),
                      bitmap -> bitmap.select(bitmap.getCardinality() - 1));
   }
 
   @Test
   public void intersectsRangeFirstLastInvariance() {
-    verifyInvariance(true, rb -> rb.intersects(toUnsignedLong(rb.first()), toUnsignedLong(rb.last())));
+    verifyInvariance("intersectsRangeFirstLastInvariance", true, rb -> rb.intersects(toUnsignedLong(rb.first()), toUnsignedLong(rb.last())));
   }
 
   @Test
   public void containsRangeFirstLastInvariance() {
-    verifyInvariance(true,
+    verifyInvariance("containsRangeFirstLastInvariance", true,
             rb -> MutableRoaringBitmap.add(rb.clone(), toUnsignedLong(rb.first()), toUnsignedLong(rb.last()))
                     .contains(toUnsignedLong(rb.first()), toUnsignedLong(rb.last())));
   }
 
   @Test
   public void andCardinalityInvariance() {
-    verifyInvariance(ITERATIONS, 1 << 9,
+    verifyInvariance("andCardinalityInvariance", ITERATIONS, 1 << 9,
             (l, r) -> MutableRoaringBitmap.and(l, r).getCardinality(),
             (l, r) -> MutableRoaringBitmap.andCardinality(l, r));
   }
 
   @Test
   public void orCardinalityInvariance() {
-    verifyInvariance(ITERATIONS, 1 << 9,
+    verifyInvariance("orCardinalityInvariance", ITERATIONS, 1 << 9,
             (l, r) -> MutableRoaringBitmap.or(l, r).getCardinality(),
             (l, r) -> MutableRoaringBitmap.orCardinality(l, r));
   }
 
   @Test
   public void xorCardinalityInvariance() {
-    verifyInvariance(ITERATIONS, 1 << 9,
+    verifyInvariance("xorCardinalityInvariance", ITERATIONS, 1 << 9,
             (l, r) -> MutableRoaringBitmap.xor(l, r).getCardinality(),
             (l, r) -> MutableRoaringBitmap.xorCardinality(l, r));
   }
 
   @Test
   public void containsContainsInvariance() {
-    verifyInvariance((l, r) -> l.contains(r) && !r.equals(l),
+    verifyInvariance("containsContainsInvariance",
+            (l, r) -> l.contains(r) && !r.equals(l),
             (l, r) -> false,
             (l, r) -> !r.contains(l));
   }
 
   @Test
   public void containsAndInvariance() {
-    verifyInvariance((l, r) -> l.contains(r), (l, r) -> MutableRoaringBitmap.and(l, r).equals(r));
+    verifyInvariance("containsAndInvariance",
+            (l, r) -> l.contains(r),
+            (l, r) -> MutableRoaringBitmap.and(l, r).equals(r));
   }
 
   @Test
   public void andCardinalityContainsInvariance() {
-    verifyInvariance((l, r) -> MutableRoaringBitmap.andCardinality(l, r) == 0,
+    verifyInvariance("andCardinalityContainsInvariance",
+            (l, r) -> MutableRoaringBitmap.andCardinality(l, r) == 0,
             (l, r) -> false,
             (l, r) -> l.contains(r) || r.contains(l));
   }
 
   @Test
   public void sizeOfUnionOfDisjointSetsEqualsSumOfSizes() {
-    verifyInvariance((l, r) -> MutableRoaringBitmap.andCardinality(l, r) == 0,
+    verifyInvariance("sizeOfUnionOfDisjointSetsEqualsSumOfSizes",
+            (l, r) -> MutableRoaringBitmap.andCardinality(l, r) == 0,
             (l, r) -> l.getCardinality() + r.getCardinality(),
             (l, r) -> MutableRoaringBitmap.orCardinality(l, r));
   }
 
   @Test
   public void sizeOfDifferenceOfDisjointSetsEqualsSumOfSizes() {
-    verifyInvariance((l, r) -> MutableRoaringBitmap.andCardinality(l, r) == 0,
+    verifyInvariance("sizeOfDifferenceOfDisjointSetsEqualsSumOfSizes",
+            (l, r) -> MutableRoaringBitmap.andCardinality(l, r) == 0,
             (l, r) -> l.getCardinality() + r.getCardinality(),
             (l, r) -> MutableRoaringBitmap.xorCardinality(l, r));
   }
 
   @Test
   public void equalsSymmetryInvariance() {
-    verifyInvariance((l, r) -> l.equals(r), (l, r) -> r.equals(l));
+    verifyInvariance("equalsSymmetryInvariance", (l, r) -> l.equals(r), (l, r) -> r.equals(l));
   }
 
   @Test
   public void orOfDisjunction() {
-    verifyInvariance(ITERATIONS, 1 << 8,
+    verifyInvariance("orOfDisjunction", ITERATIONS, 1 << 8,
             (l, r) -> l,
             (l, r) -> MutableRoaringBitmap.or(l, MutableRoaringBitmap.and(l, r)));
   }
 
   @Test
   public void orCoversXor() {
-    verifyInvariance(ITERATIONS, 1 << 8,
+    verifyInvariance("orCoversXor", ITERATIONS, 1 << 8,
             (l, r) -> MutableRoaringBitmap.or(l, r),
             (l, r) -> MutableRoaringBitmap.or(l, MutableRoaringBitmap.xor(l, r)));
   }
 
   @Test
   public void xorInvariance() {
-    verifyInvariance(ITERATIONS, 1 << 9,
+    verifyInvariance("xorInvariance", ITERATIONS, 1 << 9,
             (l, r) -> MutableRoaringBitmap.xor(l, r),
             (l, r) -> MutableRoaringBitmap.andNot(MutableRoaringBitmap.or(l, r), MutableRoaringBitmap.and(l, r)));
   }
 
   @Test
   public void rangeCardinalityVsMaterialisedRange() {
-    verifyInvariance(1 << 9,
+    verifyInvariance("rangeCardinalityVsMaterialisedRange", 1 << 9,
             (min, max, bitmap) -> {
               MutableRoaringBitmap range = new MutableRoaringBitmap();
               range.add(min, max);

--- a/fuzz-tests/src/test/java/org/roaringbitmap/Reporter.java
+++ b/fuzz-tests/src/test/java/org/roaringbitmap/Reporter.java
@@ -1,0 +1,46 @@
+package org.roaringbitmap;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+import static java.util.stream.Collectors.toList;
+
+public class Reporter {
+
+  private static final String OUTPUT_DIR = System.getProperty("org.roaringbitmap.fuzz.output", System.getProperty("user.dir"));
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  public static synchronized void report(String testName, Map<String, Object> context, Throwable error, ImmutableBitmapDataProvider... bitmaps) {
+    try {
+      Map<String, Object> output = new LinkedHashMap<>();
+      output.put("testName", testName);
+      output.put("error", getStackTrace(error));
+      output.putAll(context);
+      String[] base64 = new String[bitmaps.length];
+      for (int i = 0; i < bitmaps.length; ++i) {
+        ByteArrayDataOutput serialised = ByteStreams.newDataOutput(bitmaps[i].serializedSizeInBytes());
+        bitmaps[i].serialize(serialised);
+        base64[i] = Base64.getEncoder().encodeToString(serialised.toByteArray());
+      }
+      output.put("bitmaps", base64);
+      Path dir = Paths.get(OUTPUT_DIR);
+      if (!Files.exists(dir)) {
+        Files.createDirectory(dir);
+      }
+      Files.write(dir.resolve(testName + "-" + UUID.randomUUID() + ".json"), MAPPER.writeValueAsBytes(output));
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private static String getStackTrace(Throwable t) {
+    return String.join("\n\t", Arrays.stream(t.getStackTrace()).map(StackTraceElement::toString).collect(toList()));
+  }
+}


### PR DESCRIPTION
…and location of the failure

This creates a JSON file when a fuzz test fails, it includes the test name, the stack trace, any context information relevant to writing a unit test reproducing the error, and the bitmaps involved as a list of base 64 encoded serialised bitmaps.