### PR TITLE
avoid allocations when modifying node keys, specify behaviour of shif…

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/IntegerUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/IntegerUtil.java
@@ -31,14 +31,15 @@ public class IntegerUtil {
   /**
    * set a specified position byte to another value to return a fresh integer
    * @param v the input integer value
-   * @param bv the byte value to replace
-   * @param pos the position of an 8 byte array to replace
+   * @param bv the byte value to insert
+   * @param pos the position of an 4 byte array to replace
    * @return a fresh integer after a specified position byte been replaced
    */
   public static int setByte(int v, byte bv, int pos) {
-    byte[] bytes = toBDBytes(v);
-    bytes[pos] = bv;
-    return fromBDBytes(bytes);
+    int i = ((3 - pos) << 3);
+    v &= ~(0xFF << i);
+    v |= (bv & 0xFF) << i;
+    return v;
   }
 
   /**

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/IntegerUtilTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/IntegerUtilTest.java
@@ -1,23 +1,50 @@
 package org.roaringbitmap.longlong;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class IntegerUtilTest {
 
   @Test
-  public void test() {
+  public void testConvertIntToBytes() {
     int v = 1;
     byte[] bytes = IntegerUtil.toBDBytes(v);
     int revertVal = IntegerUtil.fromBDBytes(bytes);
-    Assertions.assertTrue(revertVal == v);
+    assertEquals(revertVal, v);
     v = -1;
     bytes = IntegerUtil.toBDBytes(v);
     revertVal = IntegerUtil.fromBDBytes(bytes);
-    Assertions.assertTrue(revertVal == v);
+    assertEquals(revertVal, v);
     v = -125;
     bytes = IntegerUtil.toBDBytes(v);
     revertVal = IntegerUtil.fromBDBytes(bytes);
-    Assertions.assertTrue(revertVal == v);
+    assertEquals(revertVal, v);
+  }
+
+  @Test
+  public void testSetByte() {
+    for (int i = 0; i < 4; ++i) {
+      int value = IntegerUtil.setByte(0x55555555, (byte)0xAA, i);
+      byte[] bytes = IntegerUtil.toBDBytes(value);
+      for (int j = 0; j < 4; ++j) {
+        byte expected = i == j ? (byte)0xAA : (byte)0x55;
+        assertEquals(expected, bytes[j]);
+      }
+    }
+  }
+
+  @Test
+  public void testShiftLeftFromSpecifiedPosition() {
+    assertEquals(0xBBCCDDDD, IntegerUtil.shiftLeftFromSpecifiedPosition(0xAABBCCDD, 0, 3));
+    assertEquals(0xBBCCCCDD, IntegerUtil.shiftLeftFromSpecifiedPosition(0xAABBCCDD, 0, 2));
+    assertEquals(0xBBBBCCDD, IntegerUtil.shiftLeftFromSpecifiedPosition(0xAABBCCDD, 0, 1));
+    assertEquals(0xAABBCCDD, IntegerUtil.shiftLeftFromSpecifiedPosition(0xAABBCCDD, 0, 0));
+    assertEquals(0xAACCDDDD, IntegerUtil.shiftLeftFromSpecifiedPosition(0xAABBCCDD, 1, 2));
+    assertEquals(0xAACCCCDD, IntegerUtil.shiftLeftFromSpecifiedPosition(0xAABBCCDD, 1, 1));
+    assertEquals(0xAABBCCDD, IntegerUtil.shiftLeftFromSpecifiedPosition(0xAABBCCDD, 1, 0));
+    assertEquals(0xAABBDDDD, IntegerUtil.shiftLeftFromSpecifiedPosition(0xAABBCCDD, 2, 1));
+    assertEquals(0xAABBCCDD, IntegerUtil.shiftLeftFromSpecifiedPosition(0xAABBCCDD, 2, 0));
+    assertEquals(0xAABBCCDD, IntegerUtil.shiftLeftFromSpecifiedPosition(0xAABBCCDD, 3, 0));
   }
 }


### PR DESCRIPTION
I found that large scale tests of `Roaring64Bitmap` I have been working on were occasionally throwing OOME in `IntegerUtils.setByte` which could be allocation free. The method `IntegerUtils.shiftLeftFromSpecifiedPosition` does the same thing, but as mentioned in #516 its behaviour is suspicious so I left it alone and just added a test to make what it does clear, rather than enshrine the behaviour in a harder to read implementation.