### PR TITLE
implement new bitmap intersection algorithm

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -542,7 +542,7 @@ public final class BitmapContainer extends Container implements Cloneable {
   public Container iand(final ArrayContainer b2) {
     if (-1 == cardinality) {
       // actually we can avoid allocating in lazy mode
-      Util.intersect(bitmap, b2.content, b2.cardinality);
+      Util.intersectArrayIntoBitmap(bitmap, b2.content, b2.cardinality);
       return this;
     } else {
       return b2.and(this);
@@ -596,15 +596,20 @@ public final class BitmapContainer extends Container implements Cloneable {
     }
     int start = 0;
     for (int rlepos = 0; rlepos < x.nbrruns; ++rlepos) {
-      int end = (x.getValue(rlepos));
-      int prevOnes = cardinalityInRange(start, end);
-      Util.resetBitmapRange(this.bitmap, start, end);
-      if (-1 != cardinality) {
+      int end = x.getValue(rlepos);
+      if (-1 == cardinality) {
+        Util.resetBitmapRange(this.bitmap, start, end);
+      } else {
+        int prevOnes = cardinalityInRange(start, end);
+        Util.resetBitmapRange(this.bitmap, start, end);
         updateCardinality(prevOnes, 0);
       }
       start = end + x.getLength(rlepos) + 1;
     }
-    if (-1 != cardinality) { // in lazy mode don't try to trim
+    if (-1 == cardinality) {
+      // in lazy mode don't try to trim
+      Util.resetBitmapRange(this.bitmap, start, MAX_CAPACITY);
+    } else {
       int ones = cardinalityInRange(start, MAX_CAPACITY);
       Util.resetBitmapRange(this.bitmap, start, MAX_CAPACITY);
       updateCardinality(ones, 0);

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/FastAggregation.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/FastAggregation.java
@@ -7,7 +7,6 @@ package org.roaringbitmap;
 import java.util.*;
 
 
-
 /**
  * Fast algorithms to aggregate many bitmaps.
  *
@@ -37,6 +36,9 @@ public final class FastAggregation {
    * @return aggregated bitmap
    */
   public static RoaringBitmap and(RoaringBitmap... bitmaps) {
+    if (bitmaps.length > 2) {
+      return workShyAnd(bitmaps);
+    }
     return naive_and(bitmaps);
   }
 
@@ -266,6 +268,70 @@ public final class FastAggregation {
       answer.and(bitmaps[k]);
     }
     return answer;
+  }
+
+  /**
+   * Computes the intersection by first intersecting the keys, avoids
+   * materialising containers.
+   *
+   * @param bitmaps the inputs
+   * @return the intersection of the bitmaps
+   */
+  public static RoaringBitmap workShyAnd(RoaringBitmap... bitmaps) {
+    long[] words = new long[1024];
+    RoaringBitmap first = bitmaps[0];
+    for (int i = 0; i < first.highLowContainer.size; ++i) {
+      char key = first.highLowContainer.keys[i];
+      words[key >>> 6] |= 1L << key;
+    }
+    int containersInResult = 0;
+    for (int i = 1; i < bitmaps.length; ++i) {
+      containersInResult = Util.intersect(words,
+              bitmaps[i].highLowContainer.keys, bitmaps[i].highLowContainer.size);
+    }
+    if (containersInResult == 0) {
+      return new RoaringBitmap();
+    }
+    char[] keys = new char[containersInResult];
+    int base = 0;
+    int pos = 0;
+    for (long word : words) {
+      while (word != 0L) {
+        keys[pos++] = (char)(base + Long.numberOfTrailingZeros(word));
+        word &= (word - 1);
+      }
+      base += 64;
+    }
+    Container[][] containers = new Container[containersInResult][bitmaps.length];
+    for (int i = 0; i < bitmaps.length; ++i) {
+      RoaringBitmap bitmap = bitmaps[i];
+      int position = 0;
+      for (int j = 0; j < bitmap.highLowContainer.size; ++j) {
+        char key = bitmap.highLowContainer.keys[j];
+        if ((words[key >>> 6] & (1L << key)) != 0) {
+          containers[position++][i] = bitmap.highLowContainer.values[j];
+        }
+      }
+    }
+
+    RoaringArray array =
+            new RoaringArray(keys, new Container[containersInResult], 0);
+    for (int i = 0; i < containersInResult; ++i) {
+      Container[] slice = containers[i];
+      Arrays.fill(words, -1L);
+      Container tmp = new BitmapContainer(words, -1);
+      for (Container container : slice) {
+        Container and = tmp.iand(container);
+        if (and != tmp) {
+          tmp = and;
+        }
+      }
+      tmp = tmp.repairAfterLazy();
+      if (!tmp.isEmpty()) {
+        array.append(keys[i], tmp instanceof BitmapContainer ? tmp.clone() : tmp);
+      }
+    }
+    return new RoaringBitmap(array);
   }
 
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/FastAggregation.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/FastAggregation.java
@@ -36,7 +36,10 @@ public final class FastAggregation {
    * @return aggregated bitmap
    */
   public static RoaringBitmap and(RoaringBitmap... bitmaps) {
-    return workShyAnd(bitmaps);
+    if (bitmaps.length > 2) {
+      return workShyAnd(bitmaps);
+    }
+    return naive_and(bitmaps);
   }
 
   /**

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -14,8 +14,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 
 
-
-
 /**
  * This container takes the form of runs of consecutive values (effectively, run-length encoding).
  *
@@ -381,17 +379,18 @@ public final class RunContainer extends Container implements Cloneable {
 
   @Override
   public Container and(RunContainer x) {
-    RunContainer answer = new RunContainer(new char[2 * (this.nbrruns + x.nbrruns)], 0);
+    int maxRunsAfterIntersection = nbrruns + x.nbrruns;
+    RunContainer answer = new RunContainer(new char[2 * maxRunsAfterIntersection], 0);
     if (isEmpty()) {
       return answer;
     }
     int rlepos = 0;
     int xrlepos = 0;
-    int start = (this.getValue(rlepos));
-    int end = start + (this.getLength(rlepos)) + 1;
-    int xstart = (x.getValue(xrlepos));
-    int xend = xstart + (x.getLength(xrlepos)) + 1;
-    while ((rlepos < this.nbrruns) && (xrlepos < x.nbrruns)) {
+    int start = this.getValue(rlepos);
+    int end = start + this.getLength(rlepos) + 1;
+    int xstart = x.getValue(xrlepos);
+    int xend = xstart + x.getLength(xrlepos) + 1;
+    while (rlepos < this.nbrruns && xrlepos < x.nbrruns) {
       if (end <= xstart) {
         if (ENABLE_GALLOPING_AND) {
           rlepos = skipAhead(this, rlepos, xstart); // skip over runs until we have end > xstart (or
@@ -401,8 +400,8 @@ public final class RunContainer extends Container implements Cloneable {
         }
 
         if (rlepos < this.nbrruns) {
-          start = (this.getValue(rlepos));
-          end = start + (this.getLength(rlepos)) + 1;
+          start = this.getValue(rlepos);
+          end = start + this.getLength(rlepos) + 1;
         }
       } else if (xend <= start) {
         // exit the second run
@@ -413,8 +412,8 @@ public final class RunContainer extends Container implements Cloneable {
         }
 
         if (xrlepos < x.nbrruns) {
-          xstart = (x.getValue(xrlepos));
-          xend = xstart + (x.getLength(xrlepos)) + 1;
+          xstart = x.getValue(xrlepos);
+          xend = xstart + x.getLength(xrlepos) + 1;
         }
       } else {// they overlap
         final int lateststart = Math.max(start, xstart);
@@ -424,27 +423,27 @@ public final class RunContainer extends Container implements Cloneable {
           rlepos++;
           xrlepos++;
           if (rlepos < this.nbrruns) {
-            start = (this.getValue(rlepos));
-            end = start + (this.getLength(rlepos)) + 1;
+            start = this.getValue(rlepos);
+            end = start + this.getLength(rlepos) + 1;
           }
           if (xrlepos < x.nbrruns) {
-            xstart = (x.getValue(xrlepos));
-            xend = xstart + (x.getLength(xrlepos)) + 1;
+            xstart = x.getValue(xrlepos);
+            xend = xstart + x.getLength(xrlepos) + 1;
           }
         } else if (end < xend) {
           earliestend = end;
           rlepos++;
           if (rlepos < this.nbrruns) {
-            start = (this.getValue(rlepos));
-            end = start + (this.getLength(rlepos)) + 1;
+            start = this.getValue(rlepos);
+            end = start + this.getLength(rlepos) + 1;
           }
 
         } else {// end > xend
           earliestend = xend;
           xrlepos++;
           if (xrlepos < x.nbrruns) {
-            xstart = (x.getValue(xrlepos));
-            xend = xstart + (x.getLength(xrlepos)) + 1;
+            xstart = x.getValue(xrlepos);
+            xend = xstart + x.getLength(xrlepos) + 1;
           }
         }
         answer.valueslength[2 * answer.nbrruns] = (char) lateststart;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
@@ -428,6 +428,39 @@ public final class Util {
   }
 
   /**
+   * Intersects the bitmap with the array, returning the cardinality of the result
+   * @param bitmap the bitmap
+   * @param array the array
+   * @param length how much of the array to consume
+   * @return the size of the intersection
+   */
+  public static int intersect(long[] bitmap, char[] array, int length) {
+    int lastWordIndex = 0;
+    int wordIndex = 0;
+    long word = 0L;
+    int cardinality = 0;
+    for (int i = 0; i < length; ++i) {
+      wordIndex = array[i] >>> 6;
+      if (wordIndex != lastWordIndex) {
+        bitmap[lastWordIndex] &= word;
+        cardinality += Long.bitCount(bitmap[lastWordIndex]);
+        word = 0L;
+        Arrays.fill(bitmap, lastWordIndex + 1, wordIndex, 0L);
+        lastWordIndex = wordIndex;
+      }
+      word |= 1L << array[i];
+    }
+    if (word != 0L) {
+      bitmap[wordIndex] &= word;
+      cardinality += Long.bitCount(bitmap[lastWordIndex]);
+    }
+    if (wordIndex < bitmap.length) {
+      Arrays.fill(bitmap, wordIndex + 1, bitmap.length, 0L);
+    }
+    return cardinality;
+  }
+
+  /**
    * Given a word w, return the position of the jth true bit.
    *
    * @param w word

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
@@ -429,12 +429,12 @@ public final class Util {
 
   /**
    * Intersects the bitmap with the array, returning the cardinality of the result
-   * @param bitmap the bitmap
-   * @param array the array
+   * @param bitmap the bitmap, modified
+   * @param array the array, not modified
    * @param length how much of the array to consume
-   * @return the size of the intersection
+   * @return the size of the intersection, i.e. how many bits still set in the bitmap
    */
-  public static int intersect(long[] bitmap, char[] array, int length) {
+  public static int intersectArrayIntoBitmap(long[] bitmap, char[] array, int length) {
     int lastWordIndex = 0;
     int wordIndex = 0;
     long word = 0L;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferFastAggregation.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferFastAggregation.java
@@ -26,7 +26,10 @@ public final class BufferFastAggregation {
    * @return aggregated bitmap
    */
   public static MutableRoaringBitmap and(ImmutableRoaringBitmap... bitmaps) {
-    return workShyAnd(bitmaps);
+    if (bitmaps.length > 2) {
+      return workShyAnd(bitmaps);
+    }
+    return naive_and(bitmaps);
   }
 
   /**

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/PointableRoaringArray.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/PointableRoaringArray.java
@@ -7,7 +7,6 @@ package org.roaringbitmap.buffer;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
 
 /**
  * Generic interface for the array underlying roaring bitmap classes.

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/PointableRoaringArray.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/PointableRoaringArray.java
@@ -7,6 +7,7 @@ package org.roaringbitmap.buffer;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 
 /**
  * Generic interface for the array underlying roaring bitmap classes.

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestFastAggregation.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestFastAggregation.java
@@ -3,10 +3,16 @@ package org.roaringbitmap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.roaringbitmap.SeededTestData.TestDataSet.testCase;
 
 
 @Execution(ExecutionMode.CONCURRENT)
@@ -178,6 +184,71 @@ public class TestFastAggregation {
         assertTrue(ebResult.contains(1));
         assertFalse(ebResult.contains(2));
         assertTrue(ebResult.contains(3));
+    }
+
+    public static Stream<Arguments> bitmaps() {
+        return Stream.of(
+                Arguments.of(Arrays.asList(
+                        testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build(),
+                        testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build(),
+                        testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build()
+                )),
+                Arguments.of(Arrays.asList(
+                        testCase().withBitmapAt(0).withRunAt(1).withArrayAt(2).build(),
+                        testCase().withBitmapAt(0).withRunAt(1).withArrayAt(2).build(),
+                        testCase().withBitmapAt(0).withRunAt(1).withArrayAt(2).build()
+                )),
+                Arguments.of(Arrays.asList(
+                        testCase().withArrayAt(0).withRunAt(1).withBitmapAt(2).build(),
+                        testCase().withArrayAt(0).withRunAt(1).withBitmapAt(2).build(),
+                        testCase().withArrayAt(0).withRunAt(1).withBitmapAt(2).build()
+                )),
+                Arguments.of(Arrays.asList(
+                        testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build(),
+                        testCase().withBitmapAt(0).withArrayAt(3).withRunAt(4).build(),
+                        testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build()
+                )),
+                Arguments.of(Arrays.asList(
+                        testCase().withArrayAt(0).withBitmapAt(1).withRunAt(2).build(),
+                        testCase().withRunAt(0).withArrayAt(1).withBitmapAt(2).build(),
+                        testCase().withBitmapAt(0).withRunAt(1).withArrayAt(2).build()
+                )),
+                Arguments.of(Arrays.asList(
+                        testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build(),
+                        testCase().withBitmapAt(0).withArrayAt(2).withRunAt(4).build(),
+                        testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build()
+                )),
+                Arguments.of(Arrays.asList(
+                        testCase().withArrayAt(0).withArrayAt(1).withArrayAt(2).build(),
+                        testCase().withBitmapAt(0).withBitmapAt(2).withBitmapAt(4).build(),
+                        testCase().withRunAt(0).withRunAt(1).withRunAt(2).build()
+                )),
+                Arguments.of(Arrays.asList(
+                        testCase().withArrayAt(0).withArrayAt(1).withArrayAt(2).build(),
+                        testCase().withBitmapAt(0).withBitmapAt(2).withArrayAt(4).build(),
+                        testCase().withRunAt(0).withRunAt(1).withArrayAt(2).build()
+                )),
+                Arguments.of(Arrays.asList(
+                        testCase().withArrayAt(0).withArrayAt(1).withBitmapAt(2).build(),
+                        testCase().withBitmapAt(0).withBitmapAt(2).withBitmapAt(4).build(),
+                        testCase().withRunAt(0).withRunAt(1).withBitmapAt(2).build()
+                )),
+                Arguments.of(Arrays.asList(
+                        testCase().withArrayAt(20).build(),
+                        testCase().withBitmapAt(0).withBitmapAt(1).withBitmapAt(4).build(),
+                        testCase().withRunAt(0).withRunAt(1).withBitmapAt(3).build()
+                ))
+        );
+    }
+
+
+    @MethodSource("bitmaps")
+    @ParameterizedTest(name = "testWorkShyAnd")
+    public void testWorkShyAnd(List<RoaringBitmap> list) {
+        RoaringBitmap[] bitmaps = list.toArray(new RoaringBitmap[0]);
+        RoaringBitmap result = FastAggregation.workShyAnd(bitmaps);
+        RoaringBitmap expected = FastAggregation.naive_and(bitmaps);
+        assertEquals(expected, result);
     }
 
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestFastAggregation.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestFastAggregation.java
@@ -64,6 +64,17 @@ public class TestFastAggregation {
 
     private static class ExtendedRoaringBitmap extends RoaringBitmap {}
 
+
+    @Test
+    public void testWorkShyAnd() {
+        final RoaringBitmap b1 = RoaringBitmap.bitmapOf(1, 2, 0x10001, 0x20001, 0x30001);
+        final RoaringBitmap b2 = RoaringBitmap.bitmapOf(2, 3, 0x20002, 0x30001);
+        final RoaringBitmap bResult = FastAggregation.workShyAnd(b1, b2);
+        assertFalse(bResult.contains(1));
+        assertTrue(bResult.contains(2));
+        assertFalse(bResult.contains(3));
+    }
+
     @Test
     public void testAndWithIterator() {
         final RoaringBitmap b1 = RoaringBitmap.bitmapOf(1, 2);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestUtil.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestUtil.java
@@ -4,12 +4,20 @@ package org.roaringbitmap.buffer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.roaringbitmap.Util;
 
+import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.LongBuffer;
 import java.util.Arrays;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.roaringbitmap.SeededTestData.*;
+import static org.roaringbitmap.SeededTestData.sparseRegion;
 
 @Execution(ExecutionMode.CONCURRENT)
 public class TestUtil {
@@ -92,5 +100,46 @@ public class TestUtil {
       result[i] = (char)(array[i] & 0xFFFF);
     }
     return result;
+  }
+
+  public static Stream<Arguments> sets() {
+      return Stream.of(true, false)
+              .flatMap(direct -> Stream.of(
+              Arguments.of(direct, rleRegion().toArray(), rleRegion().toArray()),
+              Arguments.of(direct, denseRegion().toArray(), rleRegion().toArray()),
+              Arguments.of(direct, sparseRegion().toArray(), rleRegion().toArray()),
+              Arguments.of(direct, rleRegion().toArray(), denseRegion().toArray()),
+              Arguments.of(direct, denseRegion().toArray(), denseRegion().toArray()),
+              Arguments.of(direct, sparseRegion().toArray(), denseRegion().toArray()),
+              Arguments.of(direct, rleRegion().toArray(), sparseRegion().toArray()),
+              Arguments.of(direct, denseRegion().toArray(), sparseRegion().toArray()),
+              Arguments.of(direct, sparseRegion().toArray(), sparseRegion().toArray())));
+  }
+
+
+  @MethodSource("sets")
+  @ParameterizedTest(name = "direct={0}")
+  public void testIntersectBitmapWithArray(boolean direct, int[] set1, int[] set2) {
+    LongBuffer bitmap = direct ? ByteBuffer.allocateDirect(8192).asLongBuffer() : LongBuffer.allocate(1024);
+    for (int i : set1) {
+      bitmap.put(i >>> 6, bitmap.get(i >>> 6) | (1L << i));
+    }
+    LongBuffer referenceBitmap = direct ? ByteBuffer.allocateDirect(8192).asLongBuffer() : LongBuffer.allocate(1024);
+    CharBuffer array = direct ? ByteBuffer.allocateDirect(2 * set2.length).asCharBuffer() : CharBuffer.allocate(set2.length);
+    int pos = 0;
+    for (int i : set2) {
+      referenceBitmap.put(i >>> 6, referenceBitmap.get(i >>> 6) | (1L << i));
+      array.put(pos++, (char)i);
+    }
+    int expectedCardinality = 0;
+    for (int i = 0; i < 1024; ++i) {
+      referenceBitmap.put(i, referenceBitmap.get(i) & bitmap.get(i));
+      expectedCardinality += Long.bitCount(referenceBitmap.get(i));
+    }
+    int cardinality = BufferUtil.intersectArrayIntoBitmap(bitmap, array, set2.length);
+    assertEquals(expectedCardinality, cardinality);
+    for (int i = 0; i < bitmap.limit(); ++i) {
+      assertEquals(bitmap.get(i), referenceBitmap.get(i), "mismatch at " + i);
+    }
   }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestUtil.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestUtil.java
@@ -1,7 +1,6 @@
 package org.roaringbitmap.buffer;
 
 
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;

--- a/fuzz-tests/src/test/java/org/roaringbitmap/BufferFuzzer.java
+++ b/fuzz-tests/src/test/java/org/roaringbitmap/BufferFuzzer.java
@@ -1,8 +1,8 @@
 package org.roaringbitmap;
 
 import com.google.common.collect.ImmutableMap;
-
 import org.junit.jupiter.api.Test;
+import org.roaringbitmap.buffer.BufferFastAggregation;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
@@ -10,7 +10,6 @@ import java.util.BitSet;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.*;
 import java.util.stream.IntStream;
-
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -488,6 +487,21 @@ public class BufferFuzzer {
         }
       }
     });
+  }
+
+  @Test
+  public void testFastAggregationAnd() {
+    IntStream.range(0, ITERATIONS)
+            .parallel()
+            .forEach(i -> {
+              MutableRoaringBitmap[] bitmaps = new MutableRoaringBitmap[ThreadLocalRandom.current().nextInt(2, 20)];
+              for (int j = 0; j < bitmaps.length; ++j) {
+                bitmaps[j] = randomBitmap(512);
+              }
+              MutableRoaringBitmap naive = BufferFastAggregation.naive_and(bitmaps);
+              MutableRoaringBitmap workShy = BufferFastAggregation.workShyAnd(bitmaps);
+              assertEquals(naive, workShy);
+            });
   }
 
   private static MutableRoaringBitmap randomBitmap(int maxKeys) {

--- a/fuzz-tests/src/test/java/org/roaringbitmap/Fuzzer.java
+++ b/fuzz-tests/src/test/java/org/roaringbitmap/Fuzzer.java
@@ -552,4 +552,19 @@ public class Fuzzer {
       }
     });
   }
+
+  @Test
+  public void testFastAggregationAnd() {
+    IntStream.range(0, ITERATIONS)
+            .parallel()
+            .forEach(i -> {
+              RoaringBitmap[] bitmaps = new RoaringBitmap[ThreadLocalRandom.current().nextInt(2, 20)];
+              for (int j = 0; j < bitmaps.length; ++j) {
+                bitmaps[j] = randomBitmap(512);
+              }
+              RoaringBitmap naive = FastAggregation.naive_and(bitmaps);
+              RoaringBitmap workShy = FastAggregation.workShyAnd(bitmaps);
+              assertEquals(naive, workShy);
+            });
+  }
 }

--- a/jmh/src/jmh/java/org/roaringbitmap/realdata/ParallelAggregatorBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/realdata/ParallelAggregatorBenchmark.java
@@ -71,6 +71,11 @@ public class ParallelAggregatorBenchmark {
   }
 
   @Benchmark
+  public RoaringBitmap fastAnd() {
+    return FastAggregation.workShyAnd(bitmaps);
+  }
+
+  @Benchmark
   public RoaringBitmap fastXor() {
     return FastAggregation.xor(bitmaps);
   }


### PR DESCRIPTION
@lemire here's an intersection algorithm based on grouping by key and eliminating keys not associated with N containers in an N way intersection. Also avoids allocation by intersecting with a constant bitmap which is reused. Probably very buggy (PR is to offload running the tests), but quite fast:

new

```
FastAggregationRLEStressTest.and                                       CONTAINER_APPENDER      100           0.01   99999  1000000  thrpt    5     548.451 ▒      12.176   ops/s
FastAggregationRLEStressTest.and:▒gc.alloc.rate                        CONTAINER_APPENDER      100           0.01   99999  1000000  thrpt    5      15.309 ▒       0.344  MB/sec
FastAggregationRLEStressTest.and                                       CONTAINER_APPENDER      100            0.1   99999  1000000  thrpt    5      48.027 ▒       7.547   ops/s
FastAggregationRLEStressTest.and:▒gc.alloc.rate                        CONTAINER_APPENDER      100            0.1   99999  1000000  thrpt    5       4.518 ▒       0.731  MB/sec
FastAggregationRLEStressTest.and                                       CONTAINER_APPENDER      100            0.5   99999  1000000  thrpt    5     154.600 ▒       5.372   ops/s
FastAggregationRLEStressTest.and:▒gc.alloc.rate                        CONTAINER_APPENDER      100            0.5   99999  1000000  thrpt    5      14.484 ▒       0.510  MB/sec
```

vs old

```
FastAggregationRLEStressTest.and                                       CONTAINER_APPENDER      100           0.01   99999  1000000  thrpt    5     215.881 ▒      14.551   ops/s
FastAggregationRLEStressTest.and:▒gc.alloc.rate                        CONTAINER_APPENDER      100           0.01   99999  1000000  thrpt    5      62.995 ▒       4.178  MB/sec
FastAggregationRLEStressTest.and                                       CONTAINER_APPENDER      100            0.1   99999  1000000  thrpt    5      40.286 ▒       1.046   ops/s
FastAggregationRLEStressTest.and:▒gc.alloc.rate                        CONTAINER_APPENDER      100            0.1   99999  1000000  thrpt    5      16.755 ▒       0.488  MB/sec
FastAggregationRLEStressTest.and                                       CONTAINER_APPENDER      100            0.5   99999  1000000  thrpt    5     114.760 ▒       1.685   ops/s
FastAggregationRLEStressTest.and:▒gc.alloc.rate                        CONTAINER_APPENDER      100            0.5   99999  1000000  thrpt    5      46.893 ▒       0.643  MB/sec

```