### PR TITLE
Less random testing.

### DIFF
--- a/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitmapWriterRandomisedTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitmapWriterRandomisedTest.java
@@ -117,7 +117,7 @@ public class RoaringBitmapWriterRandomisedTest {
     }
 
     private static int[] randomArray(int size) {
-        Random random = new Random();
+        Random random = new Random(1234);
         int[] data = new int[size];
         int last = 0;
         int i = 0;

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitSetUtil.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitSetUtil.java
@@ -37,7 +37,7 @@ public class TestBitSetUtil {
 
   @Test
   public void testFlipFlapBetweenRandomFullAndEmptyBitSet() {
-    final Random random = new Random();
+    final Random random = new Random(1234);
     final int nbitsPerBlock = 1024 * Long.SIZE;
     final int blocks = 50;
     final BitSet bitset = new BitSet(nbitsPerBlock * blocks);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestMemory.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestMemory.java
@@ -19,7 +19,7 @@ public class TestMemory {
     for (int i = 0; i < N; i++) {
       bitmaps[i] = new RoaringBitmap();
     }
-    final Random random = new Random();
+    final Random random = new Random(1234);
     for (int i = 0; i < M; i++) {
       final int x = random.nextInt(N);
       bitmaps[x].add(i);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
@@ -1079,14 +1079,15 @@ public class TestRunContainer {
 
   private void inot14once(int num, int rangeSize) {
     RunContainer container = new RunContainer();
+    Random generator = new Random(1234);
     BitSet checker = new BitSet();
     for (int i = 0; i < num; ++i) {
-      int val = (int) (Math.random() * 65536);
+      int val = (int) (generator.nextDouble() * 65536);
       checker.set(val);
       container.add((char) val);
     }
 
-    int rangeStart = (int) Math.random() * (65536 - rangeSize);
+    int rangeStart = (int) generator.nextDouble() * (65536 - rangeSize);
     int rangeEnd = rangeStart + rangeSize;
 
     // this test is not checking runcontainer flip if "add" has converted
@@ -2019,13 +2020,14 @@ public class TestRunContainer {
   private void not14once(int num, int rangeSize) {
     RunContainer container = new RunContainer();
     BitSet checker = new BitSet();
+    Random generator = new Random(1234);
     for (int i = 0; i < num; ++i) {
-      int val = (int) (Math.random() * 65536);
+      int val = (int) (generator.nextDouble() * 65536);
       checker.set(val);
       container.add((char) val);
     }
 
-    int rangeStart = (int) Math.random() * (65536 - rangeSize);
+    int rangeStart = (int) generator.nextDouble() * (65536 - rangeSize);
     int rangeEnd = rangeStart + rangeSize;
 
     assertTrue(container instanceof RunContainer);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestBitSetUtil.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestBitSetUtil.java
@@ -39,7 +39,7 @@ public class TestBitSetUtil {
 
   @Test
   public void testFlipFlapBetweenRandomFullAndEmptyBitSet() {
-    final Random random = new Random();
+    final Random random = new Random(1234);
     final int nbitsPerBlock = 1024 * Long.SIZE;
     final int blocks = 50;
     final BitSet bitset = new BitSet(nbitsPerBlock * blocks);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestMemory.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestMemory.java
@@ -19,7 +19,7 @@ public class TestMemory {
     for (int i = 0; i < N; i++) {
       bitmaps[i] = new MutableRoaringBitmap();
     }
-    final Random random = new Random();
+    final Random random = new Random(1234);
     for (int i = 0; i < M; i++) {
       final int x = random.nextInt(N);
       bitmaps[x].add(i);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
@@ -63,7 +63,7 @@ public class TestRoaringBitmap {
     
   @Test 
   public void binaryTest() throws IOException {
-    Random rand = new Random();
+    Random rand = new Random(1234);
     rand.setSeed(11111);
     for(int z = 0; z < 1000; ++z) {
       final MutableRoaringBitmap rr1 = new MutableRoaringBitmap();

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -48,7 +48,7 @@ public class TestRoaring64Bitmap {
 
   @Test
   public void test() throws Exception {
-    Random random = new Random();
+    Random random = new Random(1234);
     Roaring64Bitmap roaring64Bitmap = new Roaring64Bitmap();
     Set<Long> source = new HashSet<>();
     int total = 1000000;
@@ -69,7 +69,7 @@ public class TestRoaring64Bitmap {
 
   @Test
   public void testAllKindOfNodeTypesSerDeser() throws Exception {
-    Random random = new Random();
+    Random random = new Random(1234);
     Roaring64Bitmap roaring64Bitmap = new Roaring64Bitmap();
     Set<Long> source = new HashSet<>();
     int total = 10000;
@@ -1202,7 +1202,7 @@ public class TestRoaring64Bitmap {
 
   @Test
   public void testRandomAddRemove() {
-    Random r = new Random();
+    Random r = new Random(1234);
 
     // We need to max the considered range of longs, else each long would be in a different bucket
     long max = Integer.MAX_VALUE * 20L;

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
@@ -1482,7 +1482,7 @@ public class TestRoaring64NavigableMap {
 
   @Test
   public void testRandomAddRemove() {
-    Random r = new Random();
+    Random r = new Random(1234);
 
     // We need to max the considered range of longs, else each long would be in a different bucket
     long max = Integer.MAX_VALUE * 20L;


### PR DESCRIPTION
We are relying in many places on unseeded random number generator which means that some of our tests may run over different data from run-to-run or from Java version to Java version. Though it has not caused harm, it is prudent to avoid this added complexity.