### PR TITLE
Fix iremove cornercase in run container 

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -1618,7 +1618,7 @@ public final class RunContainer extends Container implements Cloneable {
 
       // last run is one shorter
       if (getLength(eIndex) == 0) {// special case where we remove last run
-        recoverRoomsInRange(eIndex, eIndex + 1);
+        recoverRoomsInRange(eIndex - 1, eIndex);
       } else {
         incrementValue(eIndex);
         decrementLength(eIndex);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -5265,4 +5265,19 @@ public class TestRoaringBitmap {
       rbB.runOptimize();
       assertNotEquals(rbB, rbA);
   }
+
+  @Test
+  public void regressionTestRemove377() {
+    // https://github.com/RoaringBitmap/RoaringBitmap/issues/377
+    RoaringBitmap map = new RoaringBitmap();
+    map.add(0L, 64L);
+    for (int i = 0; i < 64; i++) {
+      if (i != 30 && i != 32) {
+        map.remove(i);
+      }
+    }
+    map.remove(0L, 31L);
+    assertFalse(map.contains(30));
+    assertTrue(map.contains(32));
+  }
 }


### PR DESCRIPTION
Fixes issue #377 

Actually simpler than I thought. Test suite completes, I'm not entirely sure if I did the right thing though.

Note that `recoverRoomsInRange` is "begin exclusive, end inclusive" (which is quite weird).