### PR TITLE
fix issues when iterating the ART interwove with removing operations

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Art.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Art.java
@@ -120,6 +120,7 @@ public class Art {
         if (node == this.root) {
           this.root = null;
         }
+        keySize--;
         return new Toolkit(null, leafNode.getContainerIdx(), null);
       } else {
         return null;
@@ -144,14 +145,17 @@ public class Art {
           this.root = freshNode;
         }
         long matchedContainerIdx = ((LeafNode) child).getContainerIdx();
-        Toolkit toolkit = new Toolkit(freshNode, matchedContainerIdx, freshNode);
+        Toolkit toolkit = new Toolkit(freshNode, matchedContainerIdx, node);
+        toolkit.needToVerifyReplacing = true;
         return toolkit;
       } else {
         Toolkit toolkit = removeSpecifyKey(child, key, dep + 1);
-        if (toolkit != null && toolkit.freshEntry != null && toolkit.freshEntry != child) {
+        if (toolkit != null && toolkit.needToVerifyReplacing && toolkit.freshMatchedParentNode != null && toolkit.freshMatchedParentNode
+            != toolkit.originalMatchedParentNode) {
           //meaning find the matched key and the shrinking happened
-          node.replaceNode(pos, toolkit.freshEntry);
-          return new Toolkit(child, toolkit.matchedContainerId, toolkit.freshEntry);
+          node.replaceNode(pos, toolkit.freshMatchedParentNode);
+          toolkit.needToVerifyReplacing = false;
+          return toolkit;
         }
         if (toolkit != null) {
           return toolkit;
@@ -163,14 +167,16 @@ public class Art {
 
   class Toolkit {
 
-    Node freshEntry;//indicating a fresh node while the original node shrunk and changed
+    Node freshMatchedParentNode;//indicating a fresh parent node while the original parent node shrunk and changed
     long matchedContainerId; //holding the matched key's corresponding container index id
-    Node matchedParentNode; //holding the matched key's leaf node's fresh parent node
+    Node originalMatchedParentNode; //holding the matched key's leaf node's original old parent node
+    boolean needToVerifyReplacing = false; //indicate whether the shrinking node's parent node has replaced its
+    //corresponding child node
 
-    Toolkit(Node freshEntry, long matchedContainerId, Node matchedParentNode) {
-      this.freshEntry = freshEntry;
+    Toolkit(Node freshMatchedParentNode, long matchedContainerId, Node originalMatchedParentNode) {
+      this.freshMatchedParentNode = freshMatchedParentNode;
       this.matchedContainerId = matchedContainerId;
-      this.matchedParentNode = matchedParentNode;
+      this.originalMatchedParentNode = originalMatchedParentNode;
     }
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/LeafNode.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/LeafNode.java
@@ -80,6 +80,11 @@ public class LeafNode extends Node {
   }
 
   @Override
+  public byte getChildKey(int pos) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public Node getChild(int pos) {
     throw new UnsupportedOperationException();
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node.java
@@ -39,6 +39,13 @@ public abstract class Node {
   public abstract int getChildPos(byte k);
 
   /**
+   * get the corresponding key byte of the requested position
+   * @param pos the position
+   * @return the corresponding key byte
+   */
+  public abstract byte getChildKey(int pos);
+
+  /**
    * get the child at the specified position in the node, the 'pos' range from 0 to count
    * @param pos the position
    * @return a Node corresponding to the input position

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node16.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node16.java
@@ -39,6 +39,20 @@ public class Node16 extends Node {
   }
 
   @Override
+  public byte getChildKey(int pos) {
+    int posInLong;
+    if (pos <= 7) {
+      posInLong = pos;
+      byte[] firstBytes = LongUtils.toBDBytes(firstV);
+      return firstBytes[posInLong];
+    } else {
+      posInLong = pos - 8;
+      byte[] secondBytes = LongUtils.toBDBytes(secondV);
+      return secondBytes[posInLong];
+    }
+  }
+
+  @Override
   public Node getChild(int pos) {
     return children[pos];
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node256.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node256.java
@@ -30,6 +30,11 @@ public class Node256 extends Node {
   }
 
   @Override
+  public byte getChildKey(int pos) {
+    return (byte) pos;
+  }
+
+  @Override
   public Node getChild(int pos) {
     return children[pos];
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node4.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node4.java
@@ -29,6 +29,13 @@ public class Node4 extends Node {
   }
 
   @Override
+  public byte getChildKey(int pos) {
+    int shiftLeftLen = (3 - pos) * 8;
+    byte v = (byte) (key >> shiftLeftLen);
+    return v;
+  }
+
+  @Override
   public Node getChild(int pos) {
     return children[pos];
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node48.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node48.java
@@ -33,6 +33,12 @@ public class Node48 extends Node {
   }
 
   @Override
+  public byte getChildKey(int pos) {
+
+    return (byte) pos;
+  }
+
+  @Override
   public Node getChild(int pos) {
     byte idx = childrenIdx(pos, childIndex);
     return children[(int) idx];

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/Node16Test.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/Node16Test.java
@@ -33,6 +33,7 @@ public class Node16Test {
 
     byte key = 4;
     Assertions.assertTrue(node16.getChildPos(key) == 4);
+    Assertions.assertTrue(node16.getChildKey(4) == key);
     for (int i = 5; i < 12; i++) {
       byte key1 = (byte) i;
       LeafNode leafNode = new LeafNode(i, i);
@@ -43,11 +44,14 @@ public class Node16Test {
     key = (byte) -2;
     node16 = (Node16) Node16.insert(node16, leafNode, key);
     Assertions.assertEquals(12, node16.getChildPos(key));
+    Assertions.assertEquals(key, node16.getChildKey(12));
     leafNode = new LeafNode(13, 13);
     byte key12 = (byte) 12;
     node16 = (Node16) Node16.insert(node16, leafNode, key12);
     Assertions.assertEquals(12, node16.getChildPos(key12));
+    Assertions.assertEquals(key12, node16.getChildKey(12));
     Assertions.assertEquals(13, node16.getChildPos(key));
+    Assertions.assertEquals(key, node16.getChildKey(13));
   }
 
   @Test

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/Node256Test.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/Node256Test.java
@@ -34,6 +34,7 @@ public class Node256Test {
     }
     node256 = (Node256) node256.remove(120);
     int pos119 = node256.getChildPos((byte) 119);
+    Assertions.assertEquals((byte) 119, node256.getChildKey(pos119));
     Assertions.assertEquals(119, pos119);
     int pos121 = node256.getNextLargerPos(pos119);
     Assertions.assertEquals(121, pos121);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/Node48Test.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/Node48Test.java
@@ -32,8 +32,10 @@ public class Node48Test {
       Assertions.assertEquals(i, nextPos);
       LeafNode leafNode1 = (LeafNode) node48.getChild(nextPos);
       Assertions.assertEquals(i, leafNode1.getContainerIdx());
-      int childPos = node48.getChildPos((byte) i);
+      byte key = (byte) i;
+      int childPos = node48.getChildPos(key);
       Assertions.assertEquals(i, childPos);
+      Assertions.assertEquals(key, node48.getChildKey(childPos));
       currentPos = nextPos;
     }
     int maxPos = node48.getMaxPos();

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/Node4Test.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/Node4Test.java
@@ -24,16 +24,22 @@ public class Node4Test {
     Assertions.assertTrue(node4.getMaxPos() == 0);
     Assertions.assertTrue(node4.getMinPos() == 0);
     Assertions.assertTrue(node4.getChildPos(key1) == 0);
+    Assertions.assertTrue(node4.getChildKey(0) == key1);
+
     byte key2 = 1;
     node4 = (Node4) Node4.insert(node4, leafNode2, key2);
     Assertions.assertTrue(node4.getChildPos(key2) == 0);
     Assertions.assertTrue(node4.getChildPos(key1) == 1);
+    Assertions.assertTrue(node4.getChildKey(0) == key2);
+
     byte key3 = -1;
     node4 = (Node4) Node4.insert(node4, leafNode3, key3);
     Assertions.assertTrue(node4.getChildPos(key3) == 2);
+    Assertions.assertTrue(node4.getChildKey(2) == key3);
     node4 = (Node4) node4.remove(1);
     Assertions.assertTrue(node4.getChildPos(key2) == 0);
     Assertions.assertTrue(node4.getChildPos(key3) == 1);
+    Assertions.assertTrue(node4.getChildKey(1) == key3);
     Assertions.assertTrue(node4.getChildPos(key1) == Node.ILLEGAL_IDX);
 
     int bytesSize = node4.serializeSizeInBytes();

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import java.io.ByteArrayInputStream;
@@ -86,7 +87,8 @@ public class TestRoaring64Bitmap {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(sizeInt);
     DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
     roaring64Bitmap.serialize(dataOutputStream);
-    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(
+        byteArrayOutputStream.toByteArray());
     DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream);
     Roaring64Bitmap deserStreamOne = new Roaring64Bitmap();
     deserStreamOne.deserialize(dataInputStream);
@@ -509,11 +511,12 @@ public class TestRoaring64Bitmap {
   public void testSerialization_ToBigEndianBuffer() throws IOException, ClassNotFoundException {
     final Roaring64Bitmap map = newDefaultCtor();
     map.addLong(123);
-    ByteBuffer buffer = ByteBuffer.allocate((int) map.serializedSizeInBytes()).order(ByteOrder.BIG_ENDIAN);
+    ByteBuffer buffer = ByteBuffer.allocate((int) map.serializedSizeInBytes())
+        .order(ByteOrder.BIG_ENDIAN);
     map.serialize(buffer);
     assertEquals(map.serializedSizeInBytes(), buffer.position());
   }
-  
+
   @Test
   public void testSerialization_OneValue() throws IOException, ClassNotFoundException {
     final Roaring64Bitmap map = newDefaultCtor();
@@ -788,7 +791,7 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
-  void testToArrayAfterAndOptHasEmptyContainer (){
+  void testToArrayAfterAndOptHasEmptyContainer() {
     Roaring64Bitmap bitmap = new Roaring64Bitmap();
     bitmap.addLong(0);
 
@@ -1217,5 +1220,44 @@ public class TestRoaring64Bitmap {
     assertEquals(left.hashCode(), right.hashCode());
     assertEquals(left, right);
     assertEquals(right, left);
+  }
+
+  @Test
+  public void testIssue428() {
+    long input = 1353768194141061120L;
+
+    long[] compare = new long[]{
+        5192650370358181888L,
+        5193776270265024512L,
+        5194532734264934400L,
+        5194544828892839936L,
+        5194545653526560768L,
+        5194545688960040960L,
+        5194545692181266432L,
+        5194545705066168320L,
+        5194545722246037504L,
+        5194545928404467712L,
+        5194550326450978816L,
+        5194620695195156480L,
+        5206161169240293376L
+    };
+
+    Roaring64Bitmap inputRB = new Roaring64Bitmap();
+    inputRB.add(input);
+
+    Roaring64Bitmap compareRB = new Roaring64Bitmap();
+    compareRB.add(compare);
+    compareRB.and(inputRB);
+    assertEquals(0, compareRB.getIntCardinality());
+
+    compareRB = new Roaring64Bitmap();
+    compareRB.add(compare);
+    compareRB.or(inputRB);
+    assertEquals(14, compareRB.getIntCardinality());
+
+    compareRB = new Roaring64Bitmap();
+    compareRB.add(compare);
+    compareRB.andNot(inputRB);
+    assertEquals(13, compareRB.getIntCardinality());
   }
 }


### PR DESCRIPTION
fix [issue](https://github.com/RoaringBitmap/RoaringBitmap/issues/428).  When iterating operations interwove with the removing ones it will make the `AbstractShuttle`'s stack hold a node's stale position data. This PR's main change is to let the stack to hold the node's fresh position data.

@lemire it's ready to give a review now.