### PR TITLE
fix bug when serialising many bitmaps to same file

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
@@ -948,7 +948,9 @@ public final class RoaringArray implements Cloneable, Externalizable, Appendable
     for (int k = 0; k < size; ++k) {
       values[k].writeArray(buf);
     }
-    buffer.position(buf.position());
+    if (buf != buffer) {
+      buffer.position(buffer.position() + buf.position());
+    }
   }
 
   /**

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
@@ -732,7 +732,9 @@ public final class MutableRoaringArray implements Cloneable, Externalizable, Poi
     for (int k = 0; k < size; ++k) {
       values[k].writeArray(buf);
     }
-    buffer.position(buf.position());
+    if (buf != buffer) {
+      buffer.position(buffer.position() + buf.position());
+    }
   }
 
   /**

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestSerializationViaByteBuffer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestSerializationViaByteBuffer.java
@@ -178,6 +178,15 @@ public class TestSerializationViaByteBuffer {
   }
 
   @Test
+  public void testSerializeCorrectOffset() {
+    ByteBuffer buffer = ByteBuffer.allocateDirect(10 + serialised.length).order(order);
+    buffer.position(10);
+    int serialisedSize = input.serializedSizeInBytes();
+    input.serialize(buffer);
+    assertEquals(10 + serialisedSize, buffer.position());
+  }
+
+  @Test
   public void testSerializeToByteBufferDeserializeViaStream() throws IOException {
     ByteBuffer buffer = ByteBuffer.allocate(serialised.length).order(order);
     input.serialize(buffer);

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestSerializationViaByteBuffer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestSerializationViaByteBuffer.java
@@ -5,6 +5,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.roaringbitmap.RoaringBitmap;
 import org.roaringbitmap.SeededTestData;
 
 import java.io.*;
@@ -199,6 +200,15 @@ public class TestSerializationViaByteBuffer {
     MutableRoaringBitmap deserialised = new MutableRoaringBitmap();
     deserialised.deserialize(buffer);
     assertEquals(input, deserialised);
+  }
+
+  @Test
+  public void testSerializeCorrectOffset() {
+    ByteBuffer buffer = ByteBuffer.allocateDirect(10 + serialised.length).order(order);
+    buffer.position(10);
+    int serialisedSize = input.serializedSizeInBytes();
+    input.serialize(buffer);
+    assertEquals(10 + serialisedSize, buffer.position());
   }
 
   @Test

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestSerializationViaByteBuffer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestSerializationViaByteBuffer.java
@@ -5,7 +5,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.roaringbitmap.RoaringBitmap;
 import org.roaringbitmap.SeededTestData;
 
 import java.io.*;


### PR DESCRIPTION
Fixes a bug when serialising a bitmap to a big endian buffer with a non zero position + reproducing unit test.