### PR TITLE
flyweight container batch iterators

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayBatchIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayBatchIterator.java
@@ -2,13 +2,13 @@ package org.roaringbitmap;
 
 import static org.roaringbitmap.Util.toIntUnsigned;
 
-public class ArrayBatchIterator implements ContainerBatchIterator {
+public final class ArrayBatchIterator implements ContainerBatchIterator {
 
   private int index = 0;
-  private final ArrayContainer array;
+  private ArrayContainer array;
 
   public ArrayBatchIterator(ArrayContainer array) {
-    this.array = array;
+    wrap(array);
   }
 
   @Override
@@ -34,5 +34,15 @@ public class ArrayBatchIterator implements ContainerBatchIterator {
       // won't happen
       throw new IllegalStateException(e);
     }
+  }
+
+  @Override
+  public void releaseContainer() {
+    array = null;
+  }
+
+  void wrap(ArrayContainer array) {
+    this.array = array;
+    this.index = 0;
   }
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/BitmapBatchIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BitmapBatchIterator.java
@@ -2,15 +2,14 @@ package org.roaringbitmap;
 
 import static java.lang.Long.numberOfTrailingZeros;
 
-public class BitmapBatchIterator implements ContainerBatchIterator {
+public final class BitmapBatchIterator implements ContainerBatchIterator {
 
   private int wordIndex = 0;
   private long word;
-  private final BitmapContainer bitmap;
+  private BitmapContainer bitmap;
 
   public BitmapBatchIterator(BitmapContainer bitmap) {
-    this.bitmap = bitmap;
-    word = bitmap.bitmap[0];
+    wrap(bitmap);
   }
 
   @Override
@@ -43,5 +42,16 @@ public class BitmapBatchIterator implements ContainerBatchIterator {
       // won't happen
       throw new IllegalStateException(e);
     }
+  }
+
+  @Override
+  public void releaseContainer() {
+    bitmap = null;
+  }
+
+  void wrap(BitmapContainer bitmap) {
+    this.bitmap = bitmap;
+    word = bitmap.bitmap[0];
+    this.wordIndex = 0;
   }
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ContainerBatchIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ContainerBatchIterator.java
@@ -24,4 +24,9 @@ public interface ContainerBatchIterator extends Cloneable {
    */
   ContainerBatchIterator clone();
 
+  /**
+   * Discard the reference to the container
+   */
+  void releaseContainer();
+
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBatchIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBatchIterator.java
@@ -1,11 +1,14 @@
 package org.roaringbitmap;
 
-public class RoaringBatchIterator implements BatchIterator {
+public final class RoaringBatchIterator implements BatchIterator {
 
   private final RoaringArray highLowContainer;
-  int index = 0;
-  int key;
-  ContainerBatchIterator iterator;
+  private int index = 0;
+  private int key;
+  private ContainerBatchIterator iterator;
+  private ArrayBatchIterator arrayBatchIterator = null;
+  private BitmapBatchIterator bitmapBatchIterator = null;
+  private RunBatchIterator runBatchIterator = null;
 
   public RoaringBatchIterator(RoaringArray highLowContainer) {
     this.highLowContainer = highLowContainer;
@@ -49,11 +52,48 @@ public class RoaringBatchIterator implements BatchIterator {
   }
 
   private void nextIterator() {
+    if (null != iterator) {
+      iterator.releaseContainer();
+    }
     if (index < highLowContainer.size()) {
-      iterator = highLowContainer.getContainerAtIndex(index).getBatchIterator();
+      Container container = highLowContainer.getContainerAtIndex(index);
+      if (container instanceof ArrayContainer) {
+        nextIterator((ArrayContainer)container);
+      } else if (container instanceof BitmapContainer) {
+        nextIterator((BitmapContainer)container);
+      } else if (container instanceof RunContainer){
+        nextIterator((RunContainer)container);
+      }
       key = highLowContainer.getKeyAtIndex(index) << 16;
     } else {
       iterator = null;
     }
+  }
+
+  private void nextIterator(ArrayContainer array) {
+    if (null == arrayBatchIterator) {
+      arrayBatchIterator = new ArrayBatchIterator(array);
+    } else {
+      arrayBatchIterator.wrap(array);
+    }
+    iterator = arrayBatchIterator;
+  }
+
+  private void nextIterator(BitmapContainer bitmap) {
+    if (null == bitmapBatchIterator) {
+      bitmapBatchIterator = new BitmapBatchIterator(bitmap);
+    } else {
+      bitmapBatchIterator.wrap(bitmap);
+    }
+    iterator = bitmapBatchIterator;
+  }
+
+  private void nextIterator(RunContainer run) {
+    if (null == runBatchIterator) {
+      runBatchIterator = new RunBatchIterator(run);
+    } else {
+      runBatchIterator.wrap(run);
+    }
+    iterator = runBatchIterator;
   }
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RunBatchIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RunBatchIterator.java
@@ -2,14 +2,14 @@ package org.roaringbitmap;
 
 import static org.roaringbitmap.Util.toIntUnsigned;
 
-public class RunBatchIterator implements ContainerBatchIterator {
+public final class RunBatchIterator implements ContainerBatchIterator {
 
-  private final RunContainer runs;
+  private RunContainer runs;
   private int run = 0;
   private int cursor = 0;
 
   public RunBatchIterator(RunContainer runs) {
-    this.runs = runs;
+    wrap(runs);
   }
 
   @Override
@@ -48,5 +48,16 @@ public class RunBatchIterator implements ContainerBatchIterator {
       // won't happen
       throw new IllegalStateException(e);
     }
+  }
+
+  @Override
+  public void releaseContainer() {
+    runs = null;
+  }
+
+  void wrap(RunContainer runs) {
+    this.runs = runs;
+    this.run = 0;
+    this.cursor = 0;
   }
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/ArrayBatchIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/ArrayBatchIterator.java
@@ -6,13 +6,13 @@ import java.nio.ShortBuffer;
 
 import static org.roaringbitmap.buffer.BufferUtil.toIntUnsigned;
 
-public class ArrayBatchIterator implements ContainerBatchIterator {
+public final class ArrayBatchIterator implements ContainerBatchIterator {
 
   private int index = 0;
-  private final MappeableArrayContainer array;
+  private MappeableArrayContainer array;
 
   public ArrayBatchIterator(MappeableArrayContainer array) {
-    this.array = array;
+    wrap(array);
   }
 
   @Override
@@ -38,5 +38,15 @@ public class ArrayBatchIterator implements ContainerBatchIterator {
       // won't happen
       throw new IllegalStateException(e);
     }
+  }
+
+  @Override
+  public void releaseContainer() {
+    array = null;
+  }
+
+  public void wrap(MappeableArrayContainer array) {
+    this.array = array;
+    this.index = 0;
   }
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/BitmapBatchIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/BitmapBatchIterator.java
@@ -4,15 +4,14 @@ import org.roaringbitmap.ContainerBatchIterator;
 
 import static java.lang.Long.numberOfTrailingZeros;
 
-public class BitmapBatchIterator implements ContainerBatchIterator {
+public final class BitmapBatchIterator implements ContainerBatchIterator {
 
   private int wordIndex = 0;
   private long word;
-  private final MappeableBitmapContainer bitmap;
+  private MappeableBitmapContainer bitmap;
 
   public BitmapBatchIterator(MappeableBitmapContainer bitmap) {
-    this.bitmap = bitmap;
-    word = bitmap.bitmap.get(0);
+    wrap(bitmap);
   }
 
   @Override
@@ -46,4 +45,16 @@ public class BitmapBatchIterator implements ContainerBatchIterator {
       throw new IllegalStateException(e);
     }
   }
+
+  @Override
+  public void releaseContainer() {
+    bitmap = null;
+  }
+
+  void wrap(MappeableBitmapContainer bitmap) {
+    this.bitmap = bitmap;
+    this.word = bitmap.bitmap.get(0);
+    this.wordIndex = 0;
+  }
+
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/RunBatchIterator.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/RunBatchIterator.java
@@ -4,14 +4,14 @@ import org.roaringbitmap.ContainerBatchIterator;
 
 import static org.roaringbitmap.buffer.BufferUtil.toIntUnsigned;
 
-public class RunBatchIterator implements ContainerBatchIterator {
+public final class RunBatchIterator implements ContainerBatchIterator {
 
-  private final MappeableRunContainer runs;
+  private MappeableRunContainer runs;
   private int run = 0;
   private int cursor = 0;
 
   public RunBatchIterator(MappeableRunContainer runs) {
-    this.runs = runs;
+    wrap(runs);
   }
 
   @Override
@@ -50,5 +50,16 @@ public class RunBatchIterator implements ContainerBatchIterator {
       // won't happen
       throw new IllegalStateException(e);
     }
+  }
+
+  @Override
+  public void releaseContainer() {
+    runs = null;
+  }
+
+  void wrap(MappeableRunContainer runs) {
+    this.runs = runs;
+    this.run = 0;
+    this.cursor = 0;
   }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/DirectoryCleanup.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/DirectoryCleanup.java
@@ -1,0 +1,28 @@
+package org.roaringbitmap;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public class DirectoryCleanup extends SimpleFileVisitor<Path> {
+  @Override
+  public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+    Files.delete(file);
+    return FileVisitResult.CONTINUE;
+  }
+
+  @Override
+  public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+    Files.delete(file);
+    return FileVisitResult.CONTINUE;
+  }
+
+  @Override
+  public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+    Files.delete(dir);
+    return FileVisitResult.CONTINUE;
+  }
+}

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestSerializationViaByteBuffer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestSerializationViaByteBuffer.java
@@ -13,7 +13,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import static java.nio.channels.FileChannel.MapMode.READ_WRITE;
 import static java.nio.file.Files.delete;
@@ -36,16 +35,9 @@ public class TestSerializationViaByteBuffer {
   @AfterClass
   public static void cleanup() throws IOException {
     System.gc();
-    try (Stream<Path> files = Files.list(dir)) {
-      files.forEach(file -> {
-        try {
-          delete(file);
-        } catch (IOException e) {
-          e.printStackTrace();
-        }
-      });
-    }
-    delete(dir);
+    try {
+      Files.walkFileTree(dir, new DirectoryCleanup());
+    } catch (IOException e) { }
   }
 
   @Parameterized.Parameters(name = "{1}/{0} keys/runOptimise={2}")

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestSerializationViaByteBuffer.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestSerializationViaByteBuffer.java
@@ -5,6 +5,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.roaringbitmap.DirectoryCleanup;
 import org.roaringbitmap.SeededTestData;
 
 import java.io.*;
@@ -15,7 +16,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import static java.nio.channels.FileChannel.MapMode.READ_WRITE;
 import static java.nio.file.Files.delete;
@@ -35,16 +35,9 @@ public class TestSerializationViaByteBuffer {
   @AfterClass
   public static void cleanup() throws IOException {
     System.gc();
-    try (Stream<Path> files = Files.list(dir)) {
-       files.forEach(file -> {
-         try {
-           delete(file);
-         } catch (IOException e) {
-           e.printStackTrace();
-         }
-       });
-       delete(dir);
-    }
+    try {
+      Files.walkFileTree(dir, new DirectoryCleanup());
+    } catch (IOException e) { }
   }
 
   @Parameterized.Parameters(name = "{1}/{0} keys/runOptimise={2}")


### PR DESCRIPTION
Reduces allocation of batch iterators to a constant 40-120 bytes, depending on the number of container types which exist in the bitmap, down from potentially tens or hundreds of kilobytes depending on the size of the bitmap. Otherwise negligible impact on performance.