### PR TITLE
Add Flip ranger operation to Roaring64Bitmap

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/LongUtils.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/LongUtils.java
@@ -125,4 +125,43 @@ public class LongUtils {
   public static long initWithFirst4Byte(int v) {
     return ((long) v) << 32;
   }
+
+  /**
+   * shift the long left by the container size amount so we can loop across containers by +1 steps
+   * @param num long being treated as unsigned long
+   * @return value shifted out of value space into container high part
+   */
+  public static long leftShiftHighPart(long num) {
+    return num >>> 16;
+  }
+
+  /**
+   * shift the long by right the container size amount so we use the value after have done our steps
+   * @param num uint48 to be shift back into uint64
+   * @return value shifted out of container high part back into value space
+   */
+  public static long rightShiftHighPart(long num) {
+    return num << 16;
+  }
+
+  public static int maxLowBitAsInteger() {
+    return 0xFFFF;
+  }
+
+  /**
+   * set the high 48 bit parts of the input number into the given byte array
+   *
+   * @param num the long number
+   * @param high48 the byte array
+   * @return the high 48 bit
+   */
+  public static byte[] highPartInPlace(long num, byte[] high48) {
+    high48[0] = (byte) ((num >>> 56) & 0xff);
+    high48[1] = (byte) ((num >>> 48) & 0xff);
+    high48[2] = (byte) ((num >>> 40) & 0xff);
+    high48[3] = (byte) ((num >>> 32) & 0xff);
+    high48[4] = (byte) ((num >>> 24) & 0xff);
+    high48[5] = (byte) ((num >>> 16) & 0xff);
+    return high48;
+  }
 }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/LongUtils.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/LongUtils.java
@@ -127,20 +127,20 @@ public class LongUtils {
   }
 
   /**
-   * shift the long left by the container size amount so we can loop across containers by +1 steps
+   * shift the long right by the container size amount so we can loop across containers by +1 steps
    * @param num long being treated as unsigned long
    * @return value shifted out of value space into container high part
    */
