### PR TITLE
Validate Add Range

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -607,6 +607,10 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
    * @param rangeEnd exclusive ending of range
    */
   public void add(final long rangeStart, final long rangeEnd) {
+    if (rangeEnd == 0 || Long.compareUnsigned(rangeStart, rangeEnd) >= 0) {
+      throw new IllegalArgumentException("Invalid range [" + rangeStart + "," + rangeEnd + ")");
+    }
+
     byte[] startHigh = LongUtils.highPart(rangeStart);
     int startLow = LongUtils.lowPart(rangeStart);
     byte[] endHigh = LongUtils.highPart(rangeEnd - 1);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -920,6 +920,21 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
+  public void testAddInvalidRange() {
+    Roaring64Bitmap map = new Roaring64Bitmap();
+    // Zero edge-case
+    assertThrows(IllegalArgumentException.class, () -> map.add(0L, 0L));
+
+    // Same higher parts, different lower parts
+    assertThrows(IllegalArgumentException.class, () -> map.add(1L, 0L));
+    assertThrows(IllegalArgumentException.class, () -> map.add(-1, -2));
+
+    // Different higher parts
+    assertThrows(IllegalArgumentException.class, () -> map.add(Long.MAX_VALUE, 0L));
+    assertThrows(IllegalArgumentException.class, () -> map.add(Long.MIN_VALUE, Long.MAX_VALUE));
+  }
+
+  @Test
   public void testAddRangeSingleBucket() {
     Roaring64Bitmap map = newDefaultCtor();
 


### PR DESCRIPTION
This patch fixes a bug where Roaring64Bitmap will accept an invalid
range without failing and produce an incorrect bitmap. Since the range
is [inclusive, exclusive) adjusting the right end point by subtracting
one from it can create a bigger range. For example, bitmap.add(0, 0)
is an invalid range, but it will produce a bitmap with all positions
set to 1.