### PR TITLE
make sure benchmarks jar is multi release and named properly

### DIFF
--- a/jmh/build.gradle.kts
+++ b/jmh/build.gradle.kts
@@ -65,10 +65,12 @@ tasks.test {
 // so instead, we configure the shadowJar task to have JMH bits in it
 tasks.shadowJar {
     archiveBaseName.set("benchmarks")
+    archiveVersion.set("")
     archiveClassifier.set("")
 
     manifest {
         attributes(Pair("Main-Class", "org.openjdk.jmh.Main"))
+        attributes(Pair("Multi-Release", "true"))
     }
 
     // include dependencies


### PR DESCRIPTION
reverts a couple of minor regressions to the build.