### PR TITLE
We can now use the "addOffset" function with negative offsets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Usage
 * ``mvn compile`` will compile
 * ``mvn test`` will run the  unit tests
 * ``mvn package`` will package in a jar (found in target)
-* ``mvn checkstyle:check`` will check that you abide by the code style, run it within the roaringbitmap subdirectory (module). We enforce a strict style so that there is no debate as to the proper way to format the code.
+* ``mvn install -DskipTests`` will check that you abide by the code style and that the code compiles. We enforce a strict style so that there is no debate as to the proper way to format the code.
 
 A convenient command to build the code is :
 

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -205,7 +205,8 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
   public static RoaringBitmap addOffset(final RoaringBitmap x, long offset) {
     // we need "offset" to be a long because we want to support values
     // between -0xFFFFFFFF up to +-0xFFFFFFFF
-    long container_offset_long = offset < 0 ? (offset - (1<<16) + 1)  / (1<<16) : offset / (1 << 16);
+    long container_offset_long = offset < 0 ? 
+      (offset - (1<<16) + 1)  / (1<<16) : offset / (1 << 16);
     if((container_offset_long <= -(1<<16) ) || (container_offset_long >= (1<<16) )) {
       return new RoaringBitmap(); // it is necessarily going to be empty
     }
@@ -219,7 +220,8 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
         int key = Util.toIntUnsigned(x.highLowContainer.getKeyAtIndex(pos));
         key += container_offset;
         if((key >= 0) || (key <= 0xFFFF))  {
-          answer.highLowContainer.append((short)key, x.highLowContainer.getContainerAtIndex(pos).clone());
+          answer.highLowContainer.append((short)key, 
+            x.highLowContainer.getContainerAtIndex(pos).clone());
         }
       }
       return answer;

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -205,8 +205,8 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
   public static RoaringBitmap addOffset(final RoaringBitmap x, long offset) {
     // we need "offset" to be a long because we want to support values
     // between -0xFFFFFFFF up to +-0xFFFFFFFF
-    long container_offset_long = offset < 0 ? 
-      (offset - (1<<16) + 1)  / (1<<16) : offset / (1 << 16);
+    long container_offset_long = offset < 0 
+        ? (offset - (1<<16) + 1)  / (1<<16) : offset / (1 << 16);
     if((container_offset_long <= -(1<<16) ) || (container_offset_long >= (1<<16) )) {
       return new RoaringBitmap(); // it is necessarily going to be empty
     }
@@ -221,7 +221,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
         key += container_offset;
         if((key >= 0) || (key <= 0xFFFF))  {
           answer.highLowContainer.append((short)key, 
-            x.highLowContainer.getContainerAtIndex(pos).clone());
+              x.highLowContainer.getContainerAtIndex(pos).clone());
         }
       }
       return answer;

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
@@ -66,66 +66,67 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
   private static final long serialVersionUID = 4L; // 3L; bumped by ofk for runcontainers
 
   /**
-   * Generate a new bitmap that has the same cardinality as x, but with
+   * Generate a new bitmap, but with
    * all its values incremented by offset.
+   * The parameter offset can be
+   * negative. Values that would fall outside
+   * of the valid 32-bit range are discarded
+   * so that the result can have lower cardinality.
    * 
    * @param x source bitmap
-   * @param offset increment (non-negative)
+   * @param offset increment (can be negative)
    * @return a new bitmap
    */
