### PR TITLE
Serialisation performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ branches:
     - master
 
 script:
-  - mvn javadoc:javadoc
+  - mvn javadoc:javadoc -html5
   - mvn checkstyle:check 
   - mvn test jacoco:report  -Dgpg.skip=true -DBITMAP_TYPES=ROARING_ONLY
 

--- a/jmh/src/main/java/org/roaringbitmap/realdata/RealDataSerializationBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/realdata/RealDataSerializationBenchmark.java
@@ -73,6 +73,16 @@ public class RealDataSerializationBenchmark {
   }
 
   @Benchmark
+  public void directToBuffer(BenchmarkState state, Blackhole bh) throws IOException {
+    byte[][] buffers = state.buffers;
+    for (int i = 0; i < buffers.length; ++i) {
+      RoaringBitmap bitmap = new RoaringBitmap();
+      bitmap.deserialize(ByteBuffer.wrap(state.buffers[i]));
+      bh.consume(bitmap);
+    }
+  }
+
+  @Benchmark
   public void viaImmutable(BenchmarkState state, Blackhole bh) {
     byte[][] buffers = state.buffers;
     for (int i = 0; i < buffers.length; ++i) {

--- a/jmh/src/main/java/org/roaringbitmap/realdata/RealDataSerializationBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/realdata/RealDataSerializationBenchmark.java
@@ -26,6 +26,9 @@ public class RealDataSerializationBenchmark {
     })
     public String dataset;
 
+    @Param({"true", "false"})
+    boolean runOptimise;
+
     byte[][] buffers;
 
     @Setup(Level.Trial)
@@ -37,6 +40,9 @@ public class RealDataSerializationBenchmark {
       buffers = new byte[bitmaps.length][];
       int i = 0;
       for (RoaringBitmap bitmap : bitmaps) {
+        if (runOptimise) {
+          bitmap.runOptimize();
+        }
         ByteArrayOutputStream bos = new ByteArrayOutputStream(bitmap.serializedSizeInBytes());
         bitmap.serialize(new DataOutputStream(bos));
         buffers[i++] = bos.toByteArray();
@@ -46,22 +52,118 @@ public class RealDataSerializationBenchmark {
 
 
   @Benchmark
-  public void roaring(BenchmarkState state, Blackhole bh) throws IOException {
+  public void bufferBackedDataInput(BenchmarkState state, Blackhole bh) throws IOException {
       byte[][] buffers = state.buffers;
       for (int i = 0; i < buffers.length; ++i) {
           RoaringBitmap bitmap = new RoaringBitmap();
-          ByteArrayInputStream bis = new ByteArrayInputStream(state.buffers[i]);
-          bitmap.deserialize(new DataInputStream(bis));
+          bitmap.deserialize(new BufferDataInput(ByteBuffer.wrap(state.buffers[i])));
           bh.consume(bitmap);
       }
   }
 
   @Benchmark
-  public void buffer(BenchmarkState state, Blackhole bh) {
+  public void streamBackedDataInput(BenchmarkState state, Blackhole bh) throws IOException {
+    byte[][] buffers = state.buffers;
+    for (int i = 0; i < buffers.length; ++i) {
+      RoaringBitmap bitmap = new RoaringBitmap();
+      ByteArrayInputStream bis = new ByteArrayInputStream(state.buffers[i]);
+      bitmap.deserialize(new DataInputStream(bis));
+      bh.consume(bitmap);
+    }
+  }
+
+  @Benchmark
+  public void viaImmutable(BenchmarkState state, Blackhole bh) {
     byte[][] buffers = state.buffers;
     for (int i = 0; i < buffers.length; ++i) {
       RoaringBitmap bitmap = new ImmutableRoaringBitmap(ByteBuffer.wrap(state.buffers[i])).toRoaringBitmap();
       bh.consume(bitmap);
     }
   }
+
+  public static class BufferDataInput implements DataInput {
+
+    private final ByteBuffer data;
+
+    public BufferDataInput(ByteBuffer data) {
+      this.data = data;
+    }
+
+    @Override
+    public void readFully(byte[] bytes) throws IOException {
+      data.get(bytes);
+    }
+
+    @Override
+    public void readFully(byte[] bytes, int i, int i1) throws IOException {
+      data.get(bytes, i, i1);
+    }
+
+    @Override
+    public int skipBytes(int i) throws IOException {
+      data.position(data.position() + i);
+      return data.position();
+    }
+
+    @Override
+    public boolean readBoolean() throws IOException {
+      return data.get() != 0;
+    }
+
+    @Override
+    public byte readByte() throws IOException {
+      return data.get();
+    }
+
+    @Override
+    public int readUnsignedByte() throws IOException {
+      return data.get() & 0xFF;
+    }
+
+    @Override
+    public short readShort() throws IOException {
+      return data.getShort();
+    }
+
+    @Override
+    public int readUnsignedShort() throws IOException {
+      return data.getShort() & 0xffff;
+    }
+
+    @Override
+    public char readChar() throws IOException {
+      return data.getChar();
+    }
+
+    @Override
+    public int readInt() throws IOException {
+      return data.getInt();
+    }
+
+    @Override
+    public long readLong() throws IOException {
+      return data.getLong();
+    }
+
+    @Override
+    public float readFloat() throws IOException {
+      return data.getFloat();
+    }
+
+    @Override
+    public double readDouble() throws IOException {
+      return data.getDouble();
+    }
+
+    @Override
+    public String readLine() throws IOException {
+      return null;
+    }
+
+    @Override
+    public String readUTF() throws IOException {
+      return null;
+    }
+  }
+
 }

--- a/jmh/src/main/java/org/roaringbitmap/realdata/RealDataSerializationBenchmark.java
+++ b/jmh/src/main/java/org/roaringbitmap/realdata/RealDataSerializationBenchmark.java
@@ -1,0 +1,67 @@
+package org.roaringbitmap.realdata;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.roaringbitmap.RoaringBitmap;
+import org.roaringbitmap.ZipRealDataRetriever;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.util.stream.StreamSupport;
+
+import static org.roaringbitmap.RealDataset.*;
+
+public class RealDataSerializationBenchmark {
+
+  @State(Scope.Benchmark)
+  public static class BenchmarkState {
+
+
+    @Param({
+            CENSUS_INCOME, CENSUS1881, DIMENSION_008,
+            DIMENSION_003, DIMENSION_033, USCENSUS2000,
+            WEATHER_SEPT_85, WIKILEAKS_NOQUOTES, CENSUS_INCOME_SRT, CENSUS1881_SRT, WEATHER_SEPT_85_SRT,
+            WIKILEAKS_NOQUOTES_SRT
+    })
+    public String dataset;
+
+    byte[][] buffers;
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+      ZipRealDataRetriever dataRetriever = new ZipRealDataRetriever(dataset);
+      RoaringBitmap[] bitmaps = StreamSupport.stream(dataRetriever.fetchBitPositions().spliterator(), false)
+              .map(RoaringBitmap::bitmapOf)
+              .toArray(RoaringBitmap[]::new);
+      buffers = new byte[bitmaps.length][];
+      int i = 0;
+      for (RoaringBitmap bitmap : bitmaps) {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream(bitmap.serializedSizeInBytes());
+        bitmap.serialize(new DataOutputStream(bos));
+        buffers[i++] = bos.toByteArray();
+      }
+    }
+  }
+
+
+  @Benchmark
+  public void roaring(BenchmarkState state, Blackhole bh) throws IOException {
+      byte[][] buffers = state.buffers;
+      for (int i = 0; i < buffers.length; ++i) {
+          RoaringBitmap bitmap = new RoaringBitmap();
+          ByteArrayInputStream bis = new ByteArrayInputStream(state.buffers[i]);
+          bitmap.deserialize(new DataInputStream(bis));
+          bh.consume(bitmap);
+      }
+  }
+
+  @Benchmark
+  public void buffer(BenchmarkState state, Blackhole bh) {
+    byte[][] buffers = state.buffers;
+    for (int i = 0; i < buffers.length; ++i) {
+      RoaringBitmap bitmap = new ImmutableRoaringBitmap(ByteBuffer.wrap(state.buffers[i])).toRoaringBitmap();
+      bh.consume(bitmap);
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>3.0.1</version>
+                        <configuration>
+                            <additionalOptions>-html5</additionalOptions>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
@@ -6,7 +6,10 @@ package org.roaringbitmap;
 
 
 import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.NoSuchElementException;
 
 import static org.roaringbitmap.Util.compareUnsigned;
@@ -261,6 +264,89 @@ public final class RoaringArray implements Cloneable, Externalizable, Appendable
     final int range = end - begin;
     System.arraycopy(this.keys, begin, this.keys, newBegin, range);
     System.arraycopy(this.values, begin, this.values, newBegin, range);
+  }
+
+  /**
+   * Deserialize.
+   *
+   * @param buffer any ByteBuffer, LITTLE_ENDIAN preferred
+   * @throws IOException Signals that an I/O exception has occurred.
+   * @throws InvalidRoaringFormat if a Roaring Bitmap cookie
+   *             is missing.
+   */
+  public void deserialize(ByteBuffer buffer) {
+    ByteBuffer buf = buffer.order() == ByteOrder.LITTLE_ENDIAN
+            ? buffer
+            : buffer.order(ByteOrder.LITTLE_ENDIAN);
+    clear();
+    final int cookie = buf.getInt();
+    if ((cookie & 0xFFFF) != SERIAL_COOKIE && cookie != SERIAL_COOKIE_NO_RUNCONTAINER) {
+      throw new InvalidRoaringFormat("I failed to find a valid cookie.");
+    }
+    this.size = ((cookie & 0xFFFF) == SERIAL_COOKIE) ? (cookie >>> 16) + 1 : buf.getInt();
+    // logically we cannot have more than (1<<16) containers.
+    if(this.size > (1<<16) ) {
+      throw new InvalidRoaringFormat("Size too large");
+    }
+    if ((this.keys == null) || (this.keys.length < this.size)) {
+      this.keys = new short[this.size];
+      this.values = new Container[this.size];
+    }
+
+
+    byte[] bitmapOfRunContainers = null;
+    boolean hasrun = (cookie & 0xFFFF) == SERIAL_COOKIE;
+    if (hasrun) {
+      bitmapOfRunContainers = new byte[(size + 7) / 8];
+      buf.get(bitmapOfRunContainers);
+    }
+
+    final short[] keys = new short[this.size];
+    final int[] cardinalities = new int[this.size];
+    final BitSet isBitmap = new BitSet(this.size);
+    for (int k = 0; k < this.size; ++k) {
+      keys[k] = buf.getShort();
+      cardinalities[k] = 1 + (0xFFFF & buf.getShort());
+
+      isBitmap.set(k, cardinalities[k] > ArrayContainer.DEFAULT_MAX_SIZE);
+      if (bitmapOfRunContainers != null && (bitmapOfRunContainers[k >>> 3] & (1 << (k & 7))) != 0) {
+        isBitmap.set(k, false);
+      }
+    }
+    if ((!hasrun) || (this.size >= NO_OFFSET_THRESHOLD)) {
+      // skipping the offsets
+      buf.position(buf.position() + this.size * 4);
+    }
+    // Reading the containers
+    for (int k = 0; k < this.size; ++k) {
+      Container val;
+      if (isBitmap.get(k)) {
+        final long[] bitmapArray = new long[BitmapContainer.MAX_CAPACITY / 64];
+        // little endian
+        for (int l = 0; l < bitmapArray.length; ++l) {
+          bitmapArray[l] = buf.getLong();
+        }
+        val = new BitmapContainer(bitmapArray, cardinalities[k]);
+      } else if (bitmapOfRunContainers != null
+              && ((bitmapOfRunContainers[k >>> 3] & (1 << (k & 7))) != 0)) {
+        // cf RunContainer.writeArray()
+        int nbrruns = Util.toIntUnsigned(buf.getShort());
+        final short[] lengthsAndValues = new short[2 * nbrruns];
+
+        for (int j = 0; j < 2 * nbrruns; ++j) {
+          lengthsAndValues[j] = buf.getShort();
+        }
+        val = new RunContainer(lengthsAndValues, nbrruns);
+      } else {
+        final short[] shortArray = new short[cardinalities[k]];
+        for (int l = 0; l < shortArray.length; ++l) {
+          shortArray[l] = buf.getShort();
+        }
+        val = new ArrayContainer(shortArray);
+      }
+      this.keys[k] = keys[k];
+      this.values[k] = val;
+    }
   }
 
   /**

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
@@ -277,7 +277,7 @@ public final class RoaringArray implements Cloneable, Externalizable, Appendable
   public void deserialize(ByteBuffer buffer) {
     ByteBuffer buf = buffer.order() == ByteOrder.LITTLE_ENDIAN
             ? buffer
-            : buffer.order(ByteOrder.LITTLE_ENDIAN);
+            : buffer.asReadOnlyBuffer().order(ByteOrder.LITTLE_ENDIAN);
     clear();
     final int cookie = buf.getInt();
     if ((cookie & 0xFFFF) != SERIAL_COOKIE && cookie != SERIAL_COOKIE_NO_RUNCONTAINER) {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
+import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -1426,6 +1427,23 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
       }
     }
     return true;
+  }
+
+  /**
+   * Deserialize (retrieve) this bitmap.
+   * See format specification at https://github.com/RoaringBitmap/RoaringFormatSpec
+   *
+   * The current bitmap is overwritten.
+   *
+   * @param buffer the byte buffer (can be mapped, direct, array backed etc.
+   * @throws IOException Signals that an I/O exception has occurred.
+   */
+  public void deserialize(ByteBuffer buffer) throws IOException {
+    try {
+      this.highLowContainer.deserialize(buffer);
+    } catch(InvalidRoaringFormat cookie) {
+      throw cookie.toIOException();// we convert it to an IOException
+    }
   }
 
 

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -18,6 +18,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.*;
+import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.stream.IntStream;
 
@@ -3656,6 +3657,119 @@ public class TestRoaringBitmap {
     final RoaringBitmap rrback = new RoaringBitmap();
     final ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
     rrback.deserialize(new DataInputStream(bis));
+    Assert.assertEquals(rr.getCardinality(), rrback.getCardinality());
+    Assert.assertTrue(rr.equals(rrback));
+  }
+
+
+  @Test
+  public void testSerializationByteBuffer() throws IOException {
+    final RoaringBitmap rr = new RoaringBitmap();
+    for (int k = 65000; k < 2 * 65000; ++k) {
+      rr.add(k);
+    }
+    final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    // Note: you could use a file output steam instead of
+    // ByteArrayOutputStream
+    int howmuch = rr.serializedSizeInBytes();
+    final DataOutputStream oo = new DataOutputStream(bos);
+    rr.serialize(oo);
+    oo.close();
+    Assert.assertEquals(howmuch, bos.toByteArray().length);
+    final RoaringBitmap rrback = new RoaringBitmap();
+    final ByteBuffer buf = ByteBuffer.wrap(bos.toByteArray());
+    rrback.deserialize(buf);
+    Assert.assertEquals(rr.getCardinality(), rrback.getCardinality());
+    Assert.assertTrue(rr.equals(rrback));
+  }
+
+
+
+  @Test
+  public void testSerializationByteBufferBigInts() throws IOException {
+    final RoaringBitmap rr = new RoaringBitmap();
+    for (int k = 65000; k < 2 * 65000; ++k) {
+      rr.add((1<<31)+k);
+    }
+    final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    // Note: you could use a file output steam instead of
+    // ByteArrayOutputStream
+    int howmuch = rr.serializedSizeInBytes();
+    final DataOutputStream oo = new DataOutputStream(bos);
+    rr.serialize(oo);
+    oo.close();
+    Assert.assertEquals(howmuch, bos.toByteArray().length);
+    final RoaringBitmap rrback = new RoaringBitmap();
+    final ByteBuffer buf = ByteBuffer.wrap(bos.toByteArray());
+    rrback.deserialize(buf);
+    Assert.assertEquals(rr.getCardinality(), rrback.getCardinality());
+    Assert.assertTrue(rr.equals(rrback));
+  }
+
+
+
+
+
+  @Test
+  public void testSerializationByteBuffer2() throws IOException {
+    final RoaringBitmap rr = new RoaringBitmap();
+    for (int k = 200; k < 400; ++k) {
+      rr.add(k);
+    }
+    final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    // Note: you could use a file output steam instead of
+    // ByteArrayOutputStream
+    int howmuch = rr.serializedSizeInBytes();
+    final DataOutputStream oo = new DataOutputStream(bos);
+    rr.serialize(oo);
+    oo.close();
+    Assert.assertEquals(howmuch, bos.toByteArray().length);
+    final RoaringBitmap rrback = new RoaringBitmap();
+    final ByteBuffer buf = ByteBuffer.wrap(bos.toByteArray());
+    rrback.deserialize(buf);
+    Assert.assertEquals(rr.getCardinality(), rrback.getCardinality());
+    Assert.assertTrue(rr.equals(rrback));
+  }
+
+  @Test
+  public void testSerializationByteBuffer3() throws IOException {
+    final RoaringBitmap rr = new RoaringBitmap();
+    for (int k = 65000; k < 2 * 65000; ++k) {
+      rr.add(k);
+    }
+    rr.add(1444000);
+    final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    // Note: you could use a file output steam instead of
+    // ByteArrayOutputStream
+    int howmuch = rr.serializedSizeInBytes();
+    final DataOutputStream oo = new DataOutputStream(bos);
+    rr.serialize(oo);
+    oo.close();
+    Assert.assertEquals(howmuch, bos.toByteArray().length);
+    final RoaringBitmap rrback = new RoaringBitmap();
+    final ByteBuffer buf = ByteBuffer.wrap(bos.toByteArray());
+    rrback.deserialize(buf);
+    Assert.assertEquals(rr.getCardinality(), rrback.getCardinality());
+    Assert.assertTrue(rr.equals(rrback));
+  }
+
+  @Test
+  public void testSerializationByteBuffer4() throws IOException {
+    final RoaringBitmap rr = new RoaringBitmap();
+    for (int k = 1; k <= 10000000; k += 10) {
+      rr.add(k);
+    }
+    final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    // Note: you could use a file output steam instead of
+    // ByteArrayOutputStream
+    int howmuch = rr.serializedSizeInBytes();
+    final DataOutputStream oo = new DataOutputStream(bos);
+    rr.serialize(oo);
+    oo.close();
+    Assert.assertEquals(howmuch, bos.toByteArray().length);
+    final RoaringBitmap rrback = new RoaringBitmap();
+    final ByteBuffer buf = ByteBuffer.wrap(bos.toByteArray());
+    rrback.deserialize(buf);
     Assert.assertEquals(rr.getCardinality(), rrback.getCardinality());
     Assert.assertTrue(rr.equals(rrback));
   }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestSerializationViaByteBuffer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestSerializationViaByteBuffer.java
@@ -1,0 +1,92 @@
+package org.roaringbitmap;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class TestSerializationViaByteBuffer {
+
+  @Parameterized.Parameters
+  public static Object[][] params() {
+    return new Object[][] {
+            { SeededTestData.randomBitmap(2), ByteOrder.BIG_ENDIAN },
+            { SeededTestData.randomBitmap(2), ByteOrder.LITTLE_ENDIAN },
+            { SeededTestData.randomBitmap(3), ByteOrder.BIG_ENDIAN },
+            { SeededTestData.randomBitmap(3), ByteOrder.LITTLE_ENDIAN },
+            { SeededTestData.randomBitmap(4), ByteOrder.BIG_ENDIAN },
+            { SeededTestData.randomBitmap(4), ByteOrder.LITTLE_ENDIAN },
+            { SeededTestData.randomBitmap(5), ByteOrder.BIG_ENDIAN },
+            { SeededTestData.randomBitmap(5), ByteOrder.LITTLE_ENDIAN },
+            { SeededTestData.randomBitmap(6), ByteOrder.BIG_ENDIAN },
+            { SeededTestData.randomBitmap(6), ByteOrder.LITTLE_ENDIAN },
+            { SeededTestData.randomBitmap(7), ByteOrder.BIG_ENDIAN },
+            { SeededTestData.randomBitmap(7), ByteOrder.LITTLE_ENDIAN },
+            { SeededTestData.randomBitmap(8), ByteOrder.BIG_ENDIAN },
+            { SeededTestData.randomBitmap(8), ByteOrder.LITTLE_ENDIAN },
+            { SeededTestData.randomBitmap(9), ByteOrder.BIG_ENDIAN },
+            { SeededTestData.randomBitmap(9), ByteOrder.LITTLE_ENDIAN },
+            { SeededTestData.randomBitmap(10), ByteOrder.BIG_ENDIAN },
+            { SeededTestData.randomBitmap(10), ByteOrder.LITTLE_ENDIAN },
+            { SeededTestData.randomBitmap(11), ByteOrder.BIG_ENDIAN },
+            { SeededTestData.randomBitmap(11), ByteOrder.LITTLE_ENDIAN },
+            { SeededTestData.randomBitmap(12), ByteOrder.BIG_ENDIAN },
+            { SeededTestData.randomBitmap(12), ByteOrder.LITTLE_ENDIAN },
+            { SeededTestData.randomBitmap(13), ByteOrder.BIG_ENDIAN },
+            { SeededTestData.randomBitmap(13), ByteOrder.LITTLE_ENDIAN },
+            { SeededTestData.randomBitmap(14), ByteOrder.BIG_ENDIAN },
+            { SeededTestData.randomBitmap(14), ByteOrder.LITTLE_ENDIAN },
+            { SeededTestData.randomBitmap(15), ByteOrder.BIG_ENDIAN },
+            { SeededTestData.randomBitmap(15), ByteOrder.LITTLE_ENDIAN },
+    };
+  }
+
+  private final RoaringBitmap input;
+  private final ByteOrder order;
+  private final byte[] serialised;
+
+  public TestSerializationViaByteBuffer(RoaringBitmap input, ByteOrder order) throws IOException {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(bos)) {
+      input.serialize(new DataOutputStream(bos));
+    }
+    this.serialised = bos.toByteArray();
+    this.order = order;
+    this.input = input;
+  }
+
+  @Test
+  public void testDeserializeFromMappedFile() throws IOException {
+    Path file = Paths.get(System.getProperty("user.dir")).resolve(UUID.randomUUID().toString());
+    Files.createFile(file);
+    try (RandomAccessFile raf = new RandomAccessFile(file.toFile(), "rw")) {
+      ByteBuffer buffer = raf.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, serialised.length);
+      buffer.put(serialised);
+      buffer.flip();
+      RoaringBitmap deserialised = new RoaringBitmap();
+      deserialised.deserialize(buffer);
+      assertEquals(input, deserialised);
+    } finally {
+       Files.delete(file);
+    }
+  }
+
+  @Test
+  public void testDeserializeFromHeap() throws IOException {
+    ByteBuffer buffer = ByteBuffer.wrap(serialised).order(order);
+    RoaringBitmap deserialised = new RoaringBitmap();
+    deserialised.deserialize(buffer);
+    assertEquals(input, deserialised);
+  }
+}


### PR DESCRIPTION
Here's a zero copy implementation of `RoaringBitmap.deserialize` which should work with any kind of `ByteBuffer`. It could probably be tweaked to be faster.

```
Benchmark                                                   (dataset)  (runOptimise)   Mode  Cnt      Score      Error  Units
RealDataSerializationBenchmark.directToBuffer           census-income           true  thrpt    5   1466.644 ±   54.840  ops/s
RealDataSerializationBenchmark.directToBuffer           census-income          false  thrpt    5   1457.662 ±   54.376  ops/s
RealDataSerializationBenchmark.directToBuffer              census1881           true  thrpt    5   1017.511 ±   12.529  ops/s
RealDataSerializationBenchmark.directToBuffer              census1881          false  thrpt    5    975.719 ±   32.263  ops/s
RealDataSerializationBenchmark.directToBuffer           dimension_008           true  thrpt    5   1675.039 ±  309.378  ops/s
RealDataSerializationBenchmark.directToBuffer           dimension_008          false  thrpt    5    323.201 ±    4.185  ops/s
RealDataSerializationBenchmark.directToBuffer           dimension_003           true  thrpt    5    671.851 ±   23.529  ops/s
RealDataSerializationBenchmark.directToBuffer           dimension_003          false  thrpt    5    292.718 ±   11.805  ops/s
RealDataSerializationBenchmark.directToBuffer           dimension_033           true  thrpt    5  10511.143 ±  419.099  ops/s
RealDataSerializationBenchmark.directToBuffer           dimension_033          false  thrpt    5    721.489 ±   34.630  ops/s
RealDataSerializationBenchmark.directToBuffer            uscensus2000           true  thrpt    5  23202.018 ±  490.423  ops/s
RealDataSerializationBenchmark.directToBuffer            uscensus2000          false  thrpt    5  24876.415 ±  706.691  ops/s
RealDataSerializationBenchmark.directToBuffer         weather_sept_85           true  thrpt    5    349.308 ±   13.629  ops/s
RealDataSerializationBenchmark.directToBuffer         weather_sept_85          false  thrpt    5    341.690 ±   18.162  ops/s
RealDataSerializationBenchmark.directToBuffer      wikileaks-noquotes           true  thrpt    5   2364.002 ±   63.768  ops/s
RealDataSerializationBenchmark.directToBuffer      wikileaks-noquotes          false  thrpt    5    982.229 ±   46.029  ops/s
RealDataSerializationBenchmark.directToBuffer       census-income_srt           true  thrpt    5   3777.188 ±   79.576  ops/s
RealDataSerializationBenchmark.directToBuffer       census-income_srt          false  thrpt    5   1511.823 ±  124.301  ops/s
RealDataSerializationBenchmark.directToBuffer          census1881_srt           true  thrpt    5   6260.407 ±  862.596  ops/s
RealDataSerializationBenchmark.directToBuffer          census1881_srt          false  thrpt    5   1288.755 ±   36.064  ops/s
RealDataSerializationBenchmark.directToBuffer     weather_sept_85_srt           true  thrpt    5   2202.364 ±   17.541  ops/s
RealDataSerializationBenchmark.directToBuffer     weather_sept_85_srt          false  thrpt    5    571.677 ±   17.375  ops/s
RealDataSerializationBenchmark.directToBuffer  wikileaks-noquotes_srt           true  thrpt    5   6681.119 ±  212.469  ops/s
RealDataSerializationBenchmark.directToBuffer  wikileaks-noquotes_srt          false  thrpt    5   1942.603 ±  128.506  ops/s
RealDataSerializationBenchmark.viaImmutable             census-income           true  thrpt    5   1675.430 ±  622.567  ops/s
RealDataSerializationBenchmark.viaImmutable             census-income          false  thrpt    5   1587.956 ±  522.393  ops/s
RealDataSerializationBenchmark.viaImmutable                census1881           true  thrpt    5   1524.577 ±   73.809  ops/s
RealDataSerializationBenchmark.viaImmutable                census1881          false  thrpt    5   1522.492 ±   74.257  ops/s
RealDataSerializationBenchmark.viaImmutable             dimension_008           true  thrpt    5    782.718 ±   38.322  ops/s
RealDataSerializationBenchmark.viaImmutable             dimension_008          false  thrpt    5    368.743 ±   85.817  ops/s
RealDataSerializationBenchmark.viaImmutable             dimension_003           true  thrpt    5    367.719 ±   14.662  ops/s
RealDataSerializationBenchmark.viaImmutable             dimension_003          false  thrpt    5    312.730 ±    6.139  ops/s
RealDataSerializationBenchmark.viaImmutable             dimension_033           true  thrpt    5   6270.182 ±  161.656  ops/s
RealDataSerializationBenchmark.viaImmutable             dimension_033          false  thrpt    5    969.822 ±   37.754  ops/s
RealDataSerializationBenchmark.viaImmutable              uscensus2000           true  thrpt    5   6831.987 ±  285.591  ops/s
RealDataSerializationBenchmark.viaImmutable              uscensus2000          false  thrpt    5   7014.126 ± 6356.781  ops/s
RealDataSerializationBenchmark.viaImmutable           weather_sept_85           true  thrpt    5    463.294 ±   12.182  ops/s
RealDataSerializationBenchmark.viaImmutable           weather_sept_85          false  thrpt    5    462.226 ±   18.546  ops/s
RealDataSerializationBenchmark.viaImmutable        wikileaks-noquotes           true  thrpt    5   2941.153 ±   79.706  ops/s
RealDataSerializationBenchmark.viaImmutable        wikileaks-noquotes          false  thrpt    5   3429.944 ±  156.949  ops/s
RealDataSerializationBenchmark.viaImmutable         census-income_srt           true  thrpt    5   5936.962 ±  104.509  ops/s
RealDataSerializationBenchmark.viaImmutable         census-income_srt          false  thrpt    5   1965.802 ±   54.120  ops/s
RealDataSerializationBenchmark.viaImmutable            census1881_srt           true  thrpt    5   2331.209 ±   58.467  ops/s
RealDataSerializationBenchmark.viaImmutable            census1881_srt          false  thrpt    5   2496.958 ±   19.363  ops/s
RealDataSerializationBenchmark.viaImmutable       weather_sept_85_srt           true  thrpt    5   2806.114 ±  128.969  ops/s
RealDataSerializationBenchmark.viaImmutable       weather_sept_85_srt          false  thrpt    5    668.576 ±   18.688  ops/s
RealDataSerializationBenchmark.viaImmutable    wikileaks-noquotes_srt           true  thrpt    5   5148.269 ±  176.735  ops/s
RealDataSerializationBenchmark.viaImmutable    wikileaks-noquotes_srt          false  thrpt    5   2402.069 ±   33.408  ops/s

```