### PR TITLE
some trivial fixes

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/AbstractShuttle.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/AbstractShuttle.java
@@ -58,7 +58,7 @@ public abstract class AbstractShuttle implements Shuttle {
       int pos;
       int nextPos;
       if (!currentNodeEntry.visited) {
-        pos = currentNodeEntry.node.getMinPos();
+        pos = boundaryNodePosition(currentNodeEntry.node);
         currentNodeEntry.position = pos;
         nextPos = pos;
         currentNodeEntry.visited = true;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node16.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node16.java
@@ -153,8 +153,8 @@ public class Node16 extends Node {
     children[pos] = null;
     ByteBuffer byteBuffer = ByteBuffer.allocate(16).order(ByteOrder.BIG_ENDIAN);
     byte[] bytes = byteBuffer.putLong(firstV).putLong(secondV).array();
-    System.arraycopy(bytes, pos + 1, bytes, pos, count - pos);
-    System.arraycopy(children, pos + 1, children, pos, count - pos);
+    System.arraycopy(bytes, pos + 1, bytes, pos, (16 - pos - 1));
+    System.arraycopy(children, pos + 1, children, pos, (16 - pos - 1));
     firstV = byteBuffer.getLong(0);
     secondV = byteBuffer.getLong(8);
     count--;


### PR DESCRIPTION
This PR fix one potential bug of `Node16` which is the same as `Node4`. Another potential bug is about to reverse iterating the `Roaring64Bitmap` .