### PR TITLE
fix javadoc comment to be name the correct operation happening.

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/Container.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/Container.java
@@ -903,7 +903,7 @@ public abstract class Container implements Iterable<Character>, Cloneable, Exter
 
 
   /**
-   * Computes the bitwise OR of this container with another (symmetric difference). This container
+   * Computes the bitwise XOR of this container with another (symmetric difference). This container
    * as well as the provided container are left unaffected.
    *
    * @param x other parameter


### PR DESCRIPTION
The comment says OR but the operation is XOR, so fix that.