### PR TITLE
Runcontainer efficiency

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -316,6 +316,25 @@ public final class BitmapContainer extends Container implements Cloneable {
     this.cardinality = oldCardinality - prevOnes + newOnes;
   }
 
+  boolean isNonEmptyInRange(int start, int end) {
+    if (start >= end) {
+      return false;
+    }
+    int firstword = start >>> 6;
+    int endword = (end - 1) >>> 6;
+    if (firstword == endword) {
+      return (bitmap[firstword] & ( (~0L << start) & (~0L >>> -end) )) > 0;
+    }
+    if ((bitmap[firstword] & (~0L << start)) == 0) {
+      for (int i = firstword + 1; i < endword; i++) {
+        if (bitmap[i] != 0) {
+          return true;
+        }
+      }
+    }
+    return (bitmap[endword] & (~0L >>> -end)) > 0;
+  }
+
   @Override
   public boolean contains(final char i) {
     return (bitmap[i >>> 6] & (1L << i)) != 0;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -323,16 +323,17 @@ public final class BitmapContainer extends Container implements Cloneable {
     int firstword = start >>> 6;
     int endword = (end - 1) >>> 6;
     if (firstword == endword) {
-      return (bitmap[firstword] & ( (~0L << start) & (~0L >>> -end) )) > 0;
+      return (bitmap[firstword] & ( (~0L << start) & (~0L >>> -end) )) != 0;
     }
-    if ((bitmap[firstword] & (~0L << start)) == 0) {
-      for (int i = firstword + 1; i < endword; i++) {
-        if (bitmap[i] != 0) {
-          return true;
-        }
+    if ((bitmap[firstword] & (~0L << start)) != 0) {
+      return true;
+    }
+    for (int i = firstword + 1; i < endword; i++) {
+      if (bitmap[i] != 0) {
+        return true;
       }
     }
-    return (bitmap[endword] & (~0L >>> -end)) > 0;
+    return (bitmap[endword] & (~0L >>> -end)) != 0;
   }
 
   @Override

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -316,26 +316,6 @@ public final class BitmapContainer extends Container implements Cloneable {
     this.cardinality = oldCardinality - prevOnes + newOnes;
   }
 
-  boolean isNonEmptyInRange(int start, int end) {
-    if (start >= end) {
-      return false;
-    }
-    int firstword = start >>> 6;
-    int endword = (end - 1) >>> 6;
-    if (firstword == endword) {
-      return (bitmap[firstword] & ( (~0L << start) & (~0L >>> -end) )) != 0;
-    }
-    if ((bitmap[firstword] & (~0L << start)) != 0) {
-      return true;
-    }
-    for (int i = firstword + 1; i < endword; i++) {
-      if (bitmap[i] != 0) {
-        return true;
-      }
-    }
-    return (bitmap[endword] & (~0L >>> -end)) != 0;
-  }
-
   @Override
   public boolean contains(final char i) {
     return (bitmap[i >>> 6] & (1L << i)) != 0;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringArray.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringArray.java
@@ -552,7 +552,7 @@ public final class RoaringArray implements Cloneable, Externalizable, Appendable
     buffer.order(LITTLE_ENDIAN);
     final int cookie = buffer.getInt();
     if ((cookie & 0xFFFF) != SERIAL_COOKIE && cookie != SERIAL_COOKIE_NO_RUNCONTAINER) {
-      throw new RuntimeException("I failed to find one of the right cookies. " + cookie);
+      throw new InvalidRoaringFormat("I failed to find one of the right cookies. " + cookie);
     }
     boolean hasRunContainers = (cookie & 0xFFFF) == SERIAL_COOKIE;
     this.size = hasRunContainers ? (cookie >>> 16) + 1 : buffer.getInt();

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -1406,7 +1406,7 @@ public final class RunContainer extends Container implements Cloneable {
     for (int run = 0; run < this.nbrruns; ++run) {
       int runStart = this.getValue(run);
       int runEnd = runStart + this.getLength(run);
-      if (x.isNonEmptyInRange(runStart, runEnd + 1)) {
+      if (x.intersects(runStart, runEnd + 1)) {
         return true;
       }
     }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -492,14 +492,9 @@ public final class RunContainer extends Container implements Cloneable {
     // could be implemented as return toBitmapOrArrayContainer().iand(x);
     int cardinality = 0;
     for (int rlepos = 0; rlepos < this.nbrruns; ++rlepos) {
-      int runStart = (this.getValue(rlepos));
-      int runEnd = runStart + (this.getLength(rlepos));
-      for (int runValue = runStart; runValue <= runEnd; ++runValue) {
-        if (x.contains((char) runValue)) {// it looks like contains() should be cheap enough if
-                                           // accessed sequentially
-          cardinality++;
-        }
-      }
+      int runStart = this.getValue(rlepos);
+      int runEnd = runStart + this.getLength(rlepos);
+      cardinality += x.cardinalityInRange(runStart, runEnd + 1);
     }
     return cardinality;
   }
@@ -745,8 +740,8 @@ public final class RunContainer extends Container implements Cloneable {
     }
     index = -index - 2; // points to preceding value, possibly -1
     if (index != -1) {// possible match
-      int offset = (x) - (getValue(index));
-      int le = (getLength(index));
+      int offset = x - getValue(index);
+      int le = getLength(index);
       return offset <= le;
     }
     return false;
@@ -1385,8 +1380,8 @@ public final class RunContainer extends Container implements Cloneable {
     }
     int rlepos = 0;
     int arraypos = 0;
-    int rleval = (this.getValue(rlepos));
-    int rlelength = (this.getLength(rlepos));
+    int rleval = this.getValue(rlepos);
+    int rlelength = this.getLength(rlepos);
     while (arraypos < x.cardinality) {
       int arrayval = (x.content[arraypos]);
       while (rleval + rlelength < arrayval) {// this will frequently be false
@@ -1394,8 +1389,8 @@ public final class RunContainer extends Container implements Cloneable {
         if (rlepos == this.nbrruns) {
           return false;
         }
-        rleval = (this.getValue(rlepos));
-        rlelength = (this.getLength(rlepos));
+        rleval = this.getValue(rlepos);
+        rlelength = this.getLength(rlepos);
       }
       if (rleval > arrayval) {
         arraypos = Util.advanceUntil(x.content, arraypos, x.cardinality, this.getValue(rlepos));
@@ -1408,14 +1403,11 @@ public final class RunContainer extends Container implements Cloneable {
 
   @Override
   public boolean intersects(BitmapContainer x) {
-    // TODO: this is probably not optimally fast
-    for (int rlepos = 0; rlepos < this.nbrruns; ++rlepos) {
-      int runStart = (this.getValue(rlepos));
-      int runEnd = runStart + (this.getLength(rlepos));
-      for (int runValue = runStart; runValue <= runEnd; ++runValue) {
-        if (x.contains((char) runValue)) {
-          return true;
-        }
+    for (int run = 0; run < this.nbrruns; ++run) {
+      int runStart = this.getValue(run);
+      int runEnd = runStart + this.getLength(run);
+      if (x.isNonEmptyInRange(runStart, runEnd + 1)) {
+        return true;
       }
     }
     return false;
@@ -1425,11 +1417,11 @@ public final class RunContainer extends Container implements Cloneable {
   public boolean intersects(RunContainer x) {
     int rlepos = 0;
     int xrlepos = 0;
-    int start = (this.getValue(rlepos));
-    int end = start + (this.getLength(rlepos)) + 1;
-    int xstart = (x.getValue(xrlepos));
-    int xend = xstart + (x.getLength(xrlepos)) + 1;
-    while ((rlepos < this.nbrruns) && (xrlepos < x.nbrruns)) {
+    int start = this.getValue(rlepos);
+    int end = start + this.getLength(rlepos) + 1;
+    int xstart = x.getValue(xrlepos);
+    int xend = xstart + x.getLength(xrlepos) + 1;
+    while (rlepos < this.nbrruns && xrlepos < x.nbrruns) {
       if (end <= xstart) {
         if (ENABLE_GALLOPING_AND) {
           rlepos = skipAhead(this, rlepos, xstart); // skip over runs until we have end > xstart (or

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringArray.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringArray.java
@@ -4,6 +4,8 @@
 
 package org.roaringbitmap.buffer;
 
+import org.roaringbitmap.InvalidRoaringFormat;
+
 import java.io.DataOutput;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -43,7 +45,7 @@ public final class ImmutableRoaringArray implements PointableRoaringArray {
     buffer.order(ByteOrder.LITTLE_ENDIAN);
     final int cookie = buffer.getInt(0);
     if ((cookie & 0xFFFF) != SERIAL_COOKIE && cookie != SERIAL_COOKIE_NO_RUNCONTAINER) {
-      throw new RuntimeException("I failed to find one of the right cookies. " + cookie);
+      throw new InvalidRoaringFormat("I failed to find one of the right cookies. " + cookie);
     }
     boolean hasRunContainers = (cookie & 0xFFFF) == SERIAL_COOKIE;
     this.size = hasRunContainers ? (cookie >>> 16) + 1 : buffer.getInt(4);

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -396,26 +396,6 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
     this.cardinality = oldCardinality - prevOnes + newOnes;
   }
 
-  boolean isNonEmptyInRange(int start, int end) {
-    if (start >= end) {
-      return false;
-    }
-    int firstword = start >>> 6;
-    int endword = (end - 1) >>> 6;
-    if (firstword == endword) {
-      return (bitmap.get(firstword) & ( (~0L << start) & (~0L >>> -end) )) != 0;
-    }
-    if ((bitmap.get(firstword) & (~0L << start)) != 0) {
-      return true;
-    }
-    for (int i = firstword + 1; i < endword; i++) {
-      if (bitmap.get(i) != 0) {
-        return true;
-      }
-    }
-    return (bitmap.get(endword) & (~0L >>> -end)) != 0;
-  }
-
   @Override
   public boolean contains(final char i) {
     return (bitmap.get(i >>> 6) & (1L << i)) != 0;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -396,6 +396,25 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
     this.cardinality = oldCardinality - prevOnes + newOnes;
   }
 
+  boolean isNonEmptyInRange(int start, int end) {
+    if (start >= end) {
+      return false;
+    }
+    int firstword = start >>> 6;
+    int endword = (end - 1) >>> 6;
+    if (firstword == endword) {
+      return (bitmap.get(firstword) & ( (~0L << start) & (~0L >>> -end) )) > 0;
+    }
+    if ((bitmap.get(firstword) & (~0L << start)) == 0) {
+      for (int i = firstword + 1; i < endword; i++) {
+        if (bitmap.get(i) != 0) {
+          return true;
+        }
+      }
+    }
+    return (bitmap.get(endword) & (~0L >>> -end)) > 0;
+  }
+
   @Override
   public boolean contains(final char i) {
     return (bitmap.get(i >>> 6) & (1L << i)) != 0;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -403,16 +403,17 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
     int firstword = start >>> 6;
     int endword = (end - 1) >>> 6;
     if (firstword == endword) {
-      return (bitmap.get(firstword) & ( (~0L << start) & (~0L >>> -end) )) > 0;
+      return (bitmap.get(firstword) & ( (~0L << start) & (~0L >>> -end) )) != 0;
     }
-    if ((bitmap.get(firstword) & (~0L << start)) == 0) {
-      for (int i = firstword + 1; i < endword; i++) {
-        if (bitmap.get(i) != 0) {
-          return true;
-        }
+    if ((bitmap.get(firstword) & (~0L << start)) != 0) {
+      return true;
+    }
+    for (int i = firstword + 1; i < endword; i++) {
+      if (bitmap.get(i) != 0) {
+        return true;
       }
     }
-    return (bitmap.get(endword) & (~0L >>> -end)) > 0;
+    return (bitmap.get(endword) & (~0L >>> -end)) != 0;
   }
 
   @Override

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -1324,14 +1324,11 @@ public final class MappeableRunContainer extends MappeableContainer implements C
 
   @Override
   public boolean intersects(MappeableBitmapContainer x) {
-    // possibly inefficient
     for (int rlepos = 0; rlepos < this.nbrruns; ++rlepos) {
-      int runStart = (this.getValue(rlepos));
-      int runEnd = runStart + (this.getLength(rlepos));
-      for (int runValue = runStart; runValue <= runEnd; ++runValue) {
-        if (x.contains((char) runValue)) {
-          return true;
-        }
+      int runStart = this.getValue(rlepos);
+      int runEnd = runStart + this.getLength(rlepos);
+      if (x.isNonEmptyInRange(runStart, runEnd + 1)) {
+        return true;
       }
     }
     return false;
@@ -2492,14 +2489,9 @@ public final class MappeableRunContainer extends MappeableContainer implements C
     // could be implemented as return toBitmapOrArrayContainer().iand(x);
     int cardinality = 0;
     for (int rlepos = 0; rlepos < this.nbrruns; ++rlepos) {
-      int runStart = (this.getValue(rlepos));
-      int runEnd = runStart + (this.getLength(rlepos));
-      for (int runValue = runStart; runValue <= runEnd; ++runValue) {
-        if (x.contains((char) runValue)) {// it looks like contains() should be cheap enough if
-                                           // accessed sequentially
-          cardinality++;
-        }
-      }
+      int runStart = this.getValue(rlepos);
+      int runEnd = runStart + this.getLength(rlepos);
+      cardinality += x.cardinalityInRange(runStart, runEnd + 1);
     }
     return cardinality;
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -1327,7 +1327,7 @@ public final class MappeableRunContainer extends MappeableContainer implements C
     for (int rlepos = 0; rlepos < this.nbrruns; ++rlepos) {
       int runStart = this.getValue(rlepos);
       int runEnd = runStart + this.getLength(rlepos);
-      if (x.isNonEmptyInRange(runStart, runEnd + 1)) {
+      if (x.intersects(runStart, runEnd + 1)) {
         return true;
       }
     }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
@@ -350,7 +350,7 @@ public final class MutableRoaringArray implements Cloneable, Externalizable, Poi
     ByteBuffer buffer = bbf.order() == LITTLE_ENDIAN ? bbf : bbf.slice().order(LITTLE_ENDIAN);
     final int cookie = buffer.getInt();
     if ((cookie & 0xFFFF) != SERIAL_COOKIE && cookie != SERIAL_COOKIE_NO_RUNCONTAINER) {
-      throw new RuntimeException("I failed to find one of the right cookies. " + cookie);
+      throw new InvalidRoaringFormat("I failed to find one of the right cookies. " + cookie);
     }
     boolean hasRunContainers = (cookie & 0xFFFF) == SERIAL_COOKIE;
     this.size = hasRunContainers ? (cookie >>> 16) + 1 : buffer.getInt();

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitmapBatchIteratorTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitmapBatchIteratorTest.java
@@ -37,7 +37,7 @@ public class RoaringBitmapBatchIteratorTest {
                 new RoaringBitmap()
         ).flatMap(bitmap -> IntStream.concat(
                 IntStream.of(128, 256, 1024, 65536, 8192),
-                IntStream.range(0, 10).map(i -> ThreadLocalRandom.current().nextInt(0, 1 << 16))
+                IntStream.range(0, 10).map(i -> ThreadLocalRandom.current().nextInt(1, 1 << 16))
         ).mapToObj(i -> Arguments.of(bitmap, i)));
     }
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitmapContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitmapContainer.java
@@ -7,6 +7,8 @@ package org.roaringbitmap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.roaringbitmap.buffer.MappeableBitmapContainer;
+import org.roaringbitmap.buffer.MappeableContainer;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -1260,6 +1262,43 @@ public class TestBitmapContainer {
     assertEquals(((1 << 15) | 6), container.nextAbsentValue((char)((1 << 15) | 6)));
     assertEquals(((1 << 15) | 8), container.nextAbsentValue((char)((1 << 15) | 7)));
     assertEquals(((1 << 15) | 8), container.nextAbsentValue((char)((1 << 15) | 8)));
+  }
+
+  @Test
+  public void testNonEmptyInRangeBadRange() {
+    BitmapContainer bc = new BitmapContainer();
+    assertFalse(bc.isNonEmptyInRange(1, 0));
+  }
+
+  @Test
+  public void testNonEmptyInRangeIntraWordEmpty() {
+    BitmapContainer bc = new BitmapContainer();
+    assertFalse(bc.isNonEmptyInRange(65, 70));
+  }
+
+  @Test
+  public void testNonEmptyInRangeIntraWordNonEmpty() {
+    Container bc = new BitmapContainer().add((char)66);
+    assertTrue(((BitmapContainer)bc).isNonEmptyInRange(65, 70));
+  }
+
+  @Test
+  public void testNonEmptyInRangeNonEmptyInFirstWord() {
+    Container bc = new BitmapContainer().add((char)66);
+    assertTrue(((BitmapContainer)bc).isNonEmptyInRange(65, 1000));
+  }
+
+  @Test
+  public void testNonEmptyInRangeNonEmptyInLastWord() {
+    Container bc = new BitmapContainer().add((char)999);
+    assertTrue(((BitmapContainer)bc).isNonEmptyInRange(65, 1000));
+  }
+
+
+  @Test
+  public void testNonEmptyInRangeNonEmptyInMiddle() {
+    Container bc = new BitmapContainer().add((char)600);
+    assertTrue(((BitmapContainer)bc).isNonEmptyInRange(65, 1000));
   }
 
   private static long[] evenBits() {

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitmapContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitmapContainer.java
@@ -7,8 +7,6 @@ package org.roaringbitmap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.roaringbitmap.buffer.MappeableBitmapContainer;
-import org.roaringbitmap.buffer.MappeableContainer;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitmapContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitmapContainer.java
@@ -7,6 +7,9 @@ package org.roaringbitmap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -16,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
 import java.util.Random;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -887,6 +891,21 @@ public class TestBitmapContainer {
     assertFalse(container.intersects(11, lower16Bits(-1)));
   }
 
+  public static Stream<Arguments> bitmapsForRangeIntersection() {
+    return Stream.of(
+            Arguments.of(new BitmapContainer().add((char)60), 0, 61, true),
+            Arguments.of(new BitmapContainer().add((char)60), 0, 60, false),
+            Arguments.of(new BitmapContainer().add((char)1000), 0, 1001, true),
+            Arguments.of(new BitmapContainer().add((char)1000), 0, 1000, false),
+            Arguments.of(new BitmapContainer().add((char)1000), 0, 10000, true)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitmapsForRangeIntersection")
+  public void testIntersectsWithRangeUpperBoundaries(Container container, int min, int sup, boolean intersects) {
+    assertEquals(intersects, container.intersects(min, sup));
+  }
 
   @Test
   public void testIntersectsWithRangeHitScan() {
@@ -1260,43 +1279,6 @@ public class TestBitmapContainer {
     assertEquals(((1 << 15) | 6), container.nextAbsentValue((char)((1 << 15) | 6)));
     assertEquals(((1 << 15) | 8), container.nextAbsentValue((char)((1 << 15) | 7)));
     assertEquals(((1 << 15) | 8), container.nextAbsentValue((char)((1 << 15) | 8)));
-  }
-
-  @Test
-  public void testNonEmptyInRangeBadRange() {
-    BitmapContainer bc = new BitmapContainer();
-    assertFalse(bc.isNonEmptyInRange(1, 0));
-  }
-
-  @Test
-  public void testNonEmptyInRangeIntraWordEmpty() {
-    BitmapContainer bc = new BitmapContainer();
-    assertFalse(bc.isNonEmptyInRange(65, 70));
-  }
-
-  @Test
-  public void testNonEmptyInRangeIntraWordNonEmpty() {
-    Container bc = new BitmapContainer().add((char)66);
-    assertTrue(((BitmapContainer)bc).isNonEmptyInRange(65, 70));
-  }
-
-  @Test
-  public void testNonEmptyInRangeNonEmptyInFirstWord() {
-    Container bc = new BitmapContainer().add((char)66);
-    assertTrue(((BitmapContainer)bc).isNonEmptyInRange(65, 1000));
-  }
-
-  @Test
-  public void testNonEmptyInRangeNonEmptyInLastWord() {
-    Container bc = new BitmapContainer().add((char)999);
-    assertTrue(((BitmapContainer)bc).isNonEmptyInRange(65, 1000));
-  }
-
-
-  @Test
-  public void testNonEmptyInRangeNonEmptyInMiddle() {
-    Container bc = new BitmapContainer().add((char)600);
-    assertTrue(((BitmapContainer)bc).isNonEmptyInRange(65, 1000));
   }
 
   private static long[] evenBits() {

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/ImmutableRoaringBitmapBatchIteratorTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/ImmutableRoaringBitmapBatchIteratorTest.java
@@ -40,7 +40,7 @@ public class ImmutableRoaringBitmapBatchIteratorTest {
                 new MutableRoaringBitmap()
         ).flatMap(bitmap -> IntStream.concat(
                 IntStream.of(128, 256, 1024, 65536, 8192),
-                IntStream.range(0, 10).map(i -> ThreadLocalRandom.current().nextInt(0, 1 << 16))
+                IntStream.range(0, 10).map(i -> ThreadLocalRandom.current().nextInt(1, 1 << 16))
         ).mapToObj(i -> Arguments.of(bitmap, i)));
     }
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
@@ -1522,6 +1522,6 @@ public class TestImmutableRoaringBitmap {
 
   @Test
   public void invalidCookie() {
-    assertThrows(RuntimeException.class, () -> new ImmutableRoaringBitmap(ByteBuffer.allocate(8)));
+    assertThrows(InvalidRoaringFormat.class, () -> new ImmutableRoaringBitmap(ByteBuffer.allocate(8)));
   }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
@@ -1522,6 +1522,6 @@ public class TestImmutableRoaringBitmap {
 
   @Test
   public void invalidCookie() {
-    assertThrows(InvalidRoaringFormat.class, () -> new ImmutableRoaringBitmap(ByteBuffer.allocate(4)));
+    assertThrows(RuntimeException.class, () -> new ImmutableRoaringBitmap(ByteBuffer.allocate(8)));
   }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestMappeableBitmapContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestMappeableBitmapContainer.java
@@ -1079,6 +1079,43 @@ public class TestMappeableBitmapContainer {
     assertEquals(((1 << 15) | 8), container.nextAbsentValue((char)((1 << 15) | 8)));
   }
 
+  @Test
+  public void testNonEmptyInRangeBadRange() {
+    MappeableBitmapContainer bc = new MappeableBitmapContainer();
+    assertFalse(bc.isNonEmptyInRange(1, 0));
+  }
+
+  @Test
+  public void testNonEmptyInRangeIntraWordEmpty() {
+    MappeableBitmapContainer bc = new MappeableBitmapContainer();
+    assertFalse(bc.isNonEmptyInRange(65, 70));
+  }
+
+  @Test
+  public void testNonEmptyInRangeIntraWordNonEmpty() {
+    MappeableContainer bc = new MappeableBitmapContainer().add((char)66);
+    assertTrue(((MappeableBitmapContainer)bc).isNonEmptyInRange(65, 70));
+  }
+
+  @Test
+  public void testNonEmptyInRangeNonEmptyInFirstWord() {
+    MappeableContainer bc = new MappeableBitmapContainer().add((char)66);
+    assertTrue(((MappeableBitmapContainer)bc).isNonEmptyInRange(65, 1000));
+  }
+
+  @Test
+  public void testNonEmptyInRangeNonEmptyInLastWord() {
+    MappeableContainer bc = new MappeableBitmapContainer().add((char)999);
+    assertTrue(((MappeableBitmapContainer)bc).isNonEmptyInRange(65, 1000));
+  }
+
+
+  @Test
+  public void testNonEmptyInRangeNonEmptyInMiddle() {
+    MappeableContainer bc = new MappeableBitmapContainer().add((char)600);
+    assertTrue(((MappeableBitmapContainer)bc).isNonEmptyInRange(65, 1000));
+  }
+
 
   private static long[] evenBits() {
     long[] bitmap = new long[1 << 10];

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestMappeableBitmapContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestMappeableBitmapContainer.java
@@ -8,6 +8,9 @@ package org.roaringbitmap.buffer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.roaringbitmap.BitmapContainer;
 import org.roaringbitmap.CharIterator;
 import org.roaringbitmap.IntConsumer;
@@ -20,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.LongBuffer;
 import java.util.Arrays;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.roaringbitmap.buffer.MappeableBitmapContainer.MAX_CAPACITY;
@@ -723,6 +727,22 @@ public class TestMappeableBitmapContainer {
     assertFalse(container.intersects(11, lower16Bits(-1)));
   }
 
+  public static Stream<Arguments> bitmapsForRangeIntersection() {
+    return Stream.of(
+            Arguments.of(new MappeableBitmapContainer().add((char)60), 0, 61, true),
+            Arguments.of(new MappeableBitmapContainer().add((char)60), 0, 60, false),
+            Arguments.of(new MappeableBitmapContainer().add((char)1000), 0, 1001, true),
+            Arguments.of(new MappeableBitmapContainer().add((char)1000), 0, 1000, false),
+            Arguments.of(new MappeableBitmapContainer().add((char)1000), 0, 10000, true)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitmapsForRangeIntersection")
+  public void testIntersectsWithRangeUpperBoundaries(MappeableContainer container, int min, int sup, boolean intersects) {
+    assertEquals(intersects, container.intersects(min, sup));
+  }
+
 
   @Test
   public void testIntersectsWithRangeHitScan() {
@@ -1078,44 +1098,6 @@ public class TestMappeableBitmapContainer {
     assertEquals(((1 << 15) | 8), container.nextAbsentValue((char)((1 << 15) | 7)));
     assertEquals(((1 << 15) | 8), container.nextAbsentValue((char)((1 << 15) | 8)));
   }
-
-  @Test
-  public void testNonEmptyInRangeBadRange() {
-    MappeableBitmapContainer bc = new MappeableBitmapContainer();
-    assertFalse(bc.isNonEmptyInRange(1, 0));
-  }
-
-  @Test
-  public void testNonEmptyInRangeIntraWordEmpty() {
-    MappeableBitmapContainer bc = new MappeableBitmapContainer();
-    assertFalse(bc.isNonEmptyInRange(65, 70));
-  }
-
-  @Test
-  public void testNonEmptyInRangeIntraWordNonEmpty() {
-    MappeableContainer bc = new MappeableBitmapContainer().add((char)66);
-    assertTrue(((MappeableBitmapContainer)bc).isNonEmptyInRange(65, 70));
-  }
-
-  @Test
-  public void testNonEmptyInRangeNonEmptyInFirstWord() {
-    MappeableContainer bc = new MappeableBitmapContainer().add((char)66);
-    assertTrue(((MappeableBitmapContainer)bc).isNonEmptyInRange(65, 1000));
-  }
-
-  @Test
-  public void testNonEmptyInRangeNonEmptyInLastWord() {
-    MappeableContainer bc = new MappeableBitmapContainer().add((char)999);
-    assertTrue(((MappeableBitmapContainer)bc).isNonEmptyInRange(65, 1000));
-  }
-
-
-  @Test
-  public void testNonEmptyInRangeNonEmptyInMiddle() {
-    MappeableContainer bc = new MappeableBitmapContainer().add((char)600);
-    assertTrue(((MappeableBitmapContainer)bc).isNonEmptyInRange(65, 1000));
-  }
-
 
   private static long[] evenBits() {
     long[] bitmap = new long[1 << 10];

--- a/jmh/build.gradle.kts
+++ b/jmh/build.gradle.kts
@@ -9,7 +9,7 @@ val deps: Map<String, String> by extra
 
 repositories {
     maven {
-        url = URI("https://metamx.artifactoryonline.com/metamx/pub-libs-releases-local")
+        url = URI("https://metamx.artifactoryonline.com/artifactory/pub-libs-releases-local")
     }
 }
 


### PR DESCRIPTION
- change `RunContainer.intersects(BitmapContainer)` to check if the bitmap intersects with the range
- change `RunContainer.andCardinality(BitmapContainer)` to add the cardinality in the range of the run
- some miscellaneous test coverage enhancements