### PR TITLE
benchmark for slow buffer run vs run and

### DIFF
--- a/jmh/src/jmh/java/org/roaringbitmap/aggregation/FastAggregationRLEStressTest.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/aggregation/FastAggregationRLEStressTest.java
@@ -1,0 +1,88 @@
+package org.roaringbitmap.aggregation;
+
+import org.openjdk.jmh.annotations.*;
+import org.roaringbitmap.FastAggregation;
+import org.roaringbitmap.RoaringBitmap;
+import org.roaringbitmap.RoaringBitmapWriter;
+import org.roaringbitmap.buffer.BufferFastAggregation;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+
+import java.util.SplittableRandom;
+
+public class FastAggregationRLEStressTest {
+
+  @State(Scope.Benchmark)
+  public static class BitmapState {
+
+    public enum ConstructionStrategy {
+      CONSTANT_MEMORY {
+        @Override
+        public RoaringBitmapWriter<RoaringBitmap> create() {
+          return RoaringBitmapWriter.writer()
+                  .constantMemory()
+                  .get();
+        }
+      },
+      CONTAINER_APPENDER {
+        @Override
+        public RoaringBitmapWriter<RoaringBitmap> create() {
+          return RoaringBitmapWriter.writer()
+                  .get();
+        }
+      }
+      ;
+      public abstract RoaringBitmapWriter<RoaringBitmap> create();
+    }
+
+    // adapted from druid
+    // https://github.com/apache/druid/blob/master/benchmarks/src/test/java/org/apache/druid/benchmark/BitmapIterationBenchmark.java
+
+    @Param({"10", "100"})
+    int count;
+
+    @Param({"1000000"})
+    int size;
+
+    @Param({"0.01", "0.1", "0.5"})
+    double probability;
+
+    @Param
+    ConstructionStrategy constructionStrategy;
+
+    @Param("99999")
+    long seed;
+
+    SplittableRandom random;
+    RoaringBitmap[] bitmaps;
+    ImmutableRoaringBitmap[] bufferBitmaps;
+
+    @Setup(Level.Trial)
+    public void createBitmaps() {
+      random = new SplittableRandom(seed);
+      RoaringBitmapWriter<RoaringBitmap> bitmapWriter = constructionStrategy.create();
+      bitmaps = new RoaringBitmap[count];
+      bufferBitmaps = new ImmutableRoaringBitmap[count];
+      double p = Math.pow(probability, 1D/count);
+      for (int i = 0; i < count; ++i) {
+        for (int j = (int)(Math.log(random.nextDouble())/Math.log(1-p));
+             j < size;
+             j += (int)(Math.log(random.nextDouble())/Math.log(1-p)) + 1) {
+            bitmapWriter.add(j);
+        }
+        bitmaps[i] = bitmapWriter.get();
+        bufferBitmaps[i] = bitmaps[i].toMutableRoaringBitmap();
+        bitmapWriter.reset();
+      }
+    }
+  }
+
+  @Benchmark
+  public RoaringBitmap and(BitmapState state) {
+    return FastAggregation.and(state.bitmaps);
+  }
+
+  @Benchmark
+  public ImmutableRoaringBitmap andBuffer(BitmapState state) {
+    return BufferFastAggregation.and(state.bufferBitmaps);
+  }
+}


### PR DESCRIPTION
To reproduce #404 use: 

```
java -jar jmh/build/libs/benchmarks.jar -wi 5 -i 5 -r 1 -w 1 -f 1 -p count=100 FastAggregationRLEStressTest.andBuffer
```

Note that the array version is much faster, so the 18% just after the bounds check in the profile I posted on the issue might have something to do with it :):

```
Benchmark                               (constructionStrategy)  (count)  (probability)  (seed)   (size)   Mode  Cnt    Score    Error  Units
FastAggregationRLEStressTest.and               CONSTANT_MEMORY      100           0.01   99999  1000000  thrpt    5  216.592 ▒ 17.550  ops/s
FastAggregationRLEStressTest.and               CONSTANT_MEMORY      100            0.1   99999  1000000  thrpt    5   40.412 ▒  0.832  ops/s
FastAggregationRLEStressTest.and               CONSTANT_MEMORY      100            0.5   99999  1000000  thrpt    5  115.613 ▒  5.611  ops/s
FastAggregationRLEStressTest.and            CONTAINER_APPENDER      100           0.01   99999  1000000  thrpt    5  219.694 ▒  1.806  ops/s
FastAggregationRLEStressTest.and            CONTAINER_APPENDER      100            0.1   99999  1000000  thrpt    5   40.865 ▒  0.686  ops/s
FastAggregationRLEStressTest.and            CONTAINER_APPENDER      100            0.5   99999  1000000  thrpt    5  116.458 ▒  1.154  ops/s
FastAggregationRLEStressTest.andBuffer         CONSTANT_MEMORY      100           0.01   99999  1000000  thrpt    5  126.804 ▒  2.217  ops/s
FastAggregationRLEStressTest.andBuffer         CONSTANT_MEMORY      100            0.1   99999  1000000  thrpt    5    5.019 ▒  0.051  ops/s
FastAggregationRLEStressTest.andBuffer         CONSTANT_MEMORY      100            0.5   99999  1000000  thrpt    5    5.734 ▒  0.064  ops/s
FastAggregationRLEStressTest.andBuffer      CONTAINER_APPENDER      100           0.01   99999  1000000  thrpt    5  127.200 ▒  3.350  ops/s
FastAggregationRLEStressTest.andBuffer      CONTAINER_APPENDER      100            0.1   99999  1000000  thrpt    5    5.024 ▒  0.074  ops/s
FastAggregationRLEStressTest.andBuffer      CONTAINER_APPENDER      100            0.5   99999  1000000  thrpt    5    5.746 ▒  0.065  ops/s

```

