### PR TITLE
Use BitmapDataProvider.add in Roaring64NavigableMap.add

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
@@ -1274,13 +1274,7 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
           pushBitmapForHigh(high, bitmap);
         }
 
-        if (bitmap instanceof RoaringBitmap) {
-          ((RoaringBitmap) bitmap).add(startLowAsLong, endLowAsLong);
-        } else if (bitmap instanceof MutableRoaringBitmap) {
-          ((MutableRoaringBitmap) bitmap).add(startLowAsLong, endLowAsLong);
-        } else {
-          throw new UnsupportedOperationException("TODO. Not for " + bitmap.getClass());
-        }
+        bitmap.add(startLowAsLong, endLowAsLong);
       }
     }
 


### PR DESCRIPTION
There is no need to cast the bitmap to either RoaringBitmap or MutableRoaringBitmap, since `add(long,long)` was added to BitmapDataProvider
in v0.7.22 https://github.com/RoaringBitmap/RoaringBitmap/commit/e21398ed25e38c54dcb351413d0f8fde42398f15#diff-2845c9ffc4aff5c1702093d822944f8a67d47d4b61e2ef2865a1d2405f60a6fcR24
