### PR TITLE
partial radix sort with early exit

### DIFF
--- a/RoaringBitmap/src/test/java/org/roaringbitmap/KryoTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/KryoTest.java
@@ -19,7 +19,7 @@ public class KryoTest {
         kryo.register(RoaringBitmap.class, new RoaringSerializer());
         return kryo;
     }
-    
+
     public static void writeRoaringToFile(File f,
             RoaringBitmap roaring,
             Serializer<RoaringBitmap> serializer) throws FileNotFoundException {
@@ -38,7 +38,7 @@ public class KryoTest {
         inputMap.close();
         return roaring;
     }
-    
+
     @Test
     public void roaringTest() throws IOException {
         RoaringSerializer serializer = new RoaringSerializer();
@@ -76,7 +76,7 @@ class RoaringSerializer extends Serializer<RoaringBitmap> {
             throw new RuntimeException();
         }
     }
-    
+
     @Override
     public RoaringBitmap read(Kryo kryo, Input input, Class<? extends RoaringBitmap> type) {
         RoaringBitmap bitmap = new RoaringBitmap();
@@ -88,5 +88,5 @@ class RoaringSerializer extends Serializer<RoaringBitmap> {
         }
         return bitmap;
     }
-    
+
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestUtil.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestUtil.java
@@ -52,35 +52,70 @@ public class TestUtil {
     @Test
     public void testPartialRadixSortIsStableInSameKey() {
         int[] data = new int[] {25, 1, 0, 10};
-        int[] test = Arrays.copyOf(data, data.length);
-        Util.partialRadixSort(test);
-        assertArrayEquals(data, test);
+        for (int key : new int[]{0, 1 << 16, 1 << 17, 1 << 24, 1 << 25}) {
+            // clear the old key and prepend the new key
+            for (int i = 0; i < data.length; ++i) {
+                data[i] &= 0xFFFF;
+                data[i] |= key;
+            }
+            int[] test = Arrays.copyOf(data, data.length);
+            Util.partialRadixSort(test);
+            assertArrayEquals(data, test);
+        }
     }
 
     @Test
     public void testPartialRadixSortSortsKeysCorrectly() {
-        int key1 = 1 << 16;
-        int key2 = 1 << 17;
-        int[] data = new int[] {key2 | 25, key1 | 1, 0, key2 | 10, 25, key1 | 10, key1, 10};
-        // sort by keys, leave values stable
-        int[] expected = new int[] {0, 25, 10, key1 | 1, key1 | 10, key1, key2 | 25, key2 | 10};
-        int[] test = Arrays.copyOf(data, data.length);
-        Util.partialRadixSort(test);
-        assertArrayEquals(expected, test);
+        int[] keys = {
+                // the test expects the first key to be less than the second key,
+                // neither should have any of the lower 16 bits set
+                1 << 16, 1 << 25,
+                1 << 16, 1 << 17,
+                1 << 17, 1 << 18,
+                1 << 25, 1 << 26,
+                1 << 23, 1 << 25,
+                1 << 24, 1 << 25,
+                1 << 25, 1 << 27,
+                1 << 29, 1 << 30,
+        };
+        for (int i = 0; i < keys.length; i += 2) {
+            int key1 = keys[i];
+            int key2 = keys[i+1];
+            int[] data = new int[]{key2 | 25, key1 | 1, 0, key2 | 10, 25, key1 | 10, key1, 10};
+            // sort by keys, leave values stable
+            int[] expected = new int[]{0, 25, 10, key1 | 1, key1 | 10, key1, key2 | 25, key2 | 10};
+            int[] test = Arrays.copyOf(data, data.length);
+            Util.partialRadixSort(test);
+            assertArrayEquals(expected, test);
+        }
     }
 
     @Test
     public void testPartialRadixSortSortsKeysCorrectlyWithDuplicates() {
-        int key1 = 1 << 16;
-        int key2 = 1 << 17;
-        int[] data = new int[] {key2 | 25, key1 | 1, 0, key2 | 10, 25, key1 | 10, key1, 10,
-                                key2 | 25, key1 | 1, 0, key2 | 10, 25, key1 | 10, key1, 10};
-        // sort by keys, leave values stable
-        int[] expected = new int[] {0, 25, 10, 0, 25, 10, key1 | 1, key1 | 10,  key1, key1 | 1, key1 | 10,  key1,
-                                    key2 | 25, key2 | 10, key2 | 25, key2 | 10};
-        int[] test = Arrays.copyOf(data, data.length);
-        Util.partialRadixSort(test);
-        assertArrayEquals(expected, test);
+        int[] keys = {
+                // the test expects the first key to be less than the second key,
+                // neither should have any of the lower 16 bits set
+                1 << 16, 1 << 25,
+                1 << 16, 1 << 17,
+                1 << 17, 1 << 18,
+                1 << 25, 1 << 26,
+                1 << 23, 1 << 25,
+                1 << 24, 1 << 25,
+                1 << 25, 1 << 27,
+                1 << 29, 1 << 30,
+        };
+        for (int i = 0; i < keys.length; i += 2) {
+            int key1 = keys[i];
+            int key2 = keys[i + 1];
+            int[] data = new int[]{key2 | 25, key1 | 1, 0, key2 | 10, 25, key1 | 10, key1, 10,
+                    key2 | 25, key1 | 1, 0, key2 | 10, 25, key1 | 10, key1, 10};
+            // sort by keys, leave values stable
+            int[] expected = new int[]{0, 25, 10, 0, 25, 10, key1 | 1, key1 | 10, key1, key1 | 1, key1 | 10, key1,
+                    key2 | 25, key2 | 10, key2 | 25, key2 | 10};
+            int[] test = Arrays.copyOf(data, data.length);
+            Util.partialRadixSort(test);
+            assertArrayEquals(expected, test);
+        }
     }
 
     @Test

--- a/jmh/src/jmh/java/org/roaringbitmap/RadixSort.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/RadixSort.java
@@ -1,0 +1,51 @@
+package org.roaringbitmap;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.SplittableRandom;
+
+@State(Scope.Benchmark)
+public class RadixSort {
+
+  @Param({"23", "25"})
+  int bits;
+
+  @Param("100000000")
+  int size;
+
+  @Param("0")
+  int seed;
+
+  private int[] data;
+  private int[] input;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    SplittableRandom random = new SplittableRandom(seed);
+    data = new int[size];
+    input = new int[size];
+    int mask = (1 << bits) - 1;
+    for (int i = 0; i < size; ++i) {
+      // this means with the same seed the unmasked bits will be identical
+      // which improves comparability
+      int value = random.nextInt() & mask;
+      data[i] = value;
+      input[i] = value;
+    }
+  }
+
+
+  @TearDown(Level.Invocation)
+  public void restore() {
+    System.arraycopy(input, 0, data, 0, input.length);
+  }
+
+
+  @Benchmark
+  public int[] partialSort() {
+    Util.partialRadixSort(data);
+    return data;
+  }
+
+
+}


### PR DESCRIPTION
Since we're beating up on my 3 year old radix sort, here's another variant which has two benefits

1. Reduce the number of passes over the data to build the histograms by populating both at once
2. If the maximum element in the data has an empty high byte, skip one level of the sort

I added a benchmark which varies the number of bits in the input data. On my branch (skylake 2.6GHz) I get 

```
Benchmark              (bits)  (seed)     (size)  Mode  Cnt  Score   Error  Units
RadixSort.partialSort      23       0  100000000  avgt    5  0.507 ▒ 0.011   s/op
RadixSort.partialSort      25       0  100000000  avgt    5  0.600 ▒ 0.016   s/op
```

On master I get 

```
Benchmark              (bits)  (seed)     (size)  Mode  Cnt  Score   Error  Units
RadixSort.partialSort      23       0  100000000  avgt    5  0.921 ▒ 0.165   s/op
RadixSort.partialSort      25       0  100000000  avgt    5  0.749 ▒ 0.003   s/op
```

I haven't dug in to why  the existing 2 pass algorithm is sensitive to there being 9 leading zeros but I suspect there is a dependency on the histogram's singularly populated bucket on the last pass. 

NB I still worry that this code isn't production worthy because of the linear space requirement!