### PR TITLE
Roaring64Bitmap::addInt Setting Wrong Bits

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -36,7 +36,7 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
   }
 
   public void addInt(int x) {
-    addLong(x);
+    addLong(Util.toUnsignedLong(x));
   }
 
   /**

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.roaringbitmap.Util.toUnsignedLong;
 
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
@@ -210,7 +211,7 @@ public class TestRoaring64Bitmap {
   public void testAddInt() {
     Roaring64Bitmap map = newDefaultCtor();
     map.addInt(-1);
-    assertEquals(-1, map.select(0));
+    assertEquals(4294967295L, map.select(0));
   }
 
   @Test
@@ -909,6 +910,16 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
+  public void testInvalidIntMask() {
+    Roaring64Bitmap map = new Roaring64Bitmap();
+    int a = 0xFFFF;  // -1 in two's compliment
+    map.addInt(a);
+    assertEquals(map.getIntCardinality(), 1);
+    long addedInt = map.getLongIterator().next();
+    assertEquals(0xFFFFL, addedInt);
+  }
+
+  @Test
   public void testAddRangeSingleBucket() {
     Roaring64Bitmap map = newDefaultCtor();
 
@@ -925,7 +936,7 @@ public class TestRoaring64Bitmap {
   public void testAddRangeEndExcludingNextBitmapFirstLow() {
     Roaring64Bitmap map = newDefaultCtor();
 
-    long end = Util.toUnsignedLong(-1) + 1;
+    long end = toUnsignedLong(-1) + 1;
 
     map.add(end - 2, end);
     assertEquals(2, map.getLongCardinality());
@@ -985,7 +996,7 @@ public class TestRoaring64Bitmap {
   public void testRoaringBitmapSelectAboveIntegerMaxValue() {
     RoaringBitmap map = new RoaringBitmap();
 
-    long maxForRoaringBitmap = Util.toUnsignedLong(-1) + 1;
+    long maxForRoaringBitmap = toUnsignedLong(-1) + 1;
     map.add(0L, maxForRoaringBitmap);
 
     assertEquals(maxForRoaringBitmap, map.getLongCardinality());
@@ -1162,7 +1173,7 @@ public class TestRoaring64Bitmap {
 
     long[] bitmapAsLongArray = new long[bitmapAsIntArray.length];
     for (int i = 0; i < bitmapAsIntArray.length; i++) {
-      bitmapAsLongArray[i] = Util.toUnsignedLong(bitmapAsIntArray[i]);
+      bitmapAsLongArray[i] = toUnsignedLong(bitmapAsIntArray[i]);
     }
   }
 


### PR DESCRIPTION
Since int is smaller than long, an int should always map to a positive
number in a long, that is, converting an int to a long should produce
a long in the range of [0, 2^32]. Since addInt directly calls addLong
without doing a proper conversion, the negative sign is being carried
over and setting incorrect positions in the map. For example,
addInt(-1) should be equivilant to addLong(((int) -1) & 0xffffffffL),
but its not. This patch fixes the issue by converting an int to
an unsigned long before calling addLong.