-  public static long leftShiftHighPart(long num) {
+  public static long rightShiftHighPart(long num) {
     return num >>> 16;
   }
 
   /**
-   * shift the long by right the container size amount so we use the value after have done our steps
+   * shift the long by left the container size amount so we use the value after have done our steps
    * @param num uint48 to be shift back into uint64
    * @return value shifted out of container high part back into value space
    */
-  public static long rightShiftHighPart(long num) {
+  public static long leftShiftHighPart(long num) {
     return num << 16;
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -306,9 +306,7 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
    * @param rangeEnd exclusive ending of range, in [0, 0xffffffffffffffff + 1]
    */
   public void flip(final long rangeStart, final long rangeEnd) {
-    //rangeSanityCheck(rangeStart, rangeEnd);
 
-    // I don't like these rangeEnd being v+1 as flip all bits would be [0,0) which seems like
     if(rangeStart >= 0 && rangeEnd >= 0 && rangeStart >= rangeEnd){
       // both numbers in positive range, and start is beyond end, nothing to do.
       return;
@@ -322,11 +320,10 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
 
     byte[] hbStart = LongUtils.highPart(rangeStart);
     char lbStart = LongUtils.lowPart(rangeStart);
-    byte[] hbLast = LongUtils.highPart(rangeEnd - 1L);
     char lbLast = LongUtils.lowPart(rangeEnd - 1L);
 
-    long shStart = LongUtils.leftShiftHighPart(rangeStart);
-    long shEnd = LongUtils.leftShiftHighPart(rangeEnd - 1L);
+    long shStart = LongUtils.rightShiftHighPart(rangeStart);
+    long shEnd = LongUtils.rightShiftHighPart(rangeEnd - 1L);
 
     // TODO:this can be accelerated considerably
     for (long hb = shStart; hb <= shEnd; ++hb) {
@@ -336,7 +333,7 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
       final int containerLast = (hb == shEnd) ? lbLast : LongUtils.maxLowBitAsInteger();
 
       ContainerWithIndex cwi = highLowContainer.searchContainer(
-              LongUtils.highPartInPlace(LongUtils.rightShiftHighPart(hb), hbStart));
+              LongUtils.highPartInPlace(LongUtils.leftShiftHighPart(hb), hbStart));
 
       if (cwi != null) {
         final long i = cwi.getContainerIdx();

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -299,6 +299,61 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
   }
 
   /**
+   * Complements the bits in the given range, from rangeStart (inclusive) rangeEnd (exclusive). The
+   * given bitmap is unchanged.
+   *
+   * @param rangeStart inclusive beginning of range, in [0, 0xffffffffffffffff]
+   * @param rangeEnd exclusive ending of range, in [0, 0xffffffffffffffff + 1]
+   */
+  public void flip(final long rangeStart, final long rangeEnd) {
+    //rangeSanityCheck(rangeStart, rangeEnd);
+
+    // I don't like these rangeEnd being v+1 as flip all bits would be [0,0) which seems like
+    if(rangeStart >= 0 && rangeEnd >= 0 && rangeStart >= rangeEnd){
+      // both numbers in positive range, and start is beyond end, nothing to do.
+      return;
+    } else if(rangeStart < 0 && rangeEnd < 0 && rangeStart >= rangeEnd){
+      // both numbers in negative range, and start is beyond end, nothing to do.
+      return;
+    } else if(rangeStart < 0 && rangeEnd > 0) {
+      // start is neg which is "higher" and end is above zero thus, nothing to do.
+      return;
+    }
+
+    byte[] hbStart = LongUtils.highPart(rangeStart);
+    char lbStart = LongUtils.lowPart(rangeStart);
+    byte[] hbLast = LongUtils.highPart(rangeEnd - 1L);
+    char lbLast = LongUtils.lowPart(rangeEnd - 1L);
+
+    long shStart = LongUtils.leftShiftHighPart(rangeStart);
+    long shEnd = LongUtils.leftShiftHighPart(rangeEnd - 1L);
+
+    // TODO:this can be accelerated considerably
+    for (long hb = shStart; hb <= shEnd; ++hb) {
+      // first container may contain partial range
+      final int containerStart = (hb == shStart) ? lbStart : 0;
+      // last container may contain partial range
+      final int containerLast = (hb == shEnd) ? lbLast : LongUtils.maxLowBitAsInteger();
+
+      ContainerWithIndex cwi = highLowContainer.searchContainer(
+              LongUtils.highPartInPlace(LongUtils.rightShiftHighPart(hb), hbStart));
+
+      if (cwi != null) {
+        final long i = cwi.getContainerIdx();
+        final Container c = cwi.getContainer().inot(containerStart, containerLast + 1);
+        if (!c.isEmpty()) {
+          highLowContainer.replaceContainer(i, c);
+        } else {
+          highLowContainer.remove(hbStart);
+        }
+      } else {
+        Container newContainer = Container.rangeOfOnes(containerStart, containerLast + 1);
+        highLowContainer.put(hbStart, newContainer);
+      }
+    }
+  }
+
+  /**
    * {@link Roaring64NavigableMap} are serializable. However, contrary to RoaringBitmap, the
    * serialization format is not well-defined: for now, it is strongly coupled with Java standard
    * serialization. Just like the serialization may be incompatible between various Java versions,

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -907,6 +907,158 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
+  public void testFlip_SameContainer() {
+    Roaring64Bitmap map = newDefaultCtor();
+
+    map.addLong(0);
+    map.flip(1,2);
+
+    assertEquals(2, map.getLongCardinality());
+    assertEquals(1, map.select(1));
+  }
+
+  @Test
+  public void testFlip_MiddleContainer() {
+    Roaring64Bitmap map = newDefaultCtor();
+
+    map.addLong(0);
+    map.addLong(0x20001);
+
+    map.flip(0x10001,0x10002);
+
+    assertEquals(3, map.getLongCardinality());
+    assertEquals(0x10001, map.select(1));
+  }
+
+  @Test
+  public void testFlip_NextContainer() {
+    Roaring64Bitmap map = newDefaultCtor();
+
+    map.addLong(0);
+    map.flip(0x10001,0x10002);
+
+    assertEquals(2, map.getLongCardinality());
+    assertEquals(0x10001, map.select(1));
+  }
+
+  @Test
+  public void testFlip_ToEdgeContainer() {
+    Roaring64Bitmap map = newDefaultCtor();
+
+    map.addLong(0);
+    map.flip(0xFFFF,0x10000);
+
+    assertEquals(2, map.getLongCardinality());
+    assertEquals(0xFFFF, map.select(1));
+  }
+
+  @Test
+  public void testFlip_OverEdgeContainer() {
+    Roaring64Bitmap map = newDefaultCtor();
+
+    map.addLong(0);
+    map.flip(0xFFFF,0x10002);
+
+    assertEquals(4, map.getLongCardinality());
+    assertEquals(0x10001, map.select(3));
+  }
+
+  @Test
+  public void testFlip_PriorContainer() {
+    Roaring64Bitmap map = newDefaultCtor();
+
+    map.addLong(0x10001);
+    map.flip(1L,2L);
+
+    assertEquals(2, map.getLongCardinality());
+    assertEquals(1, map.select(0));
+    assertEquals(0x10001, map.select(1));
+  }
+
+  @Test
+  public void testFlip_SameNonZeroValues_NoChange() {
+    Roaring64Bitmap map = newDefaultCtor();
+
+    map.addLong(0);
+    map.flip(1L,1L);
+
+    assertEquals(1, map.getLongCardinality());
+    assertEquals(0, map.select(0));
+  }
+
+  @Test
+  public void testFlip_PositiveStartGreaterThanEnd_NoChange() {
+    Roaring64Bitmap map = newDefaultCtor();
+
+    map.addLong(0);
+    map.flip(2L,1L);
+
+    assertEquals(1, map.getLongCardinality());
+    assertEquals(0, map.select(0));
+  }
+
+  @Test
+  public void testFlip_NegStartGreaterThanEnd_NoChange() {
+    Roaring64Bitmap map = newDefaultCtor();
+
+    map.addLong(0);
+    map.flip(-1L,-3L);
+
+    assertEquals(1, map.getLongCardinality());
+    assertEquals(0, map.select(0));
+  }
+
+  @Test
+  public void testFlip_NegStartGreaterThanPosEnd_NoChange() {
+    Roaring64Bitmap map = newDefaultCtor();
+
+    map.addLong(0);
+    map.flip(-1L,0x7FffFFffFFffFFffL);
+
+    assertEquals(1, map.getLongCardinality());
+    assertEquals(0, map.select(0));
+  }
+
+  @Test
+  public void testFlip_RangeCrossingFromPosToNegInHexWorks() {
+    Roaring64Bitmap map = newDefaultCtor();
+
+    map.addLong(0);
+    map.flip(0x7FffFFffFFffFFffL, 0x8000000000000001L);
+
+    assertEquals(3, map.getLongCardinality());
+    assertEquals(0L, map.select(0));
+    assertEquals(0x7FffFFffFFffFFffL, map.select(1));
+    assertEquals(0x8000000000000000L, map.select(2));
+  }
+
+  @Test
+  public void testFlip_RangeCrossingFromPosToNegInDecWorks() {
+    Roaring64Bitmap map = newDefaultCtor();
+
+    map.addLong(0);
+    map.flip(9223372036854775807L, -9223372036854775807L);
+
+    assertEquals(3, map.getLongCardinality());
+    assertEquals(0L, map.select(0));
+    assertEquals(9223372036854775807L, map.select(1));
+    assertEquals(-9223372036854775808L, map.select(2));
+  }
+
+  @Test
+  public void testFlip_SmallRangesInNegWorks() {
+    Roaring64Bitmap map = newDefaultCtor();
+
+    map.addLong(0);
+    map.flip(-4294967297L, -4294967296L);
+
+    assertEquals(2, map.getLongCardinality());
+    assertEquals(0L, map.select(0));
+    assertEquals(-4294967297L, map.select(1));
+  }
+
+
+  @Test
   public void testToString() {
     Roaring64Bitmap map = newDefaultCtor();
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -907,7 +907,7 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
-  public void testFlip_SameContainer() {
+  public void testFlipSameContainer() {
     Roaring64Bitmap map = newDefaultCtor();
 
     map.addLong(0);
@@ -918,7 +918,7 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
-  public void testFlip_MiddleContainer() {
+  public void testFlipMiddleContainer() {
     Roaring64Bitmap map = newDefaultCtor();
 
     map.addLong(0);
@@ -931,7 +931,7 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
-  public void testFlip_NextContainer() {
+  public void testFlipNextContainer() {
     Roaring64Bitmap map = newDefaultCtor();
 
     map.addLong(0);
@@ -942,7 +942,7 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
-  public void testFlip_ToEdgeContainer() {
+  public void testFlipToEdgeContainer() {
     Roaring64Bitmap map = newDefaultCtor();
 
     map.addLong(0);
@@ -953,7 +953,7 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
-  public void testFlip_OverEdgeContainer() {
+  public void testFlipOverEdgeContainer() {
     Roaring64Bitmap map = newDefaultCtor();
 
     map.addLong(0);
@@ -964,7 +964,7 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
-  public void testFlip_PriorContainer() {
+  public void testFlipPriorContainer() {
     Roaring64Bitmap map = newDefaultCtor();
 
     map.addLong(0x10001);
@@ -976,7 +976,7 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
-  public void testFlip_SameNonZeroValues_NoChange() {
+  public void testFlipSameNonZeroValuesNoChange() {
     Roaring64Bitmap map = newDefaultCtor();
 
     map.addLong(0);
@@ -987,7 +987,7 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
-  public void testFlip_PositiveStartGreaterThanEnd_NoChange() {
+  public void testFlipPositiveStartGreaterThanEndNoChange() {
     Roaring64Bitmap map = newDefaultCtor();
 
     map.addLong(0);
@@ -998,7 +998,7 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
-  public void testFlip_NegStartGreaterThanEnd_NoChange() {
+  public void testFlipNegStartGreaterThanEndNoChange() {
     Roaring64Bitmap map = newDefaultCtor();
 
     map.addLong(0);
@@ -1009,7 +1009,7 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
-  public void testFlip_NegStartGreaterThanPosEnd_NoChange() {
+  public void testFlipNegStartGreaterThanPosEndNoChange() {
     Roaring64Bitmap map = newDefaultCtor();
 
     map.addLong(0);
@@ -1020,7 +1020,7 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
-  public void testFlip_RangeCrossingFromPosToNegInHexWorks() {
+  public void testFlipRangeCrossingFromPosToNegInHexWorks() {
     Roaring64Bitmap map = newDefaultCtor();
 
     map.addLong(0);
@@ -1033,7 +1033,7 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
-  public void testFlip_RangeCrossingFromPosToNegInDecWorks() {
+  public void testFlipRangeCrossingFromPosToNegInDecWorks() {
     Roaring64Bitmap map = newDefaultCtor();
 
     map.addLong(0);
@@ -1046,7 +1046,7 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
-  public void testFlip_SmallRangesInNegWorks() {
+  public void testFlipSmallRangesInNegWorks() {
     Roaring64Bitmap map = newDefaultCtor();
 
     map.addLong(0);
@@ -1057,6 +1057,17 @@ public class TestRoaring64Bitmap {
     assertEquals(-4294967297L, map.select(1));
   }
 
+  @Test
+  public void testFlipEdgeOfLongWorks() {
+    Roaring64Bitmap map = newDefaultCtor();
+
+    map.addLong(0);
+    map.flip(-2L, 0L);
+
+    assertEquals(3, map.getLongCardinality());
+    assertEquals(0L, map.select(0));
+    assertEquals(-2L, map.select(1));
+  }
 
   @Test
   public void testToString() {


### PR DESCRIPTION
We were wanting a Flip range operation, so copied the existing "could be improved" operation used in the 32 bit implementation.

Added a few helper functions to work around change from int for the high word, to byte[].

Added unit tests to cover the cases I could think of while developing.

As a side note question if there is a way to get an enumerable range from the ART then the algorithm can be transposed to stepping over the existing containers in the range, and injected the gaps, and altering the existing nodes. This would remove the polling/search of every node in the range.