### PR TITLE
fix empty RoaringBatchIterator#nextBatch NPE

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBatchIterator.java
@@ -17,6 +17,9 @@ public final class RoaringBatchIterator implements BatchIterator {
 
   @Override
   public int nextBatch(int[] buffer) {
+    if (!hasNext()){
+      return 0;
+    }
     int consumed = 0;
     if (iterator.hasNext()) {
       consumed += iterator.next(key, buffer);

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/RoaringBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/RoaringBatchIterator.java
@@ -19,6 +19,9 @@ public final class RoaringBatchIterator implements BatchIterator {
 
   @Override
   public int nextBatch(int[] buffer) {
+    if (!hasNext()){
+      return 0;
+    }
     int consumed = 0;
     if (iterator.hasNext()) {
       consumed += iterator.next(key, buffer);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestEmptyRoaringBatchIterator.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestEmptyRoaringBatchIterator.java
@@ -1,0 +1,53 @@
+package org.roaringbitmap;
+
+import org.junit.jupiter.api.Test;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestEmptyRoaringBatchIterator {
+
+    @Test
+    public void testEmptyMutableRoaringBitmap(){
+        MutableRoaringBitmap mutableRoaringBitmap = new MutableRoaringBitmap();
+        BatchIterator iterator = mutableRoaringBitmap.getBatchIterator();
+        int[] ints = new int[1024];
+        int cnt = iterator.nextBatch(ints);
+        assertEquals(0, cnt);
+
+        mutableRoaringBitmap.add(1);
+        iterator = mutableRoaringBitmap.getBatchIterator();
+        cnt = iterator.nextBatch(ints);
+        assertEquals(1, cnt);
+    }
+
+    @Test
+    public void testEmptyImmutableRoaringBitmap(){
+        MutableRoaringBitmap mutableRoaringBitmap = new MutableRoaringBitmap();
+        ImmutableRoaringBitmap immutableRoaringBitmap = mutableRoaringBitmap.toImmutableRoaringBitmap();
+        BatchIterator iterator = immutableRoaringBitmap.getBatchIterator();
+        int[] ints = new int[1024];
+        int cnt = iterator.nextBatch(ints);
+        assertEquals(0, cnt);
+
+        mutableRoaringBitmap.add(1);
+        iterator = mutableRoaringBitmap.toImmutableRoaringBitmap().getBatchIterator();
+        cnt = iterator.nextBatch(ints);
+        assertEquals(1, cnt);
+    }
+
+    @Test
+    public void testEmptyRoaringBitmap(){
+        RoaringBitmap roaringBitmap = new RoaringBitmap();
+        BatchIterator iterator = roaringBitmap.getBatchIterator();
+        int[] ints = new int[1024];
+        int cnt = iterator.nextBatch(ints);
+        assertEquals(0, cnt);
+
+        roaringBitmap.add(1);
+        iterator = roaringBitmap.getBatchIterator();
+        cnt = iterator.nextBatch(ints);
+        assertEquals(1, cnt);
+    }
+}


### PR DESCRIPTION
When the bitmap is empty, directly call the RoaringBatchIterator#nextBatch will throw NPE. We can skip it by return zero if the bitmap is empty.