### PR TITLE
Issue#426 Add stream() and reverseStream() 

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ImmutableBitmapDataProvider.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ImmutableBitmapDataProvider.java
@@ -8,6 +8,11 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
+import java.util.PrimitiveIterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
 
 /**
  * Interface representing an immutable bitmap.
@@ -70,6 +75,24 @@ public interface ImmutableBitmapDataProvider {
    */
   IntIterator getReverseIntIterator();
 
+  /**
+   * @return an Ordered, Distinct, Sorted and Sized IntStream in ascending order
+   */
+  public default IntStream stream() {
+    int characteristics = Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.SORTED | Spliterator.SIZED;
+    Spliterator.OfInt x = Spliterators.spliterator(new RoaringOfInt(getIntIterator()), getCardinality(), characteristics);
+    return StreamSupport.intStream(x, false);
+  }
+
+  /**
+   * @return an Ordered, Distinct and Sized IntStream providing bits in descending sorted order
+   */
+  public default IntStream reverseStream() {
+    int characteristics = Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.SIZED;
+    Spliterator.OfInt x = Spliterators.spliterator(new RoaringOfInt(getReverseIntIterator()), getCardinality(), characteristics);
+    return StreamSupport.intStream(x, false);
+  }
+  
   /**
    * This iterator may be faster than others
    * @return iterator which works on batches of data.
@@ -272,4 +295,27 @@ public interface ImmutableBitmapDataProvider {
    */
   int[] toArray();
 
+  /**
+   * An internal class to help provide streams.
+   * Sad but true the interface of IntIterator and PrimitiveIterator.OfInt
+   * Does not match. Otherwise it would be easier to just make IntIterator 
+   * implement PrimitiveIterator.OfInt. 
+   */
+  static final class RoaringOfInt implements PrimitiveIterator.OfInt {
+    private final IntIterator iterator;
+
+    public RoaringOfInt(IntIterator iterator) {
+      this.iterator = iterator;
+    }
+
+    @Override
+    public int nextInt() {
+      return iterator.next();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return iterator.hasNext();
+    }
+  }
 }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -12,6 +12,11 @@ import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.PrimitiveIterator.OfInt;
+import java.util.Spliterator;
+import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
+import java.util.Spliterators;
 
 import static org.roaringbitmap.RoaringBitmapWriter.writer;
 import static org.roaringbitmap.Util.lowbitsAsInteger;
@@ -1918,7 +1923,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     return new RoaringReverseIntIterator();
   }
 
