### PR TITLE
Optimizations related to issue 470

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
@@ -1149,6 +1149,8 @@ public final class Util {
       mask <<= radix;
       Arrays.fill(histogram, 0);
     }
+    // We need to check that primary == data.
+    //
     // The check is entirely deterministic in this case.
     // We go:
     //   shift = 16

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
@@ -1097,7 +1097,7 @@ public final class Util {
    * take into account the most significant 16 bits. The least
    * significant 16 bits are ignored. Note that we treat int values
    * as unsigned integers (from 0 to 2^32).
-   * @param data - the data
+   * @param array - the data
    * @return whether it is sorted
    */
   public static boolean isPartialSorted(int[] array) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
@@ -1119,8 +1119,8 @@ public final class Util {
   public static void partialRadixSort(int[] data) {
     // It should be fast to check whether the data is already
     // sorted, and if it is, it can be advantageous to skip
-    // sorting it.
-    if(isPartialSorted(data)) { return; }
+    // sorting it. However, we lack relevant benchmarks.
+    // if(isPartialSorted(data)) { return; }
     final int radix = 8;
     int shift = 16;
     int mask = 0xFF0000;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
@@ -1091,34 +1091,79 @@ public final class Util {
   public static long toUnsignedLong(int x) {
     return ((long) x) & 0xffffffffL;
   }
-
   /**
-   * Sorts the data by the 16 bit prefix.
+   * Checks whether the data is sorted by the 16-bit prefix.
+   * The resulting data is considered partially sorted if you just
+   * take into account the most significant 16 bits. The least
+   * significant 16 bits are ignored. Note that we treat int values
+   * as unsigned integers (from 0 to 2^32).
    * @param data - the data
+   * @return whether it is sorted
+   */
+  public static boolean isPartialSorted(int[] array) {
+    for (int i = 0; i < array.length - 1; i++) {
+      if ((array[i] & 0xFFFF0000L) > (array[i + 1] & 0xFFFF0000L)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  /**
+   * Sorts the data by the 16 bit prefix using Radix sort.
+   * The resulting data will be partially sorted if you just
+   * take into account the most significant 16 bits. The least
+   * significant 16 bits are unsorted. Note that we treat int values
+   * as unsigned integers (from 0 to 2^32).
+   * @param data - the data (sorted in place)
    */
   public static void partialRadixSort(int[] data) {
+    // It should be fast to check whether the data is already
+    // sorted, and if it is, it can be advantageous to skip
+    // sorting it.
+    if(isPartialSorted(data)) { return; }
     final int radix = 8;
     int shift = 16;
     int mask = 0xFF0000;
     int[] copy = new int[data.length];
     int[] histogram = new int[(1 << radix) + 1];
+    // We want to avoid copying the data, see
+    // https://github.com/RoaringBitmap/RoaringBitmap/issues/470
+    int[] primary = data;
+    int[] secondary = copy;
     while (shift < 32) {
       for (int i = 0; i < data.length; ++i) {
-        ++histogram[((data[i] & mask) >>> shift) + 1];
+        ++histogram[((primary[i] & mask) >>> shift) + 1];
       }
       for (int i = 0; i < 1 << radix; ++i) {
         histogram[i + 1] += histogram[i];
       }
-      for (int i = 0; i < data.length; ++i) {
-        copy[histogram[(data[i] & mask) >>> shift]++] = data[i];
+      for (int i = 0; i < primary.length; ++i) {
+        secondary[histogram[(primary[i] & mask) >>> shift]++] = primary[i];
       }
-      System.arraycopy(copy, 0, data, 0, data.length);
+      // swap
+      int[] tmp = primary;
+      primary = secondary;
+      secondary = tmp;
+      //
       shift += radix;
       mask <<= radix;
       Arrays.fill(histogram, 0);
     }
+    // The check is entirely deterministic in this case.
+    // We go:
+    //   shift = 16
+    //       data == primary
+    //   shift = 24
+    //       data == secondary
+    //   // exit:
+    //   data == primary
+    //
+    // If unsure, we could do the following:
+    //
+    // if(data != primary) {
+    //    System.arraycopy(secondary, 0, data, 0, data.length);
+    // }
   }
-
   /**
    * Private constructor to prevent instantiation of utility class
    */

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
@@ -1092,23 +1092,6 @@ public final class Util {
     return ((long) x) & 0xffffffffL;
   }
   /**
-   * Checks whether the data is sorted by the 16-bit prefix.
-   * The resulting data is considered partially sorted if you just
-   * take into account the most significant 16 bits. The least
-   * significant 16 bits are ignored. Note that we treat int values
-   * as unsigned integers (from 0 to 2^32).
-   * @param array - the data
-   * @return whether it is sorted
-   */
-  public static boolean isPartialSorted(int[] array) {
-    for (int i = 0; i < array.length - 1; i++) {
-      if ((array[i] & 0xFFFF0000L) > (array[i + 1] & 0xFFFF0000L)) {
-        return false;
-      }
-    }
-    return true;
-  }
-  /**
    * Sorts the data by the 16 bit prefix using Radix sort.
    * The resulting data will be partially sorted if you just
    * take into account the most significant 16 bits. The least
@@ -1117,10 +1100,6 @@ public final class Util {
    * @param data - the data (sorted in place)
    */
   public static void partialRadixSort(int[] data) {
-    // It should be fast to check whether the data is already
-    // sorted, and if it is, it can be advantageous to skip
-    // sorting it. However, we lack relevant benchmarks.
-    // if(isPartialSorted(data)) { return; }
     final int radix = 8;
     int shift = 16;
     int mask = 0xFF0000;


### PR DESCRIPTION
Basically  we avoid two array copies in partialRadixSort and add a fast path for when the data is already sorted. See https://github.com/RoaringBitmap/RoaringBitmap/issues/470 Credit to @Ignition 