### PR TITLE
Fix for issue 382

### DIFF
--- a/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitmapSubsetTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitmapSubsetTest.java
@@ -4,152 +4,146 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.*;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.Set;
 
-@RunWith(Parameterized.class)
+
 public class RoaringBitmapSubsetTest {
 
 
   private static final Predicate<Integer> DIVISIBLE_BY_4 = i -> i % 4 == 0;
 
   private static final Predicate<Integer> DIVISIBLE_BY_3 = i -> i % 3 == 0;
-
-  @Parameterized.Parameters(name = "assert that {1} is subset of {0}")
-  public static Object[][] params() {
-    return new Object[][]
-            {
-                    { // array vs array
-                            ImmutableSet.of(1, 2, 3, 4),
-                            ImmutableSet.of(2, 3)
-                    },
-                    { // array vs empty
-                            ImmutableSet.of(1, 2, 3, 4),
-                            ImmutableSet.of()
-                    },
-                    { // identical arrays
-                            ImmutableSet.of(1, 2, 3, 4),
-                            ImmutableSet.of(1, 2, 3, 4)
-                    },
-                    { // disjoint arrays
-                            ImmutableSet.of(10, 12, 14, 15),
-                            ImmutableSet.of(1, 2, 3, 4)
-                    },
-                    { // disjoint arrays, cardinality mismatch
-                            ImmutableSet.of(10, 12, 14),
-                            ImmutableSet.of(1, 2, 3, 4)
-                    },
-                    { // run vs array, subset
-                            ContiguousSet.create(Range.closed(1, 1 << 8), DiscreteDomain.integers()),
-                            ImmutableSet.of(1, 2, 3, 4)
-                    },
-                    { // run vs array, subset
-                            ContiguousSet.create(Range.closed(1, 1 << 16), DiscreteDomain.integers()),
-                            ImmutableSet.of(1, 2, 3, 4)
-                    },
-                    { // run vs empty
-                            ContiguousSet.create(Range.closed(1, 1 << 16), DiscreteDomain.integers()),
-                            ImmutableSet.of()
-                    },
-                    { // identical runs, 1 container
-                            ContiguousSet.create(Range.closed(1, 1 << 16), DiscreteDomain.integers()),
-                            ContiguousSet.create(Range.closed(1, 1 << 16), DiscreteDomain.integers())
-                    },
-                    { // identical runs, 2 containers
-                            ContiguousSet.create(Range.closed(1, 1 << 20), DiscreteDomain.integers()),
-                            ContiguousSet.create(Range.closed(1, 1 << 20), DiscreteDomain.integers())
-                    },
-                    { // disjoint array vs run, either side of container boundary
-                            ContiguousSet.create(Range.closed(1, 1 << 16), DiscreteDomain.integers()),
-                            ImmutableSet.of((1 << 16) + 1, (1 << 16) + 2, (1 << 16) + 3, (1 << 16) + 4)
-                    },
-                    { // disjoint array vs run
-                            ContiguousSet.create(Range.closed(3, 1 << 16), DiscreteDomain.integers()),
-                            ImmutableSet.of(1, 2)
-                    },
-                    { // run vs run, overlap with shift
-                            ContiguousSet.create(Range.closed(1, 1 << 8), DiscreteDomain.integers()),
-                            ContiguousSet.create(Range.closed(1 << 4, 1 << 12), DiscreteDomain.integers())
-                    },
-                    { // run vs run, subset
-                            ContiguousSet.create(Range.closed(1, 1 << 20), DiscreteDomain.integers()),
-                            ImmutableSet.of(1, 1 << 8)
-                    },
-                    { // run vs run, overlap with shift, 2 containers
-                            ContiguousSet.create(Range.closed(1, 1 << 20), DiscreteDomain.integers()),
-                            ImmutableSet.of(1 << 6, 1 << 26)
-                    },
-                    { // run vs 2 container run, overlap
-                            ImmutableSet.of(1, 1 << 16),
-                            ContiguousSet.create(Range.closed(0, 1 << 20), DiscreteDomain.integers())
-                    },
-                    { // bitmap vs intersecting array
-                            ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 15),
-                                                                                      DiscreteDomain.integers()),
-                                                                 DIVISIBLE_BY_4)),
-                            ImmutableSet.of(4, 8)
-                    },
-                    { // bitmap vs bitmap, cardinality mismatch
-                            ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 16),
-                                                                                      DiscreteDomain.integers()),
-                                                                 DIVISIBLE_BY_4)),
-                            ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 15),
-                                                                                      DiscreteDomain.integers()),
-                                                                 DIVISIBLE_BY_4))
-                    },
-                    { // bitmap vs empty
-                            ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 15),
-                                                                                      DiscreteDomain.integers()),
-                                                                 DIVISIBLE_BY_4)),
-                            ImmutableSet.of()
-                    },
-                    { // identical bitmaps
-                            ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 15),
-                                                                                      DiscreteDomain.integers()),
-                                                                 DIVISIBLE_BY_4)),
-                            ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 15),
-                                                                                      DiscreteDomain.integers()),
-                                                                 DIVISIBLE_BY_4))
-                    },
-                    { // bitmap vs overlapping but disjoint array
-                            ImmutableSet.of(3, 7),
-                            ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 15),
-                                                                                      DiscreteDomain.integers()),
-                                                                 DIVISIBLE_BY_4))
-                    },
-                    { // bitmap vs overlapping but disjoint bitmap
-                      ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 15),
-                                                                                DiscreteDomain.integers()),
-                                                           DIVISIBLE_BY_3)),
-                      ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 15),
-                                                                                DiscreteDomain.integers()),
-                                                           DIVISIBLE_BY_4))
-                    },
-                    { // disjoint, large (signed-negative) keys
-                            ImmutableSet.of(0xbf09001d,0xbf090169),
-                            ImmutableSet.of(0x8088000e,0x80880029)
-                    }
-            };
+  public static ImmutableSet<Integer>[][] params() {
+        return new ImmutableSet[][]
+                {
+                        { // array vs array
+                                ImmutableSet.of(1, 2, 3, 4),
+                                ImmutableSet.of(2, 3)
+                        },
+                        { // array vs empty
+                                ImmutableSet.of(1, 2, 3, 4),
+                                ImmutableSet.of()
+                        },
+                        { // identical arrays
+                                ImmutableSet.of(1, 2, 3, 4),
+                                ImmutableSet.of(1, 2, 3, 4)
+                        },
+                        { // disjoint arrays
+                                ImmutableSet.of(10, 12, 14, 15),
+                                ImmutableSet.of(1, 2, 3, 4)
+                        },
+                        { // disjoint arrays, cardinality mismatch
+                                ImmutableSet.of(10, 12, 14),
+                                ImmutableSet.of(1, 2, 3, 4)
+                        },
+                        { // run vs array, subset
+                                ContiguousSet.create(Range.closed(1, 1 << 8), DiscreteDomain.integers()),
+                                ImmutableSet.of(1, 2, 3, 4)
+                        },
+                        { // run vs array, subset
+                                ContiguousSet.create(Range.closed(1, 1 << 16), DiscreteDomain.integers()),
+                                ImmutableSet.of(1, 2, 3, 4)
+                        },
+                        { // run vs empty
+                                ContiguousSet.create(Range.closed(1, 1 << 16), DiscreteDomain.integers()),
+                                ImmutableSet.of()
+                        },
+                        { // identical runs, 1 container
+                                ContiguousSet.create(Range.closed(1, 1 << 16), DiscreteDomain.integers()),
+                                ContiguousSet.create(Range.closed(1, 1 << 16), DiscreteDomain.integers())
+                        },
+                        { // identical runs, 2 containers
+                                ContiguousSet.create(Range.closed(1, 1 << 20), DiscreteDomain.integers()),
+                                ContiguousSet.create(Range.closed(1, 1 << 20), DiscreteDomain.integers())
+                        },
+                        { // disjoint array vs run, either side of container boundary
+                                ContiguousSet.create(Range.closed(1, 1 << 16), DiscreteDomain.integers()),
+                                ImmutableSet.of((1 << 16) + 1, (1 << 16) + 2, (1 << 16) + 3, (1 << 16) + 4)
+                        },
+                        { // disjoint array vs run
+                                ContiguousSet.create(Range.closed(3, 1 << 16), DiscreteDomain.integers()),
+                                ImmutableSet.of(1, 2)
+                        },
+                        { // run vs run, overlap with shift
+                                ContiguousSet.create(Range.closed(1, 1 << 8), DiscreteDomain.integers()),
+                                ContiguousSet.create(Range.closed(1 << 4, 1 << 12), DiscreteDomain.integers())
+                        },
+                        { // run vs run, subset
+                                ContiguousSet.create(Range.closed(1, 1 << 20), DiscreteDomain.integers()),
+                                ImmutableSet.of(1, 1 << 8)
+                        },
+                        { // run vs run, overlap with shift, 2 containers
+                                ContiguousSet.create(Range.closed(1, 1 << 20), DiscreteDomain.integers()),
+                                ImmutableSet.of(1 << 6, 1 << 26)
+                        },
+                        { // run vs 2 container run, overlap
+                                ImmutableSet.of(1, 1 << 16),
+                                ContiguousSet.create(Range.closed(0, 1 << 20), DiscreteDomain.integers())
+                        },
+                        { // bitmap vs intersecting array
+                                ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 15),
+                                                                                          DiscreteDomain.integers()),
+                                                                     DIVISIBLE_BY_4)),
+                                ImmutableSet.of(4, 8)
+                        },
+                        { // bitmap vs bitmap, cardinality mismatch
+                                ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 16),
+                                                                                          DiscreteDomain.integers()),
+                                                                     DIVISIBLE_BY_4)),
+                                ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 15),
+                                                                                          DiscreteDomain.integers()),
+                                                                     DIVISIBLE_BY_4))
+                        },
+                        { // bitmap vs empty
+                                ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 15),
+                                                                                          DiscreteDomain.integers()),
+                                                                     DIVISIBLE_BY_4)),
+                                ImmutableSet.of()
+                        },
+                        { // identical bitmaps
+                                ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 15),
+                                                                                          DiscreteDomain.integers()),
+                                                                     DIVISIBLE_BY_4)),
+                                ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 15),
+                                                                                          DiscreteDomain.integers()),
+                                                                     DIVISIBLE_BY_4))
+                        },
+                        { // bitmap vs overlapping but disjoint array
+                                ImmutableSet.of(3, 7),
+                                ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 15),
+                                                                                          DiscreteDomain.integers()),
+                                                                     DIVISIBLE_BY_4))
+                        },
+                        { // bitmap vs overlapping but disjoint bitmap
+                          ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 15),
+                                                                                    DiscreteDomain.integers()),
+                                                               DIVISIBLE_BY_3)),
+                          ImmutableSet.copyOf(Iterables.filter(ContiguousSet.create(Range.closed(1, 1 << 15),
+                                                                                    DiscreteDomain.integers()),
+                                                               DIVISIBLE_BY_4))
+                        },
+                        { // disjoint, large (signed-negative) keys
+                                ImmutableSet.of(0xbf09001d,0xbf090169),
+                                ImmutableSet.of(0x8088000e,0x80880029)
+                        }
+                };
   }
 
