### PR TITLE
Verifies and fixes issue 475

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -2503,7 +2503,7 @@ public final class RunContainer extends Container implements Cloneable {
     for(int k = 0; k < this.nbrruns; ++k) {
       int base = this.getValue(k) | high;
       int le = this.getLength(k);
-      for (int l = base; l <= base + le; ++l) {
+      for(int l = base; l - le <= base; ++l) {
         ic.accept(l);
       }
     }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -2443,7 +2443,7 @@ public final class MappeableRunContainer extends MappeableContainer implements C
     for(int k = 0; k < this.nbrruns; ++k) {
       int base = (this.getValue(k) & 0xFFFF) | high;
       int le = this.getLength(k) & 0xFFFF;
-      for(int l = base; l <= base + le; ++l ) {
+      for(int l = base; l - le <= base; ++l) {
         ic.accept(l);
       }
     }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestIterators.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestIterators.java
@@ -148,7 +148,32 @@ public class TestIterators {
       assertEquals(pii.next(), 2 * i);
     }
   }
-  
+
+  // https://github.com/RoaringBitmap/RoaringBitmap/issues/475
+  @Test
+  public void testCorruptionInfiniteLoop() {
+    RoaringBitmap bitmap = new RoaringBitmap();
+    bitmap.add(Integer.MAX_VALUE - 0);
+    bitmap.add(Integer.MAX_VALUE - 1);
+    bitmap.add(Integer.MAX_VALUE - 2);
+    // Adding this one leads to the issue
+    bitmap.add(Integer.MAX_VALUE - 3);
+    System.out.println(bitmap);
+    bitmap.forEach((org.roaringbitmap.IntConsumer) e -> {
+      if (!bitmap.contains(e)) {
+        throw new IllegalStateException("Not expecting to find: " + e);
+      }
+    });
+
+    bitmap.runOptimize(); // This is the line causing the issue
+    System.out.println(bitmap);
+    bitmap.forEach((org.roaringbitmap.IntConsumer) e -> {
+      System.out.println("Checking  :: " + e);
+      if (!bitmap.contains(e)) {
+        throw new IllegalStateException("Not expecting to find: " + e);
+      }
+    });
+  }
 
   @Test
   public void testSkipsRun() {

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestIterators.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestIterators.java
@@ -73,6 +73,31 @@ public class TestIterators {
     return unboxed;
   }
 
+  // https://github.com/RoaringBitmap/RoaringBitmap/issues/475
+  @Test
+  public void testCorruptionInfiniteLoop() {
+    MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+    bitmap.add(Integer.MAX_VALUE - 0);
+    bitmap.add(Integer.MAX_VALUE - 1);
+    bitmap.add(Integer.MAX_VALUE - 2);
+    // Adding this one leads to the issue
+    bitmap.add(Integer.MAX_VALUE - 3);
+    System.out.println(bitmap);
+    bitmap.forEach((org.roaringbitmap.IntConsumer) e -> {
+      if (!bitmap.contains(e)) {
+        throw new IllegalStateException("Not expecting to find: " + e);
+      }
+    });
+
+    bitmap.runOptimize(); // This is the line causing the issue
+    System.out.println(bitmap);
+    bitmap.forEach((org.roaringbitmap.IntConsumer) e -> {
+      System.out.println("Checking  :: " + e);
+      if (!bitmap.contains(e)) {
+        throw new IllegalStateException("Not expecting to find: " + e);
+      }
+    });
+  }
 
   @Test
   public void testBitmapIteration() {


### PR DESCRIPTION
The `forEach` method has a bug for when the run ends at `Integer.MAX` because of an overflow.