### PR TITLE
Roaring64 Iterators should treat advance values as unsigned long

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -903,7 +903,7 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
     
     @Override
     boolean compare(long next, long val) {
-      return (next>>>2) == (val>>>2) ? (next&0x3)>=(val&0x3) : (next>>>2) > (val>>>2);
+      return Long.compareUnsigned(next, val) >= 0;
     }
   }
 
@@ -919,7 +919,7 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
     
     @Override
     boolean compare(long next, long val) {
-      return (next>>>2) == (val>>>2) ? (next&0x3)<=(val&0x3) : (next>>>2) < (val>>>2);
+      return Long.compareUnsigned(next, val) <= 0;
     }
   }
 }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -903,7 +903,7 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
     
     @Override
     boolean compare(long next, long val) {
-      return next >= val;
+      return (next>>>2) == (val>>>2) ? (next&0x3)>=(val&0x3) : (next>>>2) > (val>>>2);
     }
   }
 
@@ -919,7 +919,7 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
     
     @Override
     boolean compare(long next, long val) {
-      return next <= val;
+      return (next>>>2) == (val>>>2) ? (next&0x3)<=(val&0x3) : (next>>>2) < (val>>>2);
     }
   }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -1739,6 +1739,34 @@ public class TestRoaring64Bitmap {
 
     bitmap.getReverseLongIteratorFrom(0);
   }
+
+  @Test
+  public void testLongTreatedAsUnsignedOnAdvance() {
+    Roaring64Bitmap bitset = new Roaring64Bitmap();
+    bitset.add(Long.MAX_VALUE, Long.MIN_VALUE + 3);
+
+    PeekableLongIterator bitIt = bitset.getLongIterator();
+
+    bitIt.advanceIfNeeded(Long.MAX_VALUE);
+    assertEquals(Long.MAX_VALUE, bitIt.peekNext());
+
+    bitIt.advanceIfNeeded(Long.MIN_VALUE + 1);
+    assertEquals(Long.MIN_VALUE + 1, bitIt.peekNext());
+  }
+
+  @Test
+  public void testLongTreatedAsUnsignedOnAdvanceReverse() {
+    Roaring64Bitmap bitset = new Roaring64Bitmap();
+    bitset.add(Long.MAX_VALUE, Long.MIN_VALUE + 3);
+
+    PeekableLongIterator bitIt = bitset.getReverseLongIterator();
+
+    bitIt.advanceIfNeeded(Long.MIN_VALUE + 1);
+    assertEquals(Long.MIN_VALUE + 1, bitIt.peekNext());
+
+    bitIt.advanceIfNeeded(Long.MAX_VALUE);
+    assertEquals(Long.MAX_VALUE, bitIt.peekNext());
+  }
   
   private static long[] takeSortedAndDistinct(Random source, int count) {
     LinkedHashSet<Long> longs = new LinkedHashSet<>(count);


### PR DESCRIPTION
While reviewing Larsk-db PR #489 I noticed the adanceIfNeeded on the iterators was doing a signed compare instead of unsigned as needed.

So here is some tests (for forward/reverse iterators) to show this and a fix.