### PR TITLE
Fix intersection between Roaring BitMap and range (#333)

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -1140,7 +1140,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     return pos < len
             && supKey == keys[pos]
             && highLowContainer.getContainerAtIndex(pos)
-                               .intersects(0, (int)((supremum - 1) & 0xFFFF) + 1);
+                               .intersects(offset, (int)((supremum - 1) & 0xFFFF) + 1);
   }
 
 

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -1474,8 +1474,11 @@ public final class RunContainer extends Container implements Cloneable {
   @Override
   public boolean intersects(int minimum, int supremum) {
     for (int i = 0; i < numberOfRuns(); ++i) {
-      if (Util.compareUnsigned(getValue(i), (short)minimum) >= 0
-              && Util.toIntUnsigned(getValue(i)) < supremum) {
+      short runFirstValue = getValue(i);
+      short runLastValue = (short) (runFirstValue + getLength(i));
+
+      if (Util.toIntUnsigned(runFirstValue) < supremum
+          && Util.compareUnsigned(runLastValue, (short)minimum) >= 0){
         return true;
       }
     }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -1905,6 +1905,45 @@ public class TestRoaringBitmap {
   }
 
   @Test
+  public void intersecttestWithRange() {
+    RoaringBitmap rr1 = new RoaringBitmap();
+    RoaringBitmap rr2 = new RoaringBitmap();
+    RoaringBitmap rr3 = new RoaringBitmap();
+
+    // This bitmap containers will be Run Containers
+    rr1.add(1L, 4L);
+    rr1.add(6L, 10L);
+
+
+    // This one will be Array Containers
+    rr2.add(0);
+    rr2.add(2);
+
+    rr2.add(6);
+    rr2.add(7);
+    rr2.add(9);
+
+    Assert.assertFalse(rr1.intersects(0, 1));
+    Assert.assertTrue(rr1.intersects(0, 3));
+    Assert.assertTrue(rr1.intersects(0, 11));
+    Assert.assertFalse(rr1.intersects(12, 14));
+    Assert.assertFalse(rr1.intersects(4, 5));
+    Assert.assertTrue(rr1.intersects(2, 3));
+    Assert.assertTrue(rr1.intersects(4, 8));
+    Assert.assertTrue(rr1.intersects(8, 12));
+
+    Assert.assertTrue(rr2.intersects(0, 11));
+    Assert.assertFalse(rr2.intersects(12, 14));
+    Assert.assertFalse(rr2.intersects(4, 5));
+    Assert.assertTrue(rr2.intersects(2, 3));
+    Assert.assertTrue(rr2.intersects(4, 8));
+    Assert.assertTrue(rr2.intersects(8, 12));
+
+    rr3.add(5L, 10L);
+    Assert.assertTrue(rr3.intersects(5, 10));
+  }
+
+  @Test
   public void orBigIntsTest() {
     RoaringBitmap rb = new RoaringBitmap();
     RoaringBitmap rb2 = new RoaringBitmap();


### PR DESCRIPTION
Two bugs were addressed:
* In method RoaringBitMap.intersects(long minimum, long supremum), the starting position used to lookup into the last container was always forced to zero whereas it should not be the case if the minimum and supremum are in the same container.
* The intersection detection in the runContainer between the range (minimum, supremum) and the various runs in the container was wrong: In fact, [a, b] and [c, d] intersect if a <= d && c <=b