### PR TITLE
Fix Node48.getNextSmallerPos to handle input of 0 correctly

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node48.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node48.java
@@ -145,7 +145,7 @@ public class Node48 extends Node {
     }
     pos--;
     int i = pos >>> INDEX_SHIFT;
-    for (; i >= 0 && i < 32; i--) {
+    for (; i >= 0 && i < LONGS_USED; i--) {
       long longv = childIndex[i];
       if (longv == INIT_LONG_VALUE) {
         //skip over empty bytes

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node48.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node48.java
@@ -143,6 +143,9 @@ public class Node48 extends Node {
     if (pos == ILLEGAL_IDX) {
       pos = 256;
     }
+    if (pos == 0) {
+      return ILLEGAL_IDX;
+    }
     pos--;
     int i = pos >>> INDEX_SHIFT;
     for (; i >= 0; i--) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node48.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node48.java
@@ -143,12 +143,9 @@ public class Node48 extends Node {
     if (pos == ILLEGAL_IDX) {
       pos = 256;
     }
-    if (pos == 0) {
-      return ILLEGAL_IDX;
-    }
     pos--;
     int i = pos >>> INDEX_SHIFT;
-    for (; i >= 0; i--) {
+    for (; i >= 0 && i < 32; i--) {
       long longv = childIndex[i];
       if (longv == INIT_LONG_VALUE) {
         //skip over empty bytes

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/art/Node48Test.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/art/Node48Test.java
@@ -371,6 +371,15 @@ public class Node48Test {
   }
 
   @Test
+  public void testGetNextPosShouldNotThrowOnLegalInputs() {
+    Node node = new Node48(0);
+    for (int key = 0; key < 256; key++) {
+      Assertions.assertEquals(Node.ILLEGAL_IDX, node.getNextSmallerPos(key));
+      Assertions.assertEquals(Node.ILLEGAL_IDX, node.getNextLargerPos(key));
+    }
+  }
+
+  @Test
   public void testSetOneByte() {
     long[] longs = new long[Node48.LONGS_USED];
 


### PR DESCRIPTION
### SUMMARY
- This adds a test case, which reproduces #504 
- Add a fix for the bug

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.

### Discussion

It turns out this has nothing to do with the iterator seek code whatsoever, but it actually an ancient bug in `Node48.getNextSmallerPos`. It couldn't handle the case where `pos=0`. The `pos--;` before the loop would decrement it to `pos=-1`, which we would then right-shift to `i=536870911`. That's clearly not a legal index into a 48-value array.

Now this issue by itself an easy fix, but I have another concern about `Node48` implementation that I'd like some feedback on (I could fix both at the same time, ideally):
I feel like `Node48` is breaking an implicit contract that functions like `getChildPos`, `getNearestChildPos`, `getNextLargerPos`, `getNextLowerPos` should return a concrete position within `children`, not a key that still needs to be translated via `childrenIdx(pos, childIndex)` in `getChild`. All other `Node` implementations fulfil this contract (in `Node256` there's no difference between the two, of course).
I would like to make this implicit contract explicit, and convert `Node48` to adhere to it. I'm wondering if there is any particular reason that `Node48` was implemented differently? Is there any history to this, that I'm missing here? @weijietong @lemire @simeonpilgrim ?