### PR TITLE
Roaring64Bitmap Memory Leak

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Containers.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Containers.java
@@ -341,11 +341,6 @@ public class Containers {
     this.secondLevelIdx = byteBuffer.getInt();
   }
 
-  //TODO: remove allocated unused memory
-  public void trim() {
-
-  }
-
   private byte containerType(Container container) {
     if (container instanceof RunContainer) {
       return 0;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/HighLowContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/HighLowContainer.java
@@ -12,6 +12,7 @@ import org.roaringbitmap.art.ContainerIterator;
 import org.roaringbitmap.art.Containers;
 import org.roaringbitmap.art.KeyIterator;
 import org.roaringbitmap.art.LeafNodeIterator;
+import org.roaringbitmap.art.Node;
 
 public class HighLowContainer {
 
@@ -52,6 +53,17 @@ public class HighLowContainer {
   public void put(byte[] highPart, Container container) {
     long containerIdx = containers.addContainer(container);
     art.insert(highPart, containerIdx);
+  }
+
+  /**
+   * Attempt to remove the container that corresponds to the 48 bit key.
+   * @param highPart the 48 bit key
+   */
+  public void remove(byte[] highPart) {
+    long containerIdx = art.remove(highPart);
+    if (containerIdx != Node.ILLEGAL_IDX) {
+      containers.remove(containerIdx);
+    }
   }
 
   /**

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -653,7 +653,12 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
       char low = LongUtils.lowPart(x);
       Container container = containerWithIdx.getContainer();
       Container freshContainer = container.remove(low);
-      highLowContainer.replaceContainer(containerWithIdx.getContainerIdx(), freshContainer);
+      if (freshContainer.isEmpty()) {
+        // Attempt to remove empty container to save memory
+        highLowContainer.remove(high);
+      } else {
+        highLowContainer.replaceContainer(containerWithIdx.getContainerIdx(), freshContainer);
+      }
     }
   }
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -39,6 +39,17 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
+  public void testEquality() {
+    Roaring64Bitmap rb1 = new Roaring64Bitmap();
+    Roaring64Bitmap rb2 = new Roaring64Bitmap();
+    assertEquals(rb1, rb2);
+    rb1.addLong(1);
+    assertNotEquals(rb1, rb2);
+    rb1.removeLong(1);
+    assertEquals(rb1, rb2);
+  }
+
+  @Test
   public void test() throws Exception {
     Random random = new Random();
     Roaring64Bitmap roaring64Bitmap = new Roaring64Bitmap();
@@ -1214,7 +1225,9 @@ public class TestRoaring64Bitmap {
       long chunksSize = targetCardinality / chunks;
       for (int i = 0; i < chunksSize; i++) {
         long v = map.select(r.nextInt(map.getIntCardinality()));
+        assertTrue(map.contains(v));
         map.removeLong(v);
+        assertFalse(map.contains(v));
       }
       assertEquals(targetCardinality - chunksSize * (j + 1), map.getIntCardinality());
     }


### PR DESCRIPTION
Since Roaring64Bitmap only adds to the ART and never removes a
prefix even if the lowpart container is empty, the tree leak memory,
even when empty. This patch will remove the high part from the
HighLowContainer when the lowpart container is empty after
a removeLong operation.

Also, this highpart leak can lead to incorrect results when
checking for logical equality.