### PR TITLE
Remove Iterable<Integer>

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -12,8 +12,10 @@ import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.PrimitiveIterator.OfInt;
 import java.util.Spliterator;
+import java.util.function.Consumer;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 import java.util.Spliterators;
@@ -54,7 +56,7 @@ import static org.roaringbitmap.Util.lowbitsAsInteger;
  */
 
 
-public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>, Externalizable,
+public class RoaringBitmap implements Cloneable, Serializable, Externalizable,
     ImmutableBitmapDataProvider, BitmapDataProvider, AppendableStorage<Container> {
 
   private final class RoaringIntIterator implements PeekableIntIterator {
@@ -2044,56 +2046,6 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
   public boolean isEmpty() {
     return highLowContainer.size() == 0;
   }
-
-
-  /**
-   * iterate over the positions of the true values.
-   *
-   * @return the iterator
-   */
-  @Override
-  public Iterator<Integer> iterator() {
-    return new Iterator<Integer>() {
-      private int hs = 0;
-
-      private CharIterator iter;
-
-      private int pos = 0;
-
-      private int x;
-
-      @Override
-      public boolean hasNext() {
-        return pos < RoaringBitmap.this.highLowContainer.size();
-      }
-
-      private Iterator<Integer> init() {
-        if (pos < RoaringBitmap.this.highLowContainer.size()) {
-          iter = RoaringBitmap.this.highLowContainer.getContainerAtIndex(pos).getCharIterator();
-          hs = RoaringBitmap.this.highLowContainer.getKeyAtIndex(pos) << 16;
-        }
-        return this;
-      }
-
-      @Override
-      public Integer next() {
-        x = iter.nextAsInt() | hs;
-        if (!iter.hasNext()) {
-          ++pos;
-          init();
-        }
-        return x;
-      }
-
-      @Override
-      public void remove() {
-        // todo: implement
-        throw new UnsupportedOperationException();
-      }
-
-    }.init();
-  }
-
 
   // don't forget to call repairAfterLazy() afterward
   // important: x2 should not have been computed lazily

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -70,8 +70,7 @@ import static org.roaringbitmap.buffer.MutableRoaringBitmap.rangeSanityCheck;
  *
  * @see MutableRoaringBitmap
  */
-public class ImmutableRoaringBitmap
-    implements Iterable<Integer>, Cloneable, ImmutableBitmapDataProvider {
+public class ImmutableRoaringBitmap implements Cloneable, ImmutableBitmapDataProvider {
 
   private final class ImmutableRoaringIntIterator implements PeekableIntIterator {
     private MappeableContainerPointer cp =
@@ -1451,54 +1450,6 @@ public class ImmutableRoaringBitmap
   @Override
   public boolean isEmpty() {
     return highLowContainer.size() == 0;
-  }
-
-  /**
-   * iterate over the positions of the true values.
-   *
-   * @return the iterator
-   */
-  @Override
-  public Iterator<Integer> iterator() {
-    return new Iterator<Integer>() {
-      int hs = 0;
-
-      CharIterator iter;
-
-      int pos = 0;
-
-      int x;
-
-      @Override
-      public boolean hasNext() {
-        return pos < ImmutableRoaringBitmap.this.highLowContainer.size();
-      }
-
-      public Iterator<Integer> init() {
-        if (pos < ImmutableRoaringBitmap.this.highLowContainer.size()) {
-          iter = ImmutableRoaringBitmap.this.highLowContainer.getContainerAtIndex(pos)
-              .getCharIterator();
-          hs = (ImmutableRoaringBitmap.this.highLowContainer.getKeyAtIndex(pos)) << 16;
-        }
-        return this;
-      }
-
-      @Override
-      public Integer next() {
-        x = iter.nextAsInt() | hs;
-        if (!iter.hasNext()) {
-          ++pos;
-          init();
-        }
-        return x;
-      }
-
-      @Override
-      public void remove() {
-        throw new RuntimeException("Cannot modify.");
-      }
-
-    }.init();
   }
 
   /**

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
@@ -62,7 +62,7 @@ import java.util.Iterator;
  * @see org.roaringbitmap.RoaringBitmap
  */
 public class MutableRoaringBitmap extends ImmutableRoaringBitmap
-    implements Cloneable, Serializable, Iterable<Integer>, Externalizable,
+    implements Cloneable, Serializable, Externalizable,
         BitmapDataProvider, AppendableStorage<MappeableContainer> {
   private static final long serialVersionUID = 4L; // 3L; bumped by ofk for runcontainers
 
@@ -1202,54 +1202,6 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
     return (MutableRoaringArray) highLowContainer;
   }
 
-  /**
-   * iterate over the positions of the true values.
-   *
-   * @return the iterator
-   */
-  @Override
-  public Iterator<Integer> iterator() {
-    return new Iterator<Integer>() {
-      private int hs = 0;
-
-      private CharIterator iter;
-
-      private int pos = 0;
-
-      private int x;
-
-      @Override
-      public boolean hasNext() {
-        return pos < MutableRoaringBitmap.this.highLowContainer.size();
-      }
-
-      private Iterator<Integer> init() {
-        if (pos < MutableRoaringBitmap.this.highLowContainer.size()) {
-          iter = MutableRoaringBitmap.this.highLowContainer.getContainerAtIndex(pos)
-              .getCharIterator();
-          hs = (MutableRoaringBitmap.this.highLowContainer.getKeyAtIndex(pos)) << 16;
-        }
-        return this;
-      }
-
-      @Override
-      public Integer next() {
-        x = (iter.next()) | hs;
-        if (!iter.hasNext()) {
-          ++pos;
-          init();
-        }
-        return x;
-      }
-
-      @Override
-      public void remove() {
-         // todo: implement
-        throw new UnsupportedOperationException();
-      }
-
-    }.init();
-  }
 
   // call repairAfterLazy on result, eventually
   // important: x2 should not have been computed lazily

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestIteratorMemory.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestIteratorMemory.java
@@ -107,13 +107,7 @@ public class TestIteratorMemory {
   public void measureBoxedIterationAllocation() {
     if (isThreadAllocatedMemorySupported(THREAD_MBEAN)) {
       long before = getThreadAllocatedBytes(THREAD_MBEAN, Thread.currentThread().getId());
-
-      Iterator<Integer> intIterator = bitmap_a.iterator();
-      long result = 0;
-      while (intIterator.hasNext()) {
-        result += intIterator.next();
-
-      }
+      long result = bitmap_a.stream().sum();
       // A small check for iterator consistency
       assertEquals(407, result % 1024);
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestIterators.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestIterators.java
@@ -74,7 +74,6 @@ public class TestIterators {
 
   @Test
   public void testEmptyIteration() {
-    assertFalse(RoaringBitmap.bitmapOf().iterator().hasNext());
     assertFalse(RoaringBitmap.bitmapOf().getIntIterator().hasNext());
     assertFalse(RoaringBitmap.bitmapOf().getReverseIntIterator().hasNext());
   }
@@ -85,14 +84,11 @@ public class TestIterators {
     final int[] data = takeSortedAndDistinct(source, 450000);
     RoaringBitmap bitmap = RoaringBitmap.bitmapOf(data);
 
-    final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
     final List<Integer> intIteratorCopy = asList(bitmap.getIntIterator());
     final List<Integer> reverseIntIteratorCopy = asList(bitmap.getReverseIntIterator());
 
-    assertEquals(bitmap.getCardinality(), iteratorCopy.size());
     assertEquals(bitmap.getCardinality(), intIteratorCopy.size());
     assertEquals(bitmap.getCardinality(), reverseIntIteratorCopy.size());
-    assertEquals(Ints.asList(data), iteratorCopy);
     assertEquals(Ints.asList(data), intIteratorCopy);
     assertEquals(Lists.reverse(Ints.asList(data)), reverseIntIteratorCopy);
   }
@@ -101,11 +97,9 @@ public class TestIterators {
   public void testSmallIteration() {
     RoaringBitmap bitmap = RoaringBitmap.bitmapOf(1, 2, 3);
 
-    final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
     final List<Integer> intIteratorCopy = asList(bitmap.getIntIterator());
     final List<Integer> reverseIntIteratorCopy = asList(bitmap.getReverseIntIterator());
 
-    assertEquals(ImmutableList.of(1, 2, 3), iteratorCopy);
     assertEquals(ImmutableList.of(1, 2, 3), intIteratorCopy);
     assertEquals(ImmutableList.of(3, 2, 1), reverseIntIteratorCopy);
   }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -2984,9 +2984,7 @@ public class TestRoaringBitmap {
             rb.add(k * 100);
         }
         RoaringBitmap copy1 = new RoaringBitmap();
-        for (int x : rb) {
-            copy1.add(x);
-        }
+        rb.forEach(copy1::add);
         assertEquals(copy1, rb);
         RoaringBitmap copy2 = new RoaringBitmap();
         IntIterator i = rb.getIntIterator();
@@ -3007,9 +3005,7 @@ public class TestRoaringBitmap {
             rb.add((1 << 31) + k * 100);
         }
         RoaringBitmap copy1 = new RoaringBitmap();
-        for (int x : rb) {
-            copy1.add(x);
-        }
+        rb.forEach(copy1::add);
         assertEquals(copy1, rb);
         RoaringBitmap copy2 = new RoaringBitmap();
         IntIterator i = rb.getIntIterator();

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestSerialization.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestSerialization.java
@@ -208,39 +208,20 @@ public class TestSerialization {
     presoutbb.position(presoutbb.position() + imrempty.serializedSizeInBytes());
     assertEquals(imrempty.isEmpty(), true);
     ImmutableRoaringBitmap imrb = new ImmutableRoaringBitmap(presoutbb);
-    int cksum1 = 0, cksum2 = 0, count1 = 0, count2 = 0;
-    for (int x : bitmap_a) { // or bitmap_a1 for a version without run
-      cksum1 += x;
-      ++count1;
-    }
-    for (int x : imrb) {
-      cksum2 += x;
-      ++count2;
-    }
+    int cksum1[] = {0}, cksum2[] = {0}, count1[] = {0}, count2[] = {0};
 
-    Iterator<Integer> it1, it2;
-    it1 = bitmap_a.iterator();
-    // it1 = bitmap_a1.iterator();
-    it2 = imrb.iterator();
-    int blabcount = 0;
-    int valcount = 0;
-    while (it1.hasNext() && it2.hasNext()) {
-      ++valcount;
-      int val1 = it1.next(), val2 = it2.next();
-      if (val1 != val2) {
-        if (++blabcount < 10) {
-          System.out
-              .println("disagree on " + valcount + " nonmatching values are " + val1 + " " + val2);
-        }
-      }
-    }
-    System.out.println("there were " + blabcount + " diffs");
-    if (it1.hasNext() != it2.hasNext()) {
-      System.out.println("one ran out earlier");
-    }
+    bitmap_a.forEach(x -> {
+      cksum1[0] += x;
+      ++count1[0];
+    });
 
-    assertEquals(count1, count2);
-    assertEquals(cksum1, cksum2);
+    imrb.forEach(x -> {
+      cksum2[0] += x;
+      ++count2[0];
+    });
+
+    assertEquals(count1[0], count2[0]);
+    assertEquals(cksum1[0], cksum2[0]);
   }
 
 
@@ -263,19 +244,19 @@ public class TestSerialization {
     }
     bb1.flip();
     ImmutableRoaringBitmap imrb = new ImmutableRoaringBitmap(bb1);
-    int cksum1 = 0, cksum2 = 0, count1 = 0, count2 = 0;
-    for (int x : bm1) {
-      cksum1 += x;
-      ++count1;
-    }
+    int cksum1[] = {0}, cksum2[] = {0}, count1[] = {0}, count2[] = {0};
+    bm1.forEach(val -> {
+      cksum1[0] += val;
+      ++count1[0];
+    });
 
-    for (int x : imrb) {
-      cksum2 += x;
-      ++count2;
-    }
+    imrb.forEach(val -> {
+      cksum2[0] += val;
+      ++count2[0];
+    });
 
-    assertEquals(count1, count2);
-    assertEquals(cksum1, cksum2);
+    assertEquals(count1[0], count2[0]);
+    assertEquals(cksum1[0], cksum2[0]);
   }
 
   @Test
@@ -283,13 +264,7 @@ public class TestSerialization {
     // did we build a mutable equal to the regular one?
     assertEquals(bitmap_emptyr.isEmpty(), true);
     assertEquals(bitmap_empty.isEmpty(), true);
-    int cksum1 = 0, cksum2 = 0;
-    for (int x : bitmap_a) {
-      cksum1 += x;
-    }
-    for (int x : bitmap_ar) {
-      cksum2 += x;
-    }
+    int cksum1 = bitmap_a.stream().sum(), cksum2 = bitmap_ar.stream().sum();
     assertEquals(cksum1, cksum2);
   }
 
@@ -304,13 +279,9 @@ public class TestSerialization {
     emptyt.deserialize(dis);
     assertEquals(emptyt.isEmpty(), true);
     mrb.deserialize(dis);
-    int cksum1 = 0, cksum2 = 0;
-    for (int x : bitmap_a) {
-      cksum1 += x;
-    }
-    for (int x : mrb) {
-      cksum2 += x;
-    }
+    int cksum1 = bitmap_a.stream().sum();
+    int cksum2 = mrb.stream().sum();
+
     assertEquals(cksum1, cksum2);
   }
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestStreams.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestStreams.java
@@ -77,14 +77,11 @@ public class TestStreams {
     final int[] data = takeSortedAndDistinct(source, 450000);
     RoaringBitmap bitmap = RoaringBitmap.bitmapOf(data);
 
-    final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
     final List<Integer> intIteratorCopy = bitmap.stream().mapToObj(Integer::valueOf).collect(Collectors.toList());
     final List<Integer> reverseIntIteratorCopy = bitmap.reverseStream().mapToObj(Integer::valueOf).collect(Collectors.toList());
 
-    assertEquals(bitmap.getCardinality(), iteratorCopy.size());
     assertEquals(bitmap.getCardinality(), intIteratorCopy.size());
     assertEquals(bitmap.getCardinality(), reverseIntIteratorCopy.size());
-    assertEquals(Ints.asList(data), iteratorCopy);
     assertEquals(Ints.asList(data), intIteratorCopy);
     assertEquals(Lists.reverse(Ints.asList(data)), reverseIntIteratorCopy);
   }
@@ -93,11 +90,9 @@ public class TestStreams {
   public void testSmallIteration() {
     RoaringBitmap bitmap = RoaringBitmap.bitmapOf(1, 2, 3);
 
-    final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
     final List<Integer> intIteratorCopy = bitmap.stream().mapToObj(Integer::valueOf).collect(Collectors.toList());
     final List<Integer> reverseIntIteratorCopy = bitmap.reverseStream().mapToObj(Integer::valueOf).collect(Collectors.toList());
 
-    assertEquals(ImmutableList.of(1, 2, 3), iteratorCopy);
     assertEquals(ImmutableList.of(1, 2, 3), intIteratorCopy);
     assertEquals(ImmutableList.of(3, 2, 1), reverseIntIteratorCopy);
     assertEquals(bitmap.last(), bitmap.reverseStream().max().getAsInt());

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
@@ -1505,17 +1505,17 @@ public class TestImmutableRoaringBitmap {
               .toMutableRoaringBitmap();
 
       BitSet reference = new BitSet();
-      bitmap.iterator().forEachRemaining(reference::set);
+      bitmap.forEach(reference::set);
 
-      for (int next : bitmap) {
+      bitmap.forEach(x -> {
         for (int offset : offsets) {
-          int pos = next + offset;
+          int pos = x + offset;
           if (pos >= 0) {
             assertEquals(reference.nextClearBit(pos), bitmap.nextAbsentValue(pos));
             assertEquals(reference.previousClearBit(pos), bitmap.previousAbsentValue(pos));
           }
         }
-      }
+      });
     }
   }
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestIterators.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestIterators.java
@@ -85,7 +85,6 @@ public class TestIterators {
 
   @Test
   public void testEmptyIteration() {
-    assertFalse(MutableRoaringBitmap.bitmapOf().iterator().hasNext());
     assertFalse(MutableRoaringBitmap.bitmapOf().getIntIterator().hasNext());
     assertFalse(MutableRoaringBitmap.bitmapOf().getReverseIntIterator().hasNext());
   }
@@ -97,14 +96,11 @@ public class TestIterators {
     final int[] data = takeSortedAndDistinct(source, 450000);
     MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(data);
 
-    final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
     final List<Integer> intIteratorCopy = asList(bitmap.getIntIterator());
     final List<Integer> reverseIntIteratorCopy = asList(bitmap.getReverseIntIterator());
 
-    assertEquals(bitmap.getCardinality(), iteratorCopy.size());
     assertEquals(bitmap.getCardinality(), intIteratorCopy.size());
     assertEquals(bitmap.getCardinality(), reverseIntIteratorCopy.size());
-    assertEquals(Ints.asList(data), iteratorCopy);
     assertEquals(Ints.asList(data), intIteratorCopy);
     assertEquals(Lists.reverse(Ints.asList(data)), reverseIntIteratorCopy);
   }
@@ -139,14 +135,11 @@ public class TestIterators {
     MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(data);
     bitmap.runOptimize(); // result should have some runcontainers and some non.
 
-    final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
     final List<Integer> intIteratorCopy = asList(bitmap.getIntIterator());
     final List<Integer> reverseIntIteratorCopy = asList(bitmap.getReverseIntIterator());
 
-    assertEquals(bitmap.getCardinality(), iteratorCopy.size());
     assertEquals(bitmap.getCardinality(), intIteratorCopy.size());
     assertEquals(bitmap.getCardinality(), reverseIntIteratorCopy.size());
-    assertEquals(Ints.asList(data), iteratorCopy);
     assertEquals(Ints.asList(data), intIteratorCopy);
     assertEquals(Lists.reverse(Ints.asList(data)), reverseIntIteratorCopy);
   }
@@ -155,11 +148,9 @@ public class TestIterators {
   public void testSmallIteration() {
     MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(1, 2, 3);
 
-    final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
     final List<Integer> intIteratorCopy = asList(bitmap.getIntIterator());
     final List<Integer> reverseIntIteratorCopy = asList(bitmap.getReverseIntIterator());
 
-    assertEquals(ImmutableList.of(1, 2, 3), iteratorCopy);
     assertEquals(ImmutableList.of(1, 2, 3), intIteratorCopy);
     assertEquals(ImmutableList.of(3, 2, 1), reverseIntIteratorCopy);
   }
@@ -169,11 +160,9 @@ public class TestIterators {
     MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(1, 2, 3);
     bitmap.runOptimize();
 
-    final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
     final List<Integer> intIteratorCopy = asList(bitmap.getIntIterator());
     final List<Integer> reverseIntIteratorCopy = asList(bitmap.getReverseIntIterator());
 
-    assertEquals(ImmutableList.of(1, 2, 3), iteratorCopy);
     assertEquals(ImmutableList.of(1, 2, 3), intIteratorCopy);
     assertEquals(ImmutableList.of(3, 2, 1), reverseIntIteratorCopy);
   }
@@ -268,19 +257,8 @@ public class TestIterators {
       dos.close();
       ByteBuffer bb = ByteBuffer.wrap(bos.toByteArray());
       ImmutableRoaringBitmap rrback1 = new ImmutableRoaringBitmap(bb);
-      int j = 0;
-
-      // we can iterate over the mutable bitmap
-      for (int i : bitmap) {
-          j += i;
-      }
-      
-      int jj = 0;
-
-      // we can iterate over the immutable bitmap
-      for (int i : rrback1) {
-          jj+= i;
-      }
+      int j = bitmap.stream().sum();
+      int jj = rrback1.stream().sum();
       assertEquals(j, jj);
 
   }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
@@ -2907,41 +2907,6 @@ public class TestRoaringBitmap {
   }
 
   @Test
-  public void testIterator() {
-    MutableRoaringBitmap rb = new MutableRoaringBitmap();
-    for (int k = 0; k < 4000; ++k) {
-      rb.add(k);
-    }
-    for (int k = 0; k < 1000; ++k) {
-      rb.add(k * 100);
-    }
-    MutableRoaringBitmap copy1 = new MutableRoaringBitmap();
-    for (int x : rb) {
-      copy1.add(x);
-    }
-    assertTrue(copy1.equals(rb));
-    MutableRoaringBitmap copy2 = new MutableRoaringBitmap();
-    IntIterator i = rb.getIntIterator();
-    Iterator<Integer> is = rb.iterator();
-    while (i.hasNext()) {
-      if (!is.hasNext()) {
-        throw new RuntimeException("bug");
-      }
-      int x = i.next();
-      copy2.add(x);
-      int xs = is.next();
-      if (x != xs) {
-        throw new RuntimeException("values differ " + x + " " + xs);
-      }
-    }
-    if (is.hasNext()) {
-      throw new RuntimeException("bug: more data available");
-    }
-    assertTrue(copy2.equals(rb));
-  }
-
-
-  @Test
   public void testIteratorBigInts() {
     MutableRoaringBitmap rb = new MutableRoaringBitmap();
     for (int k = 0; k < 4000; ++k) {
@@ -2951,34 +2916,22 @@ public class TestRoaringBitmap {
       rb.add((1<<31)+k * 100);
     }
     MutableRoaringBitmap copy1 = new MutableRoaringBitmap();
-    for (int x : rb) {
-      copy1.add(x);
-    }
-    assertTrue(copy1.equals(rb));
+    rb.forEach(copy1::add);
+    assertEquals(rb, copy1);
     MutableRoaringBitmap copy2 = new MutableRoaringBitmap();
     IntIterator i = rb.getIntIterator();
-    Iterator<Integer> is = rb.iterator();
     while (i.hasNext()) {
-      if (!is.hasNext()) {
-        throw new RuntimeException("bug");
-      }
       int x = i.next();
       copy2.add(x);
-      int xs = is.next();
-      if (x != xs) {
-        throw new RuntimeException("values differ " + x + " " + xs);
-      }
     }
-    if (is.hasNext()) {
-      throw new RuntimeException("bug: more data available");
-    }
-    assertTrue(copy2.equals(rb));
+
+    assertEquals(rb, copy2);
   }
 
 
 
 
-  
+
   @Test
   public void testIteratorMapped() {
     MutableRoaringBitmap orb = new MutableRoaringBitmap();
@@ -2989,30 +2942,19 @@ public class TestRoaringBitmap {
       orb.add(k * 100);
     }
     MutableRoaringBitmap ocopy1 = new MutableRoaringBitmap();
-    for (int x : orb) {
-      ocopy1.add(x);
-    }
-    assertTrue(ocopy1.equals(orb));
+    orb.forEach(ocopy1::add);
+    assertEquals(orb, ocopy1);
+
     MutableRoaringBitmap copy2 = new MutableRoaringBitmap();
     IntIterator i = toMapped(orb).getIntIterator();
-    Iterator<Integer> is = toMapped(orb).iterator();
     while (i.hasNext()) {
-      if (!is.hasNext()) {
-        throw new RuntimeException("bug");
-      }
       int x = i.next();
       copy2.add(x);
-      int xs = is.next();
-      if (x != xs) {
-        throw new RuntimeException("values differ " + x + " " + xs);
-      }
     }
-    if (is.hasNext()) {
-      throw new RuntimeException("bug: more data available");
-    }
+
     assertTrue(copy2.equals(toMapped(orb)));
   }
- 
+
 
  @Test
   public void testIteratorMappedBigInts() {
@@ -3024,26 +2966,14 @@ public class TestRoaringBitmap {
       orb.add((1<<32)+k * 100);
     }
     MutableRoaringBitmap ocopy1 = new MutableRoaringBitmap();
-    for (int x : orb) {
-      ocopy1.add(x);
-    }
+    orb.forEach(ocopy1::add);
+
     assertTrue(ocopy1.equals(orb));
     MutableRoaringBitmap copy2 = new MutableRoaringBitmap();
     IntIterator i = toMapped(orb).getIntIterator();
-    Iterator<Integer> is = toMapped(orb).iterator();
     while (i.hasNext()) {
-      if (!is.hasNext()) {
-        throw new RuntimeException("bug");
-      }
       int x = i.next();
       copy2.add(x);
-      int xs = is.next();
-      if (x != xs) {
-        throw new RuntimeException("values differ " + x + " " + xs);
-      }
-    }
-    if (is.hasNext()) {
-      throw new RuntimeException("bug: more data available");
     }
     assertTrue(copy2.equals(toMapped(orb)));
   }

--- a/examples/src/main/java/Basic.java
+++ b/examples/src/main/java/Basic.java
@@ -16,8 +16,6 @@ public class Basic {
         long cardinality = rr.getLongCardinality();
         System.out.println(cardinality);
         // a "forEach" is faster than this loop, but a loop is possible:
-        for(int i : rr) {
-          System.out.println(i);
-        }
+        rr.forEach(System.out::println);
   }
 }

--- a/examples/src/main/java/ForEachExample.java
+++ b/examples/src/main/java/ForEachExample.java
@@ -24,12 +24,9 @@ public class ForEachExample {
             rb.add(k);
         }
         final int[] count = {0};
-        rb.forEach(new IntConsumer() {
-            @Override
-            public void accept(int value) {
-                if((value % 1500) == 0) {
-                    count[0] ++;
-                }
+        rb.forEach(value -> {
+            if((value % 1500) == 0) {
+                count[0] ++;
             }
         });
         System.out.println("There are "+count[0]+" values divisible by 1500.");

--- a/fuzz-tests/src/test/java/org/roaringbitmap/BufferFuzzer.java
+++ b/fuzz-tests/src/test/java/org/roaringbitmap/BufferFuzzer.java
@@ -7,6 +7,7 @@ import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 import java.util.BitSet;
+import java.util.Iterator;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.*;
 import java.util.stream.IntStream;
@@ -475,17 +476,16 @@ public class BufferFuzzer {
     // Size limit to avoid out of memory errors; r.last() > 0 to avoid bitmaps with last > Integer.MAX_VALUE
     verifyInvariance(r -> r.isEmpty() || (r.last() > 0 && r.last() < 1 << 30), bitmap -> {
       BitSet reference = new BitSet();
-      bitmap.forEach((IntConsumer) reference::set);
-
-      for (int next : bitmap) {
+      bitmap.forEach(reference::set);
+      bitmap.forEach(x -> {
         for (int offset : offsets) {
-          int pos = next + offset;
+          int pos = x + offset;
           if (pos >= 0) {
             assertEquals(reference.nextClearBit(pos), bitmap.nextAbsentValue(pos));
             assertEquals(reference.previousClearBit(pos), bitmap.previousAbsentValue(pos));
           }
         }
-      }
+      });
     });
   }
 

--- a/fuzz-tests/src/test/java/org/roaringbitmap/Fuzzer.java
+++ b/fuzz-tests/src/test/java/org/roaringbitmap/Fuzzer.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
 import java.util.BitSet;
+import java.util.Iterator;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.*;
 import java.util.stream.IntStream;
@@ -533,25 +534,25 @@ public class Fuzzer {
             });
   }
 
-  @Test
-  public void absentValuesConsistentWithBitSet() {
-    int[] offsets = new int[]{0, 1, -1, 10, -10, 100, -100};
-    // Size limit to avoid out of memory errors; r.last() > 0 to avoid bitmaps with last > Integer.MAX_VALUE
-    verifyInvariance(r -> r.isEmpty() || (r.last() > 0 && r.last() < 1 << 30), bitmap -> {
-      BitSet reference = new BitSet();
-      bitmap.forEach((IntConsumer) reference::set);
+    @Test
+    public void absentValuesConsistentWithBitSet() {
+        int[] offsets = new int[]{0, 1, -1, 10, -10, 100, -100};
+        // Size limit to avoid out of memory errors; r.last() > 0 to avoid bitmaps with last > Integer.MAX_VALUE
+        verifyInvariance(r -> r.isEmpty() || (r.last() > 0 && r.last() < 1 << 30), bitmap -> {
+            BitSet reference = new BitSet();
+            bitmap.forEach(reference::set);
 
-      for (int next : bitmap) {
-        for (int offset : offsets) {
-          int pos = next + offset;
-          if (pos >= 0) {
-            assertEquals(reference.nextClearBit(pos), bitmap.nextAbsentValue(pos));
-            assertEquals(reference.previousClearBit(pos), bitmap.previousAbsentValue(pos));
-          }
-        }
-      }
-    });
-  }
+            bitmap.forEach(x -> {
+                for (int offset : offsets) {
+                    int pos = x + offset;
+                    if (pos >= 0) {
+                        assertEquals(reference.nextClearBit(pos), bitmap.nextAbsentValue(pos));
+                        assertEquals(reference.previousClearBit(pos), bitmap.previousAbsentValue(pos));
+                    }
+                }
+            });
+        });
+    }
 
   @Test
   public void testFastAggregationAnd() {

--- a/jmh/src/jmh/java/org/roaringbitmap/iteration/IteratorsBenchmark32.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/iteration/IteratorsBenchmark32.java
@@ -23,13 +23,12 @@ public class IteratorsBenchmark32 {
 
   @Benchmark
   public int testBoxed_a(BenchmarkState benchmarkState) {
-    Iterator<Integer> intIterator = benchmarkState.bitmap_a.iterator();
-    int result = 0;
-    while (intIterator.hasNext()) {
-      result = intIterator.next();
+    int[] result = {0};
+    benchmarkState.bitmap_a.forEach(x -> {
+      result[0] = x;
+    });
 
-    }
-    return result;
+    return result[0];
   }
 
   @Benchmark
@@ -63,13 +62,12 @@ public class IteratorsBenchmark32 {
 
   @Benchmark
   public int testBoxed_b(BenchmarkState benchmarkState) {
-    Iterator<Integer> intIterator = benchmarkState.bitmap_b.iterator();
-    int result = 0;
-    while (intIterator.hasNext()) {
-      result = intIterator.next();
+    int[] result = {0};
+    benchmarkState.bitmap_b.forEach(x -> {
+      result[0] = x;
+    });
 
-    }
-    return result;
+    return result[0];
   }
 
 
@@ -104,13 +102,13 @@ public class IteratorsBenchmark32 {
 
   @Benchmark
   public int testBoxed_c(BenchmarkState benchmarkState) {
-    Iterator<Integer> intIterator = benchmarkState.bitmap_c.iterator();
-    int result = 0;
-    while (intIterator.hasNext()) {
-      result = intIterator.next();
+    int[] result = {0};
 
-    }
-    return result;
+    benchmarkState.bitmap_c.forEach(x -> {
+      result[0] = x;
+    });
+
+    return result[0];
   }
 
 


### PR DESCRIPTION
Implementing Iterable<T> allows applications to use  enhanced for
loops, syntactic sugar, at the cost of performance (caused by
auto-boxing). Since RoaringBitmap already implements forEach with
IntConsumer, this patch removes the Iterable interface implementation
from RoaringBitmap. This should encourage applications to use more
efficient APIs and existing applications that use the enhanced for
loop can easily convert the code to loop the iterator directly.