### PR TITLE
vectorised first set bit in bitmap containers

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -1427,12 +1427,13 @@ public final class BitmapContainer extends Container implements Cloneable {
   @Override
   public int first() {
     assertNonEmpty(cardinality == 0);
-    int i = 0;
-    while(i < bitmap.length - 1 && bitmap[i] == 0) {
-      ++i; // seek forward
+    int firstNonEmptyWordIndex = ArraysShim.indexOfFirstNonEmptyWord(bitmap);
+    if (-1 == firstNonEmptyWordIndex) { // empty bitmap in lazy state
+      assertNonEmpty(true);
     }
     // sizeof(long) * #empty words at start + number of bits preceding the first bit set
-    return i * 64 + numberOfTrailingZeros(bitmap[i]);
+    long firstNonEmptyWord = bitmap[firstNonEmptyWordIndex];
+    return firstNonEmptyWordIndex * Long.SIZE + numberOfTrailingZeros(firstNonEmptyWord);
   }
 
   @Override

--- a/jmh/src/jmh/java/org/roaringbitmap/first/BitmapContainerFirst.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/first/BitmapContainerFirst.java
@@ -1,0 +1,32 @@
+package org.roaringbitmap.first;
+
+import org.openjdk.jmh.annotations.*;
+import org.roaringbitmap.BitmapContainer;
+
+import java.util.concurrent.TimeUnit;
+
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.Throughput)
+public class BitmapContainerFirst {
+
+  @State(Scope.Benchmark)
+  public static class BitmapState {
+
+    @Param({"10", "1000", "32000", "50000"})
+    int firstBit;
+
+    BitmapContainer bitmap;
+
+    @Setup(Level.Trial)
+    public void init() {
+      long[] bitmap = new long[1024];
+      bitmap[firstBit >>> 6] |= (1L << firstBit);
+      this.bitmap = new BitmapContainer(bitmap, 1);
+    }
+  }
+
+  @Benchmark
+  public int first(BitmapState state) {
+    return state.bitmap.first();
+  }
+}

--- a/shims/src/java11/java/org/roaringbitmap/ArraysShim.java
+++ b/shims/src/java11/java/org/roaringbitmap/ArraysShim.java
@@ -7,6 +7,8 @@ import java.util.Arrays;
  */
 public class ArraysShim {
 
+  private static final long[] EMPTY = new long[64];
+
   /**
    * Checks if the two arrays are equal within the given range.
    * @param x the first array
@@ -19,5 +21,19 @@ public class ArraysShim {
    */
   public static boolean equals(short[] x, int xmin, int xmax, short[] y, int ymin, int ymax) {
     return Arrays.equals(x, xmin, xmax, y, ymin, ymax);
+  }
+
+  /**
+   * Find the index of the first non empty word
+   *
+   * @param bitmap the bitmap
+   * @return the index of the first non empty word, or -1 if the bitmap is empty
+   */
+  public static int indexOfFirstNonEmptyWord(long[] bitmap) {
+    int firstNonEmpty = -1;
+    for (int i = 0; i < bitmap.length && firstNonEmpty == -1; i += EMPTY.length) {
+      firstNonEmpty = Arrays.mismatch(bitmap, i, i + EMPTY.length, EMPTY, 0, EMPTY.length);
+    }
+    return firstNonEmpty;
   }
 }

--- a/shims/src/main/java/org/roaringbitmap/ArraysShim.java
+++ b/shims/src/main/java/org/roaringbitmap/ArraysShim.java
@@ -28,4 +28,19 @@ public class ArraysShim {
     }
     return true;
   }
+
+  /**
+   * Find the index of the first non empty word.
+   *
+   * @param bitmap the bitmap
+   * @return the index of the first non empty word, or -1 if the bitmap is empty
+   */
+  public static int indexOfFirstNonEmptyWord(long[] bitmap) {
+    for (int i = 0; i < bitmap.length; ++i) {
+      if (bitmap[i] != 0) {
+        return i;
+      }
+    }
+    return -1;
+  }
 }


### PR DESCRIPTION
Uses multi release jar feature to allow vectorised scan for the first set bit in a `BitmapContainer`, improves throughput of `BitmapContainer.first` 2-3x. 

Does allocate a 2KB static final `long[]` however, interested in opinions on whether this is deemed an acceptable cost.