-  public static MutableRoaringBitmap addOffset(final ImmutableRoaringBitmap x, int offset) {
-    int container_offset = Integer.divideUnsigned(offset, (1<<16));
-    int in_container_offset = Integer.remainderUnsigned(offset , (1<<16));
+  public static MutableRoaringBitmap addOffset(final ImmutableRoaringBitmap x, long offset) {
+    // we need "offset" to be a long because we want to support values
+    // between -0xFFFFFFFF up to +-0xFFFFFFFF
+    long container_offset_long = offset < 0 ? (offset - (1<<16) + 1)  / (1<<16) : offset / (1 << 16);
+    if((container_offset_long <= -(1<<16) ) || (container_offset_long >= (1<<16) )) {
+      return new MutableRoaringBitmap(); // it is necessarily going to be empty
+    }
+    // next cast is necessarily safe, the result is between -0xFFFF and 0xFFFF
+    int container_offset = (int) container_offset_long;
+    // next case is safe
+    int in_container_offset = (int)(offset - container_offset_long * (1L<<16));
     if(in_container_offset == 0) {
       MutableRoaringBitmap answer = new MutableRoaringBitmap();
       for(int pos = 0; pos < x.highLowContainer.size(); pos++) {
         int key = BufferUtil.toIntUnsigned(x.highLowContainer.getKeyAtIndex(pos));
-        MappeableContainer c = x.highLowContainer.getContainerAtIndex(pos);
         key += container_offset;
-        key = key % (1<<16); // we rotate
-        // here we use a binary search which is inefficient.
-        int containerindex = answer.highLowContainer.getIndex((short)key);
-        int actualindex = - containerindex - 1;
-        answer.getMappeableRoaringArray().insertNewKeyValueAt(actualindex, (short) key, c.clone());
+        if((key >= 0) || (key <= 0xFFFF))  {
+          answer.getMappeableRoaringArray().append((short)key, x.highLowContainer.getContainerAtIndex(pos).clone());
+        }
       }
       return answer;
     } else {
       MutableRoaringBitmap answer = new MutableRoaringBitmap();
       for(int pos = 0; pos < x.highLowContainer.size(); pos++) {
         int key = BufferUtil.toIntUnsigned(x.highLowContainer.getKeyAtIndex(pos));
-        MappeableContainer c = x.highLowContainer.getContainerAtIndex(pos);
         key += container_offset;
-        key = key % (1<<16); // we rotate
+        MappeableContainer c = x.highLowContainer.getContainerAtIndex(pos);
         MappeableContainer[] offsetted = BufferUtil.addOffset(c,
                 (short)in_container_offset);
-        if( !offsetted[0].isEmpty()) {
-          // here we use a binary search which is inefficient.
-          int containerindex = answer.highLowContainer.getIndex((short) key);
-          if (containerindex < 0) {
-            int actualindex = - containerindex - 1;
-            answer.getMappeableRoaringArray()
-                    .insertNewKeyValueAt(actualindex, (short) key, offsetted[0]);
-          } else {
+        boolean keyok = (key >= 0) && (key <= 0xFFFF);
+        boolean keypok = (key + 1 >= 0) && (key + 1 <= 0xFFFF);
+        if( !offsetted[0].isEmpty() && keyok) {
+          int current_size = answer.highLowContainer.size();
+          int lastkey = 0;
+          if(current_size > 0) {
+            lastkey = BufferUtil.toIntUnsigned(answer.highLowContainer.getKeyAtIndex(
+                    current_size - 1));
+          }
+          if((current_size > 0) && (lastkey == key)) {
             MappeableContainer prev = answer.highLowContainer
-                    .getContainerAtIndex(containerindex);
+                    .getContainerAtIndex(current_size - 1);
             MappeableContainer orresult = prev.ior(offsetted[0]);
-            answer.getMappeableRoaringArray().setContainerAtIndex(containerindex, orresult);
+            answer.getMappeableRoaringArray().setContainerAtIndex(current_size - 1,
+                    orresult);
+          } else {
+            answer.getMappeableRoaringArray().append((short)key, offsetted[0]);
           }
         }
-        if( !offsetted[1].isEmpty()) {
-          int newkey = (key + 1) % (1<<16); // we rotate
-          // here we use a binary search which is inefficient.
-          int containerindex = answer.highLowContainer.getIndex((short) newkey);
-          if (containerindex < 0) {
-            int actualindex = - containerindex - 1;
-            answer.getMappeableRoaringArray()
-                    .insertNewKeyValueAt(actualindex, (short) newkey, offsetted[1]);
-          } else {
-            MappeableContainer prev = answer.highLowContainer
-                    .getContainerAtIndex(containerindex);
-            MappeableContainer orresult = prev.ior(offsetted[1]);
-            answer.getMappeableRoaringArray().setContainerAtIndex(containerindex, orresult);
-          }
+        if( !offsetted[1].isEmpty()  && keypok) {
+          answer.getMappeableRoaringArray().append((short)(key + 1), offsetted[1]);
         }
       }
       answer.repairAfterLazy();

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
@@ -80,7 +80,8 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
   public static MutableRoaringBitmap addOffset(final ImmutableRoaringBitmap x, long offset) {
     // we need "offset" to be a long because we want to support values
     // between -0xFFFFFFFF up to +-0xFFFFFFFF
-    long container_offset_long = offset < 0 ? (offset - (1<<16) + 1)  / (1<<16) : offset / (1 << 16);
+    long container_offset_long = offset < 0 ? 
+      (offset - (1<<16) + 1)  / (1<<16) : offset / (1 << 16);
     if((container_offset_long <= -(1<<16) ) || (container_offset_long >= (1<<16) )) {
       return new MutableRoaringBitmap(); // it is necessarily going to be empty
     }
@@ -94,7 +95,8 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
         int key = BufferUtil.toIntUnsigned(x.highLowContainer.getKeyAtIndex(pos));
         key += container_offset;
         if((key >= 0) || (key <= 0xFFFF))  {
-          answer.getMappeableRoaringArray().append((short)key, x.highLowContainer.getContainerAtIndex(pos).clone());
+          answer.getMappeableRoaringArray().append((short)key, 
+            x.highLowContainer.getContainerAtIndex(pos).clone());
         }
       }
       return answer;

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
@@ -80,8 +80,8 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
   public static MutableRoaringBitmap addOffset(final ImmutableRoaringBitmap x, long offset) {
     // we need "offset" to be a long because we want to support values
     // between -0xFFFFFFFF up to +-0xFFFFFFFF
-    long container_offset_long = offset < 0 ? 
-      (offset - (1<<16) + 1)  / (1<<16) : offset / (1 << 16);
+    long container_offset_long = offset < 0 
+        ? (offset - (1<<16) + 1)  / (1<<16) : offset / (1 << 16);
     if((container_offset_long <= -(1<<16) ) || (container_offset_long >= (1<<16) )) {
       return new MutableRoaringBitmap(); // it is necessarily going to be empty
     }
@@ -96,7 +96,7 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
         key += container_offset;
         if((key >= 0) || (key <= 0xFFFF))  {
           answer.getMappeableRoaringArray().append((short)key, 
-            x.highLowContainer.getContainerAtIndex(pos).clone());
+              x.highLowContainer.getContainerAtIndex(pos).clone());
         }
       }
       return answer;

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -4922,7 +4922,9 @@ public class TestRoaringBitmap {
       IntIterator i = rb.getIntIterator();
       IntIterator j = rboff.getIntIterator();
       while(i.hasNext() && j.hasNext()) {
-        assertTrue(i.next() + offset ==  j.next());  
+          int val1 = i.next() + offset;
+          int val2 = j.next();
+          assertTrue(val1 == val2);
       }
       assertTrue(i.hasNext() ==  j.hasNext());
     }
@@ -4931,13 +4933,50 @@ public class TestRoaringBitmap {
       IntIterator i = rb.getIntIterator();
       IntIterator j = rboff.getIntIterator();
       while(i.hasNext() && j.hasNext()) {
-      assertTrue(i.next() + offset ==  j.next());  
+         assertTrue(i.next() + offset ==  j.next());
       }
       assertTrue(i.hasNext() ==  j.hasNext());
     }
   }
 
-  @Test
+    @Test
+    public void addNegativeOffset() {
+        final RoaringBitmap rb = new RoaringBitmap();
+        rb.add(10);
+        rb.add(0xFFFF);
+        rb.add(0x010101);
+        for (int i = 100000; i < 200000; i += 4) {
+            rb.add(i);
+        }
+        rb.add(400000L, 1400000L);
+        for(int offset = 3; offset < 1000000; offset *= 3) {
+            RoaringBitmap rboffpos = RoaringBitmap.addOffset(rb, offset);
+            RoaringBitmap rboff = RoaringBitmap.addOffset(rboffpos, -offset);
+
+            IntIterator i = rb.getIntIterator();
+            IntIterator j = rboff.getIntIterator();
+            while(i.hasNext() && j.hasNext()) {
+                int val1 = i.next();
+                int val2 = j.next();
+                if(val1 != val2)
+                assertTrue(val1 == val2);
+            }
+            assertTrue(i.hasNext() ==  j.hasNext());
+        }
+        for(int offset = 1024; offset < 1000000; offset *= 2) {
+            RoaringBitmap rboffpos = RoaringBitmap.addOffset(rb, offset);
+            RoaringBitmap rboff = RoaringBitmap.addOffset(rboffpos, -offset);
+            IntIterator i = rb.getIntIterator();
+            IntIterator j = rboff.getIntIterator();
+            while(i.hasNext() && j.hasNext()) {
+                assertTrue(i.next() ==  j.next());
+            }
+            assertTrue(i.hasNext() ==  j.hasNext());
+        }
+    }
+
+
+    @Test
   public void testNextValue() {
     RoaringBitmap bitmap = SeededTestData.TestDataSet.testCase()
             .withRunAt(0)

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
@@ -3529,6 +3529,38 @@ public class TestRoaringBitmap {
     }
   }
 
+  @Test
+  public void addNegativeOffset() {
+    final MutableRoaringBitmap rb = new MutableRoaringBitmap();
+    rb.add(10);
+    rb.add(0xFFFF);
+    rb.add(0x010101);
+    for (int i = 100000; i < 200000; i += 4) {
+      rb.add(i);
+    }
+    rb.add(400000L, 1400000L);
+    for(int offset = 3; offset < 1000000; offset *= 3) {
+      MutableRoaringBitmap rbposoff = MutableRoaringBitmap.addOffset(rb, offset);
+      MutableRoaringBitmap rboff = MutableRoaringBitmap.addOffset(rbposoff, -offset);
+      IntIterator i = rb.getIntIterator();
+      IntIterator j = rboff.getIntIterator();
+      while(i.hasNext() && j.hasNext()) {
+        assertTrue(i.next()  ==  j.next());
+      }
+      assertTrue(i.hasNext() ==  j.hasNext());
+    }
+    for(int offset = 1024; offset < 1000000; offset *= 2) {
+      MutableRoaringBitmap rbposoff = MutableRoaringBitmap.addOffset(rb, offset);
+      MutableRoaringBitmap rboff = MutableRoaringBitmap.addOffset(rbposoff, -offset);
+      IntIterator i = rb.getIntIterator();
+      IntIterator j = rboff.getIntIterator();
+      while(i.hasNext() && j.hasNext()) {
+        assertTrue(i.next() ==  j.next());
+      }
+      assertTrue(i.hasNext() ==  j.hasNext());
+    }
+  }
+
 
   @Test
   public void testNextValueArray() {

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
@@ -3515,7 +3515,7 @@ public class TestRoaringBitmap {
       IntIterator j = rboff.getIntIterator();
       while(i.hasNext() && j.hasNext()) {
         assertTrue(i.next() + offset ==  j.next());  
-      }
+      }System.out.println("offset = "+offset);
       assertTrue(i.hasNext() ==  j.hasNext());
     }
     for(int offset = 1024; offset < 1000000; offset *= 2) {
@@ -3541,7 +3541,13 @@ public class TestRoaringBitmap {
     rb.add(400000L, 1400000L);
     for(int offset = 3; offset < 1000000; offset *= 3) {
       MutableRoaringBitmap rbposoff = MutableRoaringBitmap.addOffset(rb, offset);
+      if(rb.getLongCardinality() != rbposoff.getLongCardinality()) {
+        throw new RuntimeException("data loss");
+      }
       MutableRoaringBitmap rboff = MutableRoaringBitmap.addOffset(rbposoff, -offset);
+      if(rb.getLongCardinality() != rboff.getLongCardinality()) {
+        throw new RuntimeException("data loss");
+      }
       IntIterator i = rb.getIntIterator();
       IntIterator j = rboff.getIntIterator();
       while(i.hasNext() && j.hasNext()) {
@@ -3551,7 +3557,13 @@ public class TestRoaringBitmap {
     }
     for(int offset = 1024; offset < 1000000; offset *= 2) {
       MutableRoaringBitmap rbposoff = MutableRoaringBitmap.addOffset(rb, offset);
+      if(rb.getLongCardinality() != rbposoff.getLongCardinality()) {
+        throw new RuntimeException("data loss");
+      }
       MutableRoaringBitmap rboff = MutableRoaringBitmap.addOffset(rbposoff, -offset);
+      if(rb.getLongCardinality() != rboff.getLongCardinality()) {
+        throw new RuntimeException("data loss");
+      }
       IntIterator i = rb.getIntIterator();
       IntIterator j = rboff.getIntIterator();
       while(i.hasNext() && j.hasNext()) {


### PR DESCRIPTION
The implementation is simpler and relies on binary searches repeatedly (for simplicity)
so the performance should be lower than the previous implementation.

Note that we preserve the cardinality, so the offset can wrap values around.

This would fix https://github.com/RoaringBitmap/RoaringBitmap/issues/331