### PR TITLE
change the max depth from 6 to 7

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/AbstractShuttle.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/AbstractShuttle.java
@@ -8,7 +8,7 @@ import org.roaringbitmap.longlong.LongUtils;
  */
 public abstract class AbstractShuttle implements Shuttle {
 
-  protected static final int MAX_DEPTH = 6;
+  protected static final int MAX_DEPTH = 7;
   protected NodeEntry[] stack = new NodeEntry[MAX_DEPTH];
   //started from 0
   protected int depth = -1;


### PR DESCRIPTION
### SUMMARY
- Describe your changes, including rationale and design decisions
   change the max depth of `AbstractShuttle` from 6 to 7. The reason is though the max key length is 6 (6* 8 byte = high 48 bytes), but the `stack` member var still hold a  leaf node. So the max depth should be 7.
- If your pull request includes new functionality, then you must have corresponding new tests.

### Automated Checks

- [ ] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [ ] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
