### PR TITLE
[Roaring64Bitmap] Fix index offset calculation when removing a key from the ART.

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Art.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Art.java
@@ -128,7 +128,7 @@ public class Art {
     }
     if (node.prefixLength > 0) {
       int mismatchIndex = ArraysShim.mismatch(node.prefix, 0,
-          node.prefixLength, key, dep, node.prefixLength);
+          node.prefixLength, key, dep, dep + node.prefixLength);
       if (mismatchIndex != -1) {
         return null;
       }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Art.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Art.java
@@ -127,9 +127,11 @@ public class Art {
       }
     }
     if (node.prefixLength > 0) {
-      int mismatchIndex = ArraysShim.mismatch(node.prefix, 0,
-          node.prefixLength, key, dep, dep + node.prefixLength);
-      if (mismatchIndex != -1) {
+      int commonLength = commonPrefixLength(
+          key, dep, key.length,
+          node.prefix, 0, node.prefixLength
+      );
+      if (commonLength != node.prefixLength) {
         return null;
       }
       dep += node.prefixLength;

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.function.Executable;
@@ -800,6 +801,28 @@ public class TestRoaring64Bitmap {
 
     assertEquals(1, left.getLongCardinality());
     assertEquals(123, left.select(0));
+  }
+
+  @Test
+  public void testAndDisjoint() {
+    // There are no shared values between these maps.
+    final long[] leftData = new long[]{1076595327100L, 1074755534972L, 5060192403580L, 5060308664444L};
+    final long[] rightData = new long[]{3470563844L};
+
+    Roaring64Bitmap left = Roaring64Bitmap.bitmapOf(leftData);
+    Roaring64Bitmap right = Roaring64Bitmap.bitmapOf(rightData);
+
+    left.and(right);
+
+    Roaring64Bitmap swapLeft = Roaring64Bitmap.bitmapOf(rightData);
+    Roaring64Bitmap swapRight = Roaring64Bitmap.bitmapOf(leftData);
+
+    swapLeft.and(swapRight);
+
+    assertEquals(0, left.getLongCardinality());
+    assertEquals(0, swapLeft.getLongCardinality());
+    assertThrows(IllegalArgumentException.class, () -> left.select(0));
+    assertThrows(IllegalArgumentException.class, () -> swapLeft.select(0));
   }
 
   @Test


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/RoaringBitmap/RoaringBitmap/issues/502

The problem was that we were trying to match the key using the range [dep, node.prefixLength). The end index should instead be an offset calculated starting from dep i.e dep + node.prefixLength. 

The existing code just happened to work at the first depth, but gives incorrect results at depths > 0.

In my test i've constructed a case using data i've found that reproduces the result, but this can probably be made better using a generic construction which has a deep tree. 

I'm not sure how to do that, let me know what you think.

### Automated Checks

- [ ] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [ ] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
