### PR TITLE
FastAggregation for Roaring64NavigableMap

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -2140,15 +2140,11 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     }
   }
 
-  /**
-   * don't forget to call repairAfterLazy() afterward
-   * important: x2 should not have been computed lazily
-   * this method is like lazyor except that it will convert
-   * the current container to a bitset
-   *
-   * @param x2 other bitmap
-   */
-  public void naivelazyor(RoaringBitmap  x2) {
+  // don't forget to call repairAfterLazy() afterward
+  // important: x2 should not have been computed lazily
+  // this method is like lazyor except that it will convert
+  // the current container to a bitset
+  protected void naivelazyor(RoaringBitmap  x2) {
     int pos1 = 0, pos2 = 0;
     int length1 = highLowContainer.size();
     final int length2 = x2.highLowContainer.size();
@@ -2492,10 +2488,8 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     return answer;
   }
 
-  /**
-   * to be used with lazyor
-   */
-  public void repairAfterLazy() {
+  // to be used with lazyor
+  protected void repairAfterLazy() {
     for (int k = 0; k < highLowContainer.size(); ++k) {
       Container c = highLowContainer.getContainerAtIndex(k);
       highLowContainer.setContainerAtIndex(k, c.repairAfterLazy());

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -2140,10 +2140,14 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     }
   }
 
-  // don't forget to call repairAfterLazy() afterward
-  // important: x2 should not have been computed lazily
-  // this method is like lazyor except that it will convert
-  // the current container to a bitset
+  /**
+   * don't forget to call repairAfterLazy() afterward
+   * important: x2 should not have been computed lazily
+   * this method is like lazyor except that it will convert
+   * the current container to a bitset
+   *
+   * @param x2 other bitmap
+   */
   public void naivelazyor(RoaringBitmap  x2) {
     int pos1 = 0, pos2 = 0;
     int length1 = highLowContainer.size();
@@ -2488,7 +2492,9 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     return answer;
   }
 
-  // to be used with lazyor
+  /**
+   * to be used with lazyor
+   */
   public void repairAfterLazy() {
     for (int k = 0; k < highLowContainer.size(); ++k) {
       Container c = highLowContainer.getContainerAtIndex(k);

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -2144,7 +2144,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
   // important: x2 should not have been computed lazily
   // this method is like lazyor except that it will convert
   // the current container to a bitset
-  protected void naivelazyor(RoaringBitmap  x2) {
+  public void naivelazyor(RoaringBitmap  x2) {
     int pos1 = 0, pos2 = 0;
     int length1 = highLowContainer.size();
     final int length2 = x2.highLowContainer.size();
@@ -2489,7 +2489,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
   }
 
   // to be used with lazyor
-  protected void repairAfterLazy() {
+  public void repairAfterLazy() {
     for (int k = 0; k < highLowContainer.size(); ++k) {
       Container c = highLowContainer.getContainerAtIndex(k);
       highLowContainer.setContainerAtIndex(k, c.repairAfterLazy());

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmapPrivate.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmapPrivate.java
@@ -1,0 +1,18 @@
+package org.roaringbitmap;
+
+/**
+ * This class enables accessing/executing not-public methods.
+ * Its usage should be reserved to very specific cases, and
+ * given should should not be considered as part of the official API.
+ */
+@Deprecated
+public class RoaringBitmapPrivate {
+
+  public static void naivelazyor(RoaringBitmap x1, RoaringBitmap x2) {
+    x1.naivelazyor(x2);
+  }
+
+  public static void repairAfterLazy(RoaringBitmap r) {
+    r.repairAfterLazy();
+  }
+}

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmapPrivate.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmapPrivate.java
@@ -3,7 +3,7 @@ package org.roaringbitmap;
 /**
  * This class enables accessing/executing not-public methods.
  * Its usage should be reserved to very specific cases, and
- * given should should not be considered as part of the official API.
+ * given should not be considered as part of the official API.
  */
 @Deprecated
 public class RoaringBitmapPrivate {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmapPrivate.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmapPrivate.java
@@ -3,7 +3,7 @@ package org.roaringbitmap.buffer;
 /**
  * This class enables accessing/executing not-public methods.
  * Its usage should be reserved to very specific cases, and
- * given should should not be considered as part of the official API.
+ * given should not be considered as part of the official API.
  */
 @Deprecated
 public class MutableRoaringBitmapPrivate {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmapPrivate.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmapPrivate.java
@@ -1,0 +1,18 @@
+package org.roaringbitmap.buffer;
+
+/**
+ * This class enables accessing/executing not-public methods.
+ * Its usage should be reserved to very specific cases, and
+ * given should should not be considered as part of the official API.
+ */
+@Deprecated
+public class MutableRoaringBitmapPrivate {
+
+  public static void naivelazyor(MutableRoaringBitmap x1, MutableRoaringBitmap x2) {
+    x1.naivelazyor(x2);
+  }
+
+  public static void repairAfterLazy(MutableRoaringBitmap r) {
+    r.repairAfterLazy();
+  }
+}

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
@@ -692,7 +692,9 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
     return RoaringIntPacking.highestHigh(signedLongs);
   }
 
-  // to be used with lazyor
+  /**
+   * to be used with naivelazyor
+   */
   public void repairAfterLazy() {
     for (Entry<Integer, BitmapDataProvider> e2 : highToBitmap.entrySet()) {
       BitmapDataProvider lowBitmap2 = e2.getValue();

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
@@ -700,7 +700,6 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
    * @param x2 other bitmap
    */
   public void naivelazyor(final Roaring64NavigableMap x2) {
-    boolean firstBucket = true;
     for (Entry<Integer, BitmapDataProvider> e2 : x2.highToBitmap.entrySet()) {
       // Keep object to prevent auto-boxing
       Integer high = e2.getKey();
@@ -709,49 +708,31 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
 
       BitmapDataProvider lowBitmap2 = e2.getValue();
 
-      if ((lowBitmap1 == null || lowBitmap1 instanceof RoaringBitmap)
+      if (lowBitmap1 == null){
+        // Clone to prevent future modification of this modifying the input Bitmap
+        BitmapDataProvider lowBitmap2Clone;
+        if (lowBitmap2 instanceof RoaringBitmap) {
+          lowBitmap2Clone = ((RoaringBitmap) lowBitmap2).clone();
+        } else if (lowBitmap2 instanceof MutableRoaringBitmap) {
+          lowBitmap2Clone = ((MutableRoaringBitmap) lowBitmap2).clone();
+        } else {
+          throw new UnsupportedOperationException(".naivelazyor is not between "
+                  + this.getClass() + " and " + lowBitmap2.getClass());
+        }
+
+        pushBitmapForHigh(high, lowBitmap2Clone);
+      } else if (lowBitmap1 instanceof RoaringBitmap
               && lowBitmap2 instanceof RoaringBitmap) {
-        if (lowBitmap1 == null) {
-          // Clone to prevent future modification of this modifying the input Bitmap
-          RoaringBitmap lowBitmap2Clone = ((RoaringBitmap) lowBitmap2).clone();
-
-          pushBitmapForHigh(high, lowBitmap2Clone);
-        } else {
-          RoaringBitmapPrivate.naivelazyor((RoaringBitmap) lowBitmap1, (RoaringBitmap) lowBitmap2);
-        }
-      }else if ((lowBitmap1 == null || lowBitmap1 instanceof MutableRoaringBitmap)
+        RoaringBitmapPrivate.naivelazyor((RoaringBitmap) lowBitmap1, (RoaringBitmap) lowBitmap2);
+      } else if (lowBitmap1 instanceof MutableRoaringBitmap
               && lowBitmap2 instanceof MutableRoaringBitmap) {
-        if (lowBitmap1 == null) {
-          // Clone to prevent future modification of this modifying the input Bitmap
-          BitmapDataProvider lowBitmap2Clone = ((MutableRoaringBitmap) lowBitmap2).clone();
-
-
-          pushBitmapForHigh(high, lowBitmap2Clone);
-        } else {
-          MutableRoaringBitmapPrivate.naivelazyor((MutableRoaringBitmap) lowBitmap1,
-                  (MutableRoaringBitmap) lowBitmap2);
-        }
+        MutableRoaringBitmapPrivate.naivelazyor((MutableRoaringBitmap) lowBitmap1,
+                (MutableRoaringBitmap) lowBitmap2);
       } else {
-        throw new UnsupportedOperationException(
-                ".naivelazyor is not between " + this.getClass() + " and " + lowBitmap2.getClass());
+        throw new UnsupportedOperationException(".naivelazyor is not between "
+                + lowBitmap1.getClass() + " and " + lowBitmap2.getClass());
       }
-    }
-  }
 
-  /**
-   * to be used with naivelazyor
-   */
-  public void repairAfterLazy() {
-    for (Entry<Integer, BitmapDataProvider> e2 : highToBitmap.entrySet()) {
-      BitmapDataProvider lowBitmap2 = e2.getValue();
-      if (lowBitmap2 instanceof RoaringBitmap) {
-        RoaringBitmapPrivate.repairAfterLazy((RoaringBitmap) lowBitmap2);
-      } else if(lowBitmap2 instanceof MutableRoaringBitmap){
-        MutableRoaringBitmapPrivate.repairAfterLazy((MutableRoaringBitmap) lowBitmap2);
-      } else {
-        throw new UnsupportedOperationException(
-                ".repairAfterLazy is not supported for " + lowBitmap2.getClass());
-      }
     }
   }
 
@@ -1131,6 +1112,22 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
   @Override
   public ImmutableLongBitmapDataProvider limit(long x) {
     throw new UnsupportedOperationException("TODO");
+  }
+
+  /**
+   * to be used with naivelazyor
+   */
+  public void repairAfterLazy() {
+    for (BitmapDataProvider lowBitmap : highToBitmap.values()) {
+      if (lowBitmap instanceof RoaringBitmap) {
+        RoaringBitmapPrivate.repairAfterLazy((RoaringBitmap) lowBitmap);
+      } else if(lowBitmap instanceof MutableRoaringBitmap){
+        MutableRoaringBitmapPrivate.repairAfterLazy((MutableRoaringBitmap) lowBitmap);
+      } else {
+        throw new UnsupportedOperationException(
+                ".repairAfterLazy is not supported for " + lowBitmap.getClass());
+      }
+    }
   }
 
   /**

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
@@ -1529,4 +1529,14 @@ public class TestRoaring64NavigableMap {
     map.select(16);
     assertEquals(264, map.getLongSizeInBytes());
   }
+
+  @Test
+  public void testLazyOr() {
+    Roaring64NavigableMap map1 = Roaring64NavigableMap.bitmapOf(1 << 16, 1 << 18, 1 << 19, 1 << 33);
+    map1.naivelazyor(Roaring64NavigableMap.bitmapOf(4, 7, 8, 9));
+    map1.naivelazyor(Roaring64NavigableMap.bitmapOf(1, 2, 3, 4, 5, 1 << 16, 1 << 17, 1 << 20));
+    map1.repairAfterLazy();
+    Roaring64NavigableMap map2 = Roaring64NavigableMap.bitmapOf(1, 2, 3, 4, 5, 7, 8, 9, 1 << 16, 1 << 17, 1 << 18, 1 << 19, 1 << 20 , 1 << 33);
+    assertEquals(map2, map1);
+  }
 }

--- a/jmh/src/jmh/java/org/roaringbitmap/aggregation/or/RoaringBitmapBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/aggregation/or/RoaringBitmapBenchmark.java
@@ -1,0 +1,50 @@
+package org.roaringbitmap.aggregation.or;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.roaringbitmap.FastAggregation;
+import org.roaringbitmap.RandomData;
+import org.roaringbitmap.RoaringBitmap;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+public class RoaringBitmapBenchmark {
+
+    @Param({"10", "50", "100"})
+    int bitmapSize;
+    private List<RoaringBitmap> bitmaps = new ArrayList<>();
+
+    @Setup
+    public void setup() {
+        for (int n = 0; n < bitmapSize; n++) {
+            bitmaps.add(RandomData.randomBitmap(1 << 12, 1 / 3.0, 1 / 3.0));
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public void or() {
+        RoaringBitmap b1 = new RoaringBitmap();
+        for (int n = 0; n < bitmapSize; n++) {
+            b1.or(bitmaps.get(n));
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public void lazyor() {
+        FastAggregation.naive_or(bitmaps.iterator());
+    }
+
+}


### PR DESCRIPTION
Based on [pr](https://github.com/RoaringBitmap/RoaringBitmap/pull/416) of @baibaichen, I add ut and benchmark.

and Roaring64NavigableMap's lazyor call RoaringBitmap#naivelazyor to accelerate,  so I just add benchmark for the comparison between RoaringBitmap's or method and RoaringBitmap's  lazyor method

The result of benchmark:

Benchmark                      (bitmapSize)  Mode  Cnt        Score        Error  Units
RoaringBitmapBenchmark.lazyor            10  avgt    5   140801.978 ±  13538.443  us/op
RoaringBitmapBenchmark.lazyor            50  avgt    5  1002109.229 ± 252619.378  us/op
RoaringBitmapBenchmark.lazyor           100  avgt    5  1374633.000 ±  82727.392  us/op
RoaringBitmapBenchmark.or                10  avgt    5   166109.292 ±  10970.728  us/op
RoaringBitmapBenchmark.or                50  avgt    5  1856382.692 ± 398252.107  us/op
RoaringBitmapBenchmark.or               100  avgt    5  3205453.839 ± 493929.301  us/op