-  private final Set<Integer> superSet;
-  private final Set<Integer> subSet;
 
-  public RoaringBitmapSubsetTest(Set<Integer> superSet, Set<Integer> subSet) {
-    this.superSet = superSet;
-    this.subSet = subSet;
-  }
 
 
   @Test
   public void testProperSubset() {
-    RoaringBitmap superSetRB = create(superSet);
-    RoaringBitmap subSetRB = create(subSet);
-    Assert.assertEquals(superSet.containsAll(subSet), superSetRB.contains(subSetRB));
-    // reverse the test
-    Assert.assertEquals(subSet.containsAll(superSet), subSetRB.contains(superSetRB));
+    for(ImmutableSet<Integer>[] x : params() ) {
+      ImmutableSet<Integer> superSet = x[0];
+      ImmutableSet<Integer> subSet = x[1];
+      RoaringBitmap superSetRB = create(superSet);
+      RoaringBitmap subSetRB = create(subSet);
+      Assert.assertEquals(superSet.containsAll(subSet), superSetRB.contains(subSetRB));
+      // reverse the test
+      Assert.assertEquals(subSet.containsAll(superSet), subSetRB.contains(superSetRB));
+    }
   }
 
   private RoaringBitmap create(Set<Integer> set) {

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/MutableRoaringBitmapSubsetTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/MutableRoaringBitmapSubsetTest.java
@@ -4,12 +4,9 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.*;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.Set;
 
-@RunWith(Parameterized.class)
 public class MutableRoaringBitmapSubsetTest {
 
 
@@ -17,9 +14,8 @@ public class MutableRoaringBitmapSubsetTest {
 
   private static final Predicate<Integer> DIVISIBLE_BY_3 = i -> i % 3 == 0;
 
-  @Parameterized.Parameters(name = "assert that {1} is subset of {0}")
-  public static Object[][] params() {
-    return new Object[][]
+  public static ImmutableSet<Integer>[][] params() {
+    return new ImmutableSet[][]
             {
                     { // array vs array
                             ImmutableSet.of(1, 2, 3, 4),
@@ -134,22 +130,19 @@ public class MutableRoaringBitmapSubsetTest {
             };
   }
 
-  private final Set<Integer> superSet;
-  private final Set<Integer> subSet;
-
-  public MutableRoaringBitmapSubsetTest(Set<Integer> superSet, Set<Integer> subSet) {
-    this.superSet = superSet;
-    this.subSet = subSet;
-  }
 
 
   @Test
   public void testProperSubset() {
-    MutableRoaringBitmap superSetRB = create(superSet);
-    MutableRoaringBitmap subSetRB = create(subSet);
-    Assert.assertEquals(superSet.containsAll(subSet), superSetRB.contains(subSetRB));
-    // reverse the test
-    Assert.assertEquals(subSet.containsAll(superSet), subSetRB.contains(superSetRB));
+    for(ImmutableSet<Integer>[] x : params() ) {
+      ImmutableSet<Integer> superSet = x[0];
+      ImmutableSet<Integer> subSet = x[1];
+      MutableRoaringBitmap superSetRB = create(superSet);
+      MutableRoaringBitmap subSetRB = create(subSet);
+      Assert.assertEquals(superSet.containsAll(subSet), superSetRB.contains(subSetRB));
+      // reverse the test
+      Assert.assertEquals(subSet.containsAll(superSet), subSetRB.contains(superSetRB));
+    }
   }
   
   private MutableRoaringBitmap create(Set<Integer> set) {


### PR DESCRIPTION
With this patch, running a single short test with gradle takes 21 second on a powerful iMac. That's still an order of magnitude longer than it should take, but a hell of a lot better than what we currently have in master... where it can take minutes...

```
$ time ./gradlew :roaringbitmap:test --tests *testIndexIterator4
Starting a Gradle Daemon (subsequent builds will be faster)

> Task :RoaringBitmap:compileTestJava
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

BUILD SUCCESSFUL in 21s
7 actionable tasks: 2 executed, 5 up-to-date

real	0m21.967s
user	0m1.118s
sys	0m0.147s
```

If you think that this is not necessary, please tell me how long ` ./gradlew :roaringbitmap:test --tests *testIndexIterator4` takes to run for you. Please don't tell me that it is fine in some IDE that is configured in a certain way... this should work right out of the box in gradle. 

Fixes https://github.com/RoaringBitmap/RoaringBitmap/issues/382