### PR TITLE
add specialised andNotCardinality for improved performance

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -12,6 +12,7 @@ import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.function.ToIntBiFunction;
 
 import static org.roaringbitmap.RoaringBitmapWriter.writer;
 import static org.roaringbitmap.Util.lowbitsAsInteger;
@@ -870,7 +871,42 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
    * @return cardinality of the left difference
    */
   public static int andNotCardinality(final RoaringBitmap x1, final RoaringBitmap x2) {
-    return x1.getCardinality() - andCardinality(x1, x2);
+    final int length1 = x1.highLowContainer.size(), length2 = x2.highLowContainer.size();
+
+    if (length2 > 4 * length1) {
+      // if x1 is much smaller than x2, this can be much faster
+      return x1.getCardinality() - andCardinality(x1, x2);
+    }
+
+    long cardinality = 0L;
+    int pos1 = 0, pos2 = 0;
+
+    while (pos1 < length1 && pos2 < length2) {
+      char s1 = x1.highLowContainer.getKeyAtIndex(pos1);
+      char s2 = x2.highLowContainer.getKeyAtIndex(pos2);
+      if (s1 == s2) {
+        final Container c1 = x1.highLowContainer.getContainerAtIndex(pos1);
+        final Container c2 = x2.highLowContainer.getContainerAtIndex(pos2);
+        cardinality += c1.getCardinality() - c1.andCardinality(c2);
+        ++pos1;
+        ++pos2;
+      } else if (s1 < s2) {
+        while (s1 < s2 && pos1 < length1) {
+          cardinality += x1.highLowContainer.getContainerAtIndex(pos1).getCardinality();
+          s1 = x1.highLowContainer.getKeyAtIndex(pos1);
+          ++pos1;
+        }
+      } else {
+        pos2 = x2.highLowContainer.advanceUntil(s1, pos2);
+      }
+    }
+    if (pos2 == length2) {
+      while (pos1 < length1) {
+        cardinality += x1.highLowContainer.getContainerAtIndex(pos1).getCardinality();
+        ++pos1;
+      }
+    }
+    return (int)cardinality;
   }
 
   /**

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -12,7 +12,6 @@ import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.function.ToIntBiFunction;
 
 import static org.roaringbitmap.RoaringBitmapWriter.writer;
 import static org.roaringbitmap.Util.lowbitsAsInteger;

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -2066,6 +2066,29 @@ public class TestRoaringBitmap {
     assertEquals(andNot.getCardinality(), RoaringBitmap.andNotCardinality(rb, rb2));
   }
 
+
+  @Test
+  public void testAndNotCardinalityBigVsSmall() {
+    RoaringBitmap small = RoaringBitmap.bitmapOf(1, 2, 3);
+    RoaringBitmap big = new RoaringBitmap();
+    for (int i = 0; i < 4000; ++i) {
+      big.add(1 + i * 0x1000);
+    }
+    RoaringBitmap andNot = RoaringBitmap.andNot(big, small);
+    assertEquals(andNot.getCardinality(), RoaringBitmap.andNotCardinality(big, small));
+  }
+
+  @Test
+  public void testAndNotCardinalitySmallVsBig() {
+    RoaringBitmap small = RoaringBitmap.bitmapOf(1, 2, 3);
+    RoaringBitmap big = new RoaringBitmap();
+    for (int i = 0; i < 4000; ++i) {
+        big.add(1 + i * 0x1000);
+    }
+    RoaringBitmap andNot = RoaringBitmap.andNot(small, big);
+    assertEquals(andNot.getCardinality(), RoaringBitmap.andNotCardinality(small, big));
+  }
+
   @Test
   public void ortest() {
     final RoaringBitmap rr = new RoaringBitmap();

--- a/jmh/src/jmh/java/org/roaringbitmap/combinedcardinality/CombinedCardinalityBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/combinedcardinality/CombinedCardinalityBenchmark.java
@@ -1,0 +1,102 @@
+package org.roaringbitmap.combinedcardinality;
+
+import org.openjdk.jmh.annotations.*;
+import org.roaringbitmap.RandomData;
+import org.roaringbitmap.RoaringBitmap;
+
+import java.util.concurrent.TimeUnit;
+
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@Fork(value = 1, jvmArgsPrepend =
+        {
+                "-XX:-TieredCompilation",
+                "-XX:+UseParallelGC",
+                "-mx2G",
+                "-ms2G",
+                "-XX:+AlwaysPreTouch"
+        })
+@State(Scope.Benchmark)
+public class CombinedCardinalityBenchmark {
+
+    public enum Scenario {
+        EQUAL {
+            @Override
+            RoaringBitmap[] bitmaps() {
+                RoaringBitmap bitmap = RandomData.randomBitmap(1 << 12, 0.2, 0.3);
+                return new RoaringBitmap[] {bitmap, bitmap.clone()};
+            }
+        },
+        SHIFTED {
+            @Override
+            RoaringBitmap[] bitmaps() {
+                RoaringBitmap bitmap = RandomData.randomBitmap(1 << 12, 0.2, 0.3);
+                return new RoaringBitmap[] {bitmap, RoaringBitmap.addOffset(bitmap, 1 << 16)};
+            }
+        },
+        SMALL_LARGE {
+            @Override
+            RoaringBitmap[] bitmaps() {
+                return new RoaringBitmap[] {
+                        RandomData.randomBitmap(1 << 4, 0.2, 0.3),
+                        RandomData.randomBitmap(1 << 12, 0.2, 0.3)
+                };
+            }
+        },
+        LARGE_SMALL {
+            @Override
+            RoaringBitmap[] bitmaps() {
+                return new RoaringBitmap[] {
+                        RandomData.randomBitmap(1 << 12, 0.2, 0.3),
+                        RandomData.randomBitmap(1 << 4, 0.2, 0.3)
+                };
+            }
+        }
+        ;
+        abstract RoaringBitmap[] bitmaps();
+    }
+
+    @Param
+    Scenario scenario;
+
+    RoaringBitmap left;
+    RoaringBitmap right;
+
+    @Setup(Level.Trial)
+    public void init() {
+        RoaringBitmap[] bitmaps = scenario.bitmaps();
+        left = bitmaps[0];
+        right = bitmaps[1];
+    }
+
+
+    @Benchmark
+    public int xorCardinality() {
+        return RoaringBitmap.xorCardinality(left, right);
+    }
+
+    @Benchmark
+    public int xorCardinalityBaseline() {
+        return left.getCardinality() + right.getCardinality() - 2 * RoaringBitmap.andCardinality(left, right);
+    }
+
+    @Benchmark
+    public int andNotCardinality() {
+        return RoaringBitmap.andNotCardinality(left, right);
+    }
+
+    @Benchmark
+    public int andNotCardinalityBaseline() {
+        return left.getCardinality() - RoaringBitmap.andCardinality(left, right);
+    }
+
+    @Benchmark
+    public int orCardinality() {
+        return RoaringBitmap.orCardinality(left, right);
+    }
+
+    @Benchmark
+    public int orCardinalityBaseline() {
+        return left.getCardinality() + right.getCardinality() - RoaringBitmap.andCardinality(left, right);
+    }
+}


### PR DESCRIPTION
Avoids passing over the containers twice in `RoaringBitmap.andNotCardinality` resulting in a speed up

```
Benchmark                                                (scenario)  Mode  Cnt      Score    Error  Units
CombinedCardinalityBenchmark.andNotCardinality                EQUAL  avgt    5  12824.490 ± 46.868  us/op
CombinedCardinalityBenchmark.andNotCardinality              SHIFTED  avgt    5   1436.731 ± 31.097  us/op
CombinedCardinalityBenchmark.andNotCardinality          SMALL_LARGE  avgt    5      0.823 ±  0.038  us/op
CombinedCardinalityBenchmark.andNotCardinality          LARGE_SMALL  avgt    5     78.883 ±  0.606  us/op
CombinedCardinalityBenchmark.andNotCardinalityBaseline        EQUAL  avgt    5  12746.360 ± 66.701  us/op
CombinedCardinalityBenchmark.andNotCardinalityBaseline      SHIFTED  avgt    5   2587.752 ± 82.145  us/op
CombinedCardinalityBenchmark.andNotCardinalityBaseline  SMALL_LARGE  avgt    5      0.811 ±  0.008  us/op
CombinedCardinalityBenchmark.andNotCardinalityBaseline  LARGE_SMALL  avgt    5     76.981 ±  2.118  us/op
```