-
+  
   @Override
   public RoaringBatchIterator getBatchIterator() {
     return new RoaringBatchIterator(highLowContainer);

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/ImmutableLongBitmapDataProvider.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/ImmutableLongBitmapDataProvider.java
@@ -6,6 +6,11 @@ package org.roaringbitmap.longlong;
 
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.PrimitiveIterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.LongStream;
+import java.util.stream.StreamSupport;
 
 /**
  * Interface representing an immutable bitmap.
@@ -65,6 +70,23 @@ public interface ImmutableLongBitmapDataProvider {
   // RoaringBitmap proposes a PeekableLongIterator
   public LongIterator getReverseLongIterator();
 
+  /**
+   * @return an Ordered, Distinct, Sorted and Sized IntStream in ascending order
+   */
+  public default LongStream stream() {
+    int characteristics = Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.SORTED | Spliterator.SIZED;
+    Spliterator.OfLong x = Spliterators.spliterator(new RoaringOfLong(getLongIterator()), getLongCardinality(), characteristics);
+    return StreamSupport.longStream(x, false);
+  }
+
+  /**
+   * @return an Ordered, Distinct and Sized IntStream providing bits in descending sorted order
+   */
+  public default LongStream reverseStream() {
+    int characteristics = Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.SIZED;
+    Spliterator.OfLong x = Spliterators.spliterator(new RoaringOfLong(getLongIterator()), getLongCardinality(), characteristics);
+    return StreamSupport.longStream(x, false);
+  }
   /**
    * Estimate of the memory usage of this data structure.
    * 
@@ -143,4 +165,27 @@ public interface ImmutableLongBitmapDataProvider {
    */
   public long[] toArray();
 
+    /**
+   * An internal class to help provide streams.
+   * Sad but true the interface of IntIterator and PrimitiveIterator.OfInt
+   * Does not match. Otherwise it would be easier to just make IntIterator 
+   * implement PrimitiveIterator.OfInt. 
+   */
+  static final class RoaringOfLong implements PrimitiveIterator.OfLong {
+    private final LongIterator iterator;
+
+    public RoaringOfLong(LongIterator iterator) {
+      this.iterator = iterator;
+    }
+
+    @Override
+    public long nextLong() {
+      return iterator.next();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return iterator.hasNext();
+    }
+  }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestStreams.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestStreams.java
@@ -1,0 +1,106 @@
+/*
+ * (c) the authors Licensed under the Apache License, Version 2.0.
+ */
+
+
+package org.roaringbitmap;
+
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.primitives.Ints;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class TestStreams {
+  private static List<Integer> asList(IntIterator ints) {
+    int[] values = new int[10];
+    int size = 0;
+    while (ints.hasNext()) {
+      if (!(size < values.length)) {
+        values = Arrays.copyOf(values, values.length * 2);
+      }
+      values[size++] = ints.next();
+    }
+    return Ints.asList(Arrays.copyOf(values, size));
+  }
+
+  private static List<Integer> asList(final CharIterator shorts) {
+    return asList(new IntIterator() {
+      @Override
+      public IntIterator clone() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public boolean hasNext() {
+        return shorts.hasNext();
+      }
+
+      @Override
+      public int next() {
+        return shorts.next();
+      }
+    });
+  }
+
+  private static int[] takeSortedAndDistinct(Random source, int count) {
+    LinkedHashSet<Integer> ints = new LinkedHashSet<Integer>(count);
+    for (int size = 0; size < count; size++) {
+      int next;
+      do {
+        next = Math.abs(source.nextInt());
+      } while (!ints.add(next));
+    }
+    int[] unboxed = Ints.toArray(ints);
+    Arrays.sort(unboxed);
+    return unboxed;
+  }
+
+  @Test
+  public void testEmptyViaIteration() {
+    assertFalse(RoaringBitmap.bitmapOf().stream().iterator().hasNext());
+    assertFalse(RoaringBitmap.bitmapOf().reverseStream().iterator().hasNext());
+  }
+
+  @Test
+  public void testViaIteration() {
+    final Random source = new Random(0xcb000a2b9b5bdfb6l);
+    final int[] data = takeSortedAndDistinct(source, 450000);
+    RoaringBitmap bitmap = RoaringBitmap.bitmapOf(data);
+
+    final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
+    final List<Integer> intIteratorCopy = bitmap.stream().mapToObj(Integer::valueOf).collect(Collectors.toList());
+    final List<Integer> reverseIntIteratorCopy = bitmap.reverseStream().mapToObj(Integer::valueOf).collect(Collectors.toList());
+
+    assertEquals(bitmap.getCardinality(), iteratorCopy.size());
+    assertEquals(bitmap.getCardinality(), intIteratorCopy.size());
+    assertEquals(bitmap.getCardinality(), reverseIntIteratorCopy.size());
+    assertEquals(Ints.asList(data), iteratorCopy);
+    assertEquals(Ints.asList(data), intIteratorCopy);
+    assertEquals(Lists.reverse(Ints.asList(data)), reverseIntIteratorCopy);
+  }
+
+  @Test
+  public void testSmallIteration() {
+    RoaringBitmap bitmap = RoaringBitmap.bitmapOf(1, 2, 3);
+
+    final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
+    final List<Integer> intIteratorCopy = bitmap.stream().mapToObj(Integer::valueOf).collect(Collectors.toList());
+    final List<Integer> reverseIntIteratorCopy = bitmap.reverseStream().mapToObj(Integer::valueOf).collect(Collectors.toList());
+
+    assertEquals(ImmutableList.of(1, 2, 3), iteratorCopy);
+    assertEquals(ImmutableList.of(1, 2, 3), intIteratorCopy);
+    assertEquals(ImmutableList.of(3, 2, 1), reverseIntIteratorCopy);
+    assertEquals(bitmap.last(), bitmap.reverseStream().max().getAsInt());
+    assertEquals(bitmap.last(), bitmap.stream().max().getAsInt());
+  }
+}


### PR DESCRIPTION
methods that provide Int/LongStream() for streaming the index of set bits in Roaring(64)Bitmaps.

Sadly I needed to provide a wrapper class to transform a IntIterator into a PrimitiveIterator.OfInt (same for long).
IntIterator does not match the API signature of OfInt and changing that would be a backwards compatible issue.

I think I set the SplitIterator characteristics correctly, but a review of those would be appreciated.
Also the test cases copy shamelessly from the Iterator ones.