### PR TITLE
optimise array add for append-only

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -141,24 +141,33 @@ public final class ArrayContainer extends Container implements Cloneable {
    */
   @Override
   public Container add(final short x) {
-    int loc = Util.unsignedBinarySearch(content, 0, cardinality, x);
-    if (loc < 0) {
-      // Transform the ArrayContainer to a BitmapContainer
-      // when cardinality = DEFAULT_MAX_SIZE
+    if (cardinality == 0 || (cardinality > 0
+            && toIntUnsigned(x) > toIntUnsigned(content[cardinality - 1]))) {
       if (cardinality >= DEFAULT_MAX_SIZE) {
-        BitmapContainer a = this.toBitmapContainer();
-        a.add(x);
-        return a;
+        return toBitmapContainer().add(x);
       }
       if (cardinality >= this.content.length) {
         increaseCapacity();
       }
-      // insertion : shift the elements > x by one position to
-      // the right
-      // and put x in it's appropriate place
-      System.arraycopy(content, -loc - 1, content, -loc, cardinality + loc + 1);
-      content[-loc - 1] = x;
-      ++cardinality;
+      content[cardinality++] = x;
+    } else {
+      int loc = Util.unsignedBinarySearch(content, 0, cardinality, x);
+      if (loc < 0) {
+        // Transform the ArrayContainer to a BitmapContainer
+        // when cardinality = DEFAULT_MAX_SIZE
+        if (cardinality >= DEFAULT_MAX_SIZE) {
+          return toBitmapContainer().add(x);
+        }
+        if (cardinality >= this.content.length) {
+          increaseCapacity();
+        }
+        // insertion : shift the elements > x by one position to
+        // the right
+        // and put x in it's appropriate place
+        System.arraycopy(content, -loc - 1, content, -loc, cardinality + loc + 1);
+        content[-loc - 1] = x;
+        ++cardinality;
+      }
     }
     return this;
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -162,28 +162,49 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     if (BufferUtil.isBackedBySimpleArray(this.content)) {
       short[] sarray = content.array();
 
-      int loc = Util.unsignedBinarySearch(sarray, 0, cardinality, x);
-      if (loc < 0) {
-        // Transform the ArrayContainer to a BitmapContainer
-        // when cardinality exceeds DEFAULT_MAX_SIZE
+      if (cardinality == 0 || (cardinality > 0
+              && toIntUnsigned(x) > toIntUnsigned(sarray[cardinality - 1]))) {
         if (cardinality >= DEFAULT_MAX_SIZE) {
-          final MappeableBitmapContainer a = this.toBitmapContainer();
-          a.add(x);
-          return a;
+          return toBitmapContainer().add(x);
         }
         if (cardinality >= sarray.length) {
           increaseCapacity();
           sarray = content.array();
         }
-        // insertion : shift the elements > x by one
-        // position to
-        // the right
-        // and put x in it's appropriate place
-        System.arraycopy(sarray, -loc - 1, sarray, -loc, cardinality + loc + 1);
-        sarray[-loc - 1] = x;
-        ++cardinality;
+        sarray[cardinality++] = x;
+      } else {
+
+        int loc = Util.unsignedBinarySearch(sarray, 0, cardinality, x);
+        if (loc < 0) {
+          // Transform the ArrayContainer to a BitmapContainer
+          // when cardinality exceeds DEFAULT_MAX_SIZE
+          if (cardinality >= DEFAULT_MAX_SIZE) {
+            return toBitmapContainer().add(x);
+          }
+          if (cardinality >= sarray.length) {
+            increaseCapacity();
+            sarray = content.array();
+          }
+          // insertion : shift the elements > x by one
+          // position to
+          // the right
+          // and put x in it's appropriate place
+          System.arraycopy(sarray, -loc - 1, sarray, -loc, cardinality + loc + 1);
+          sarray[-loc - 1] = x;
+          ++cardinality;
+        }
       }
     } else {
+      if (cardinality == 0 || (cardinality > 0
+              && toIntUnsigned(x) > toIntUnsigned(content.get(cardinality - 1)))) {
+        if (cardinality >= DEFAULT_MAX_SIZE) {
+          return toBitmapContainer().add(x);
+        }
+        if (cardinality >= content.limit()) {
+          increaseCapacity();
+        }
+        content.put(cardinality++, x);
+      }
 
       final int loc = BufferUtil.unsignedBinarySearch(content, 0, cardinality, x);
       if (loc < 0) {


### PR DESCRIPTION
This optimises adding to arrays for append only scenarios. This will significantly speed up this case because it avoids a costly binary search, the branch is predictable, the other side of the branch will probably not even get compiled if it is never profiled. This will probably add the cost of an unpredicatable branch to random adds, but these are likely very slow anyway, and I think the penalty is likely worth it. I don't have much time to benchmark this but am receptive to opposition on the wisdom of this optimisation.