### PR TITLE
avoid resizing keys when keys are already at optimal size

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
@@ -661,7 +661,7 @@ public final class RoaringArray implements Cloneable, Externalizable, Appendable
   // make sure there is capacity for at least k more elements
   protected void extendArray(int k) {
     // size + 1 could overflow
-    if (this.size + k >= this.keys.length) {
+    if (this.size + k > this.keys.length) {
       int newCapacity;
       if (this.keys.length < 1024) {
         newCapacity = 2 * (this.size + k);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
@@ -420,7 +420,7 @@ public final class MutableRoaringArray implements Cloneable, Externalizable, Poi
   // make sure there is capacity for at least k more elements
   protected void extendArray(int k) {
     // size + 1 could overflow
-    if (this.size + k >= this.keys.length) {
+    if (this.size + k > this.keys.length) {
       int newCapacity;
       if (this.keys.length < 1024) {
         newCapacity = 2 * (this.size + k);

--- a/roaringbitmap/src/test/java/org/roaringbitmap/RoaringArrayTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/RoaringArrayTest.java
@@ -77,4 +77,14 @@ public class RoaringArrayTest {
     assertArrayEquals(new short[] {0, 2, 5, 6, 7}, array.keys);
   }
 
+  @Test
+  public void resizeOnlyIfNecessary() {
+    short[] keys = new short[1];
+    int size = 0;
+    Container[] values = new Container[1];
+    RoaringArray array = new RoaringArray(keys, values, size);
+    array.extendArray(1);
+    assertTrue("Keys were not reallocated", keys == array.keys);
+  }
+
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/MutableRoaringArrayTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/MutableRoaringArrayTest.java
@@ -1,0 +1,19 @@
+package org.roaringbitmap.buffer;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class MutableRoaringArrayTest {
+
+
+  @Test
+  public void resizeOnlyIfNecessary() {
+    short[] keys = new short[1];
+    int size = 0;
+    MappeableContainer[] values = new MappeableContainer[1];
+    MutableRoaringArray array = new MutableRoaringArray(keys, values, size);
+    array.extendArray(1);
+    assertTrue("Keys were not reallocated", keys == array.keys);
+  }
+}


### PR DESCRIPTION
Fixes a case where keys get reallocated if they have already been sized precisely + reproducing test case.