### PR TITLE
Test/build config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .setting/
 bin/
 target/
+build/
 */build
 */out
 /.gradle

--- a/RoaringBitmap/build.gradle.kts
+++ b/RoaringBitmap/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 
 
 tasks.test {
-    dependsOn(tasks.checkstyleMain)
+    mustRunAfter(tasks.checkstyleMain)
     useJUnit()
     failFast = true
     maxParallelForks = 8

--- a/RoaringBitmap/build.gradle.kts
+++ b/RoaringBitmap/build.gradle.kts
@@ -8,3 +8,11 @@ dependencies {
     testImplementation("org.apache.commons:commons-lang3:${deps["commons-lang"]}")
     testImplementation("com.esotericsoftware:kryo:5.0.0-RC1")
 }
+
+
+tasks.test {
+    dependsOn(tasks.checkstyleMain)
+    useJUnit()
+    failFast = true
+    maxParallelForks = 8
+}

--- a/RoaringBitmap/style/roaring_google_checks.xml
+++ b/RoaringBitmap/style/roaring_google_checks.xml
@@ -18,7 +18,7 @@
 <module name = "Checker">
     <property name="charset" value="UTF-8"/>
 
-    <property name="severity" value="warning"/>
+    <property name="severity" value="error"/>
 
     <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Checks for whitespace                               -->

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,7 +80,7 @@ subprojects.filter { listOf("RoaringBitmap", "shims").contains(it.name) }.forEac
             }
         }
 
-        configure<PublishingExtension>() {
+        configure<PublishingExtension> {
             publications {
                 register<MavenPublication>("bintray") {
                     groupId = project.group.toString()

--- a/jmh/build.gradle.kts
+++ b/jmh/build.gradle.kts
@@ -53,7 +53,7 @@ tasks.assemble {
 
 tasks.test {
     // stop these tests from running before RoaringBitmap
-    dependsOn(project(":RoaringBitmap").tasks.test)
+    shouldRunAfter(project(":RoaringBitmap").tasks.test)
     useJUnit()
     failFast = true
     maxParallelForks = 8

--- a/jmh/build.gradle.kts
+++ b/jmh/build.gradle.kts
@@ -51,6 +51,14 @@ tasks.assemble {
     dependsOn(tasks.shadowJar)
 }
 
+tasks.test {
+    // stop these tests from running before RoaringBitmap
+    dependsOn(project(":RoaringBitmap").tasks.test)
+    useJUnit()
+    failFast = true
+    maxParallelForks = 8
+}
+
 
 // jmhJar task provided by jmh gradle plugin is currently broken
 // https://github.com/melix/jmh-gradle-plugin/issues/97


### PR DESCRIPTION
This makes a few changes:

- ensures checkstyle runs before any tests
- ensures checkstyle violations fail build 
- ensures jmh tests run after RoaringBitmap tests (they were taking alphabetical precedence)
- parallelises RoaringBitmap and jmh tests (build runs in under 4:30 mins on my laptop)