### PR TITLE
Roaring64NavigableMap equals Bug + Leak

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
@@ -1296,6 +1296,12 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
       int low = low(x);
       bitmap.remove(low);
 
+      if (bitmap.isEmpty()) {
+        // Remove the prefix from highToBitmap map
+        highToBitmap.remove(high);
+        latestAddedHigh = null;
+      }
+
       // Invalidate only if actually modified
       invalidateAboveHigh(high);
     }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
@@ -407,6 +407,34 @@ public class TestRoaring64NavigableMap {
   }
 
   @Test
+  public void testEmptyAfterRemove() {
+    Roaring64NavigableMap rbm = new Roaring64NavigableMap();
+    Roaring64NavigableMap empty = new Roaring64NavigableMap();
+    rbm.addLong(1);
+    assertEquals(rbm.getHighToBitmap().size(), 1);
+    rbm.removeLong(1);
+    assertTrue(rbm.getHighToBitmap().isEmpty());
+    assertEquals(rbm, empty);
+  }
+
+  @Test
+  public void testNotEmptyAfterRemove() {
+    Roaring64NavigableMap rbm = new Roaring64NavigableMap();
+    rbm.addLong(1L);
+    assertEquals(rbm.getHighToBitmap().size(), 1);
+    rbm.addLong(3L * Integer.MAX_VALUE);
+    assertEquals(rbm.getHighToBitmap().size(), 2);
+
+    // This will remove a highToBitmap entry
+    rbm.removeLong(3L * Integer.MAX_VALUE);
+    assertEquals(rbm.getHighToBitmap().size(), 1);
+
+    // This shall create again a highToBitmap entry
+    rbm.addLong(3L * Integer.MAX_VALUE);
+    assertEquals(rbm.getHighToBitmap().size(), 2);
+  }
+
+  @Test
   public void testRemove_Signed() {
     Roaring64NavigableMap map = newSignedBuffered();
 


### PR DESCRIPTION
This patch removes the key(high part) from highToBitmap when
the corresponding BitmapDataProvider becomes empty after a
removeLong call. This prevent memory leaks and fixes the equality
check when some mappings are empty but not removed from the map.