### PR TITLE
Issue#422

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/HighLowContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/HighLowContainer.java
@@ -111,8 +111,7 @@ public class HighLowContainer {
     }
     art.serializeArt(byteBuffer);
     containers.serialize(byteBuffer);
-    if(byteBuffer != buffer)
-    {
+    if (byteBuffer != buffer) {
       buffer.position(buffer.position() + byteBuffer.position());
     }
   }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -506,7 +506,7 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
-  public void testSerialization_ToBigEndianBuffer()throws IOException, ClassNotFoundException {
+  public void testSerialization_ToBigEndianBuffer() throws IOException, ClassNotFoundException {
     final Roaring64Bitmap map = newDefaultCtor();
     map.addLong(123);
     ByteBuffer buffer = ByteBuffer.allocate((int)map.serializedSizeInBytes()).order(ByteOrder.BIG_ENDIAN);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -506,6 +506,15 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
+  public void testSerialization_ToBigEndianBuffer()throws IOException, ClassNotFoundException {
+    final Roaring64Bitmap map = newDefaultCtor();
+    map.addLong(123);
+    ByteBuffer buffer = ByteBuffer.allocate((int)map.serializedSizeInBytes()).order(ByteOrder.BIG_ENDIAN);
+    map.serialize(buffer);
+    assertEquals(map.serializedSizeInBytes(),buffer.position());
+  }
+  
+  @Test
   public void testSerialization_OneValue() throws IOException, ClassNotFoundException {
     final Roaring64Bitmap map = newDefaultCtor();
     map.addLong(123);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -509,9 +509,9 @@ public class TestRoaring64Bitmap {
   public void testSerialization_ToBigEndianBuffer() throws IOException, ClassNotFoundException {
     final Roaring64Bitmap map = newDefaultCtor();
     map.addLong(123);
-    ByteBuffer buffer = ByteBuffer.allocate((int)map.serializedSizeInBytes()).order(ByteOrder.BIG_ENDIAN);
+    ByteBuffer buffer = ByteBuffer.allocate((int) map.serializedSizeInBytes()).order(ByteOrder.BIG_ENDIAN);
     map.serialize(buffer);
-    assertEquals(map.serializedSizeInBytes(),buffer.position());
+    assertEquals(map.serializedSizeInBytes(), buffer.position());
   }
   
   @Test


### PR DESCRIPTION
Roaring64Bitmap.serialize(ByteBuffer) not populating ByteBuffer position value for BigEndian byte order buffers