### PR TITLE
range bitmap

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RangeBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RangeBitmap.java
@@ -1,0 +1,478 @@
+package org.roaringbitmap;
+
+import org.roaringbitmap.buffer.MappeableArrayContainer;
+import org.roaringbitmap.buffer.MappeableBitmapContainer;
+import org.roaringbitmap.buffer.MappeableContainer;
+import org.roaringbitmap.buffer.MappeableRunContainer;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.LongBuffer;
+import java.util.Arrays;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.roaringbitmap.Util.resetBitmapRange;
+
+/**
+ * A 2D bitmap which associates values with a row index and can perform range queries.
+ */
+public final class RangeBitmap {
+
+  private static final int COOKIE = 0xF00D;
+  private static final int BITMAP = 0;
+  private static final int RUN = 1;
+  private static final int ARRAY = 2;
+  private static final int BITMAP_SIZE = 8192;
+
+  /**
+   * Append values to the RangeBitmap before sealing it.
+   * @param maxValue the maximum value to be appended, values larger than this
+   *                 value will be rejected.
+   * @param bufferSupplier provides ByteBuffers.
+   * @return an appender.
+   */
+  public static Appender appender(long maxValue,
+                                  IntFunction<ByteBuffer> bufferSupplier,
+                                  Consumer<ByteBuffer> cleaner) {
+    return new Appender(maxValue, bufferSupplier, cleaner);
+  }
+
+  public static Appender appender(long maxValue) {
+    return appender(maxValue,
+        capacity -> ByteBuffer.allocate(capacity).order(LITTLE_ENDIAN), b -> {});
+  }
+
+  /**
+   * Maps the RangeBitmap from the buffer with minimal allocation.
+   * The buffer must not be reused while the mapped RangeBitmap is live.
+   * @param buffer a buffer containing a serialized RangeBitmap.
+   * @return a RangeBitmap backed by the buffer.
+   */
+  public static RangeBitmap map(ByteBuffer buffer) {
+    ByteBuffer source = buffer.slice().order(LITTLE_ENDIAN);
+    int cookie = source.getChar();
+    if (cookie != COOKIE) {
+      throw new InvalidRoaringFormat("invalid cookie for range bitmap (expected "
+          + COOKIE + " but got " + cookie + ")");
+    }
+    int base = source.get() & 0xFF;
+    if (base != 2) {
+      throw new InvalidRoaringFormat("Unsupported base for range bitmap: " + cookie);
+    }
+    int sliceCount = source.get() & 0xFF;
+    int maxKey = source.getChar();
+    long mask = (1L << sliceCount) - 1;
+    long maxRid = source.getInt() & 0xFFFFFFFFL;
+    int masksOffset = source.position();
+    int containersOffset = masksOffset + (maxKey + 1) * (sliceCount >>> 3);
+    return new RangeBitmap(mask, maxRid,
+        (ByteBuffer)source.position(buffer.position()), masksOffset, containersOffset);
+  }
+
+  private final ByteBuffer buffer;
+  private final int masksOffset;
+  private final int containersOffset;
+  private final long mask;
+  private final long max;
+
+  RangeBitmap(long mask, long max, ByteBuffer buffer, int masksOffset, int containersOffset) {
+    this.mask = mask;
+    this.max = max;
+    this.buffer = buffer;
+    this.masksOffset = masksOffset;
+    this.containersOffset = containersOffset;
+  }
+
+  /**
+   * Returns a RoaringBitmap of rows which have a value less than or equal to the threshold.
+   * @param threshold the inclusive maximum value.
+   * @return a bitmap of matching rows.
+   */
+  public RoaringBitmap lte(long threshold) {
+    return evaluateRange(threshold, true);
+  }
+
+  /**
+   * Returns a RoaringBitmap of rows which have a value less than the threshold.
+   * @param threshold the exclusive maximum value.
+   * @return a bitmap of matching rows.
+   */
+  public RoaringBitmap lt(long threshold) {
+    return threshold <= 0 ? new RoaringBitmap() : lte(threshold - 1);
+  }
+
+  /**
+   * Returns a RoaringBitmap of rows which have a value greater than the threshold.
+   * @param threshold the exclusive minimum value.
+   * @return a bitmap of matching rows.
+   */
+  public RoaringBitmap gt(long threshold) {
+    return evaluateRange(threshold, false);
+  }
+
+  /**
+   * Returns a RoaringBitmap of rows which have a value greater than or equal to the threshold.
+   * @param threshold the inclusive minimum value.
+   * @return a bitmap of matching rows.
+   */
+  public RoaringBitmap gte(long threshold) {
+    return threshold <= 0 ? RoaringBitmap.bitmapOfRange(0, max) : gt(threshold - 1);
+  }
+
+  private RoaringBitmap evaluateRange(long threshold, boolean upper) {
+    if (Long.numberOfLeadingZeros(threshold) < Long.numberOfLeadingZeros(mask)) {
+      return upper ? RoaringBitmap.bitmapOfRange(0, max) : new RoaringBitmap();
+    }
+    ByteBuffer containers = this.buffer.slice().order(LITTLE_ENDIAN);
+    containers.position(containersOffset);
+    RoaringArray output = new RoaringArray();
+    long[] bits = new long[1024];
+    long remaining = max;
+    int mPos = masksOffset;
+    char key = 0;
+    boolean empty = true;
+    while (remaining > 0) {
+      long containerMask = this.buffer.getLong(mPos) & mask;
+      // the first slice is special: if the threshold includes this slice,
+      // fill the buffer, otherwise copy the slice
+      if ((threshold & 1) == 1) {
+        if (remaining >= 0x10000) {
+          Arrays.fill(bits, -1L);
+        } else {
+          Util.setBitmapRange(bits, 0, (int)remaining);
+          if (!empty) {
+            resetBitmapRange(bits, (int) remaining, 0x10000);
+          }
+        }
+        if ((containerMask & 1) == 1) {
+          skipContainer(containers);
+        }
+        empty = false;
+      } else {
+        if (!empty) {
+          Arrays.fill(bits, 0L);
+          empty = true;
+        }
+        if ((containerMask & 1) == 1) {
+          if ((threshold & 1) == 0) {
+            nextContainer(containers).orInto(bits);
+            empty = false;
+          } else {
+            skipContainer(containers);
+          }
+        }
+      }
+      for (int i = 1; i < Long.bitCount(mask); ++i) {
+        switch ((int) (((threshold >>> i) & 1) | ((containerMask >>> (i - 1)) & 2))) {
+          case 0: // bit absent from threshold, no container
+            if (!empty) {
+              Arrays.fill(bits, 0L);
+              empty = true;
+            }
+            break;
+          case 1: // bit present in threshold but no container, nothing to include
+            break;
+          case 2: // bit present in container, absent from threshold, filter
+            if (empty) {
+              skipContainer(containers);
+            } else {
+              nextContainer(containers).andInto(bits);
+            }
+            break;
+          case 3: // both, include bits from slice
+            nextContainer(containers).orInto(bits);
+            empty = false;
+            break;
+          default:
+        }
+      }
+      if (!upper) {
+        Util.flipBitmapRange(bits,0, Math.min(0x10000, (int)remaining));
+        empty = false;
+      }
+      if (!empty) {
+        Container toAppend = new BitmapContainer(bits, -1).repairAfterLazy().runOptimize();
+        if (!toAppend.isEmpty()) {
+          output.append(key, toAppend instanceof BitmapContainer ? toAppend.clone() : toAppend);
+        }
+      }
+      key++;
+      remaining -= 0x10000;
+      mPos += Long.bitCount(mask) >>> 3;
+    }
+    return new RoaringBitmap(output);
+  }
+
+  private static MappeableContainer nextContainer(ByteBuffer buffer) {
+    int type = buffer.get();
+    int size = buffer.getChar() & 0xFFFF;
+    if (type == BITMAP) {
+      LongBuffer lb = ((ByteBuffer)buffer.slice()
+          .order(LITTLE_ENDIAN).limit(BITMAP_SIZE)).asLongBuffer();
+      buffer.position(buffer.position() + BITMAP_SIZE);
+      return new MappeableBitmapContainer(lb, size);
+    } else {
+      int skip = size << (type == RUN ? 2 : 1);
+      CharBuffer cb = ((ByteBuffer)buffer.slice().order(LITTLE_ENDIAN).limit(skip)).asCharBuffer();
+      buffer.position(buffer.position() + skip);
+      return type == RUN
+          ? new MappeableRunContainer(cb, size)
+          : new MappeableArrayContainer(cb, size);
+    }
+  }
+
+  private static void skipContainer(ByteBuffer buffer) {
+    int type = buffer.get();
+    int size = buffer.getChar() & 0xFFFF;
+    if (type == BITMAP) {
+      buffer.position(buffer.position() + BITMAP_SIZE);
+    } else {
+      int skip = size << (type == RUN ? 2 : 1);
+      buffer.position(buffer.position() + skip);
+    }
+  }
+
+  /**
+   * Builder for constructing immutable RangeBitmaps
+   */
+  public static final class Appender {
+
+    private static final int GROWTH = 8;
+
+    Appender(long maxValue, IntFunction<ByteBuffer> bufferSupplier, Consumer<ByteBuffer> cleaner) {
+      this.bufferSupplier = bufferSupplier;
+      this.bufferCleaner = cleaner;
+      this.rangeMask = rangeMaxForLimit(maxValue);
+      this.slice = new Container[Long.bitCount(rangeMask)];
+      for (int i = 0; i < slice.length; ++i) {
+        slice[i] = containerForSlice(i);
+      }
+      this.maskBuffer = bufferSupplier.apply(maskBufferGrowth());
+      this.containers = bufferSupplier.apply(containerGrowth() * 1024);
+    }
+
+    private final IntFunction<ByteBuffer> bufferSupplier;
+    private final Consumer<ByteBuffer> bufferCleaner;
+    private final long rangeMask;
+    private final Container[] slice;
+    private ByteBuffer maskBuffer;
+    private ByteBuffer containers;
+    private int bufferPos;
+    private long mask;
+    private int rid;
+    private int key = 0;
+    private int serializedContainerSize;
+
+    /**
+     * Converts the appender into an immutable range index.
+     * @param supplier provides an appropriate ByteBuffer to store into
+     * @return a queriable RangeBitmap
+     */
+    public RangeBitmap build(IntFunction<ByteBuffer> supplier) {
+      flush();
+      return build(supplier.apply(serializedSizeInBytes()));
+    }
+
+    /**
+     * {@see #build(IntFunction)}
+     */
+    public RangeBitmap build() {
+      return build(capacity -> ByteBuffer.allocate(capacity).order(LITTLE_ENDIAN));
+    }
+
+    /**
+     * Converts the appender into an immutable range index, using the supplied ByteBuffer.
+     * @param buffer a little endian buffer which must have sufficient capacity for the appended
+     *               values.
+     * @return a queriable RangeBitmap
+     */
+    public RangeBitmap build(ByteBuffer buffer) {
+      serialize(buffer);
+      buffer.flip();
+      return RangeBitmap.map(buffer);
+    }
+
+    /**
+     * Call this to reuse the appender and its buffers
+     */
+    public void clear() {
+      // no need to zero the buffers, we'll just write over them next time.
+      containers.position(0);
+      bufferPos = 0;
+      mask = 0;
+      rid = 0;
+      key = 0;
+      serializedContainerSize = 0;
+    }
+
+    /**
+     * Returns the size of the RangeBitmap on disk.
+     * @return the serialized size in bytes.
+     */
+    public int serializedSizeInBytes() {
+      flush();
+      int cookieSize = 2;
+      int baseSize = 1;
+      int slicesSize = 1;
+      int maxKeySize = 2;
+      int maxRidSize = 4;
+      int headerSize = cookieSize
+          + baseSize
+          + slicesSize
+          + maxKeySize
+          + maxRidSize;
+      int keysSize = (key + 1) * (Long.bitCount(rangeMask) >>> 3);
+      return headerSize + keysSize + serializedContainerSize;
+    }
+
+    /**
+     * Serializes the bitmap to the buffer without materialising it.
+     * The user should call {@see serializedSizeInBytes} to size the
+     * buffer appropriately.
+     *
+     * It is not guaranteed that all values will be written
+     * @param buffer expected to be large enough to contain the bitmap.
+     */
+    public void serialize(ByteBuffer buffer) {
+      if (flush()) {
+        throw new IllegalStateException(
+            "Attempted to serialize without calling serializedSizeInBytes first");
+      }
+      ByteBuffer target = buffer.order() == LITTLE_ENDIAN
+          ? buffer
+          : buffer.slice().order(LITTLE_ENDIAN);
+      target.putChar((char) COOKIE);
+      target.put((byte)2);
+      target.put((byte)Long.bitCount(rangeMask));
+      target.putChar((char)key);
+      target.putInt(rid);
+      int spaceForKeys = (key + 1) * (Long.bitCount(rangeMask) >>> 3);
+      target.put(((ByteBuffer)maskBuffer.slice()
+          .order(LITTLE_ENDIAN).limit(spaceForKeys)));
+      target.put(((ByteBuffer)containers.slice()
+          .order(LITTLE_ENDIAN).limit(serializedContainerSize)));
+      if (buffer != target) {
+        buffer.position(target.position());
+      }
+    }
+
+    /**
+     * Adds the value and associates it with the current row index.
+     * @param value the value, will be rejected if greater than max value.
+     */
+    public void add(long value) {
+      if ((value & rangeMask) == value) {
+        long bits = ~value & rangeMask;
+        mask |= bits;
+        while (bits != 0) {
+          int index = Long.numberOfTrailingZeros(bits);
+          bits &= (bits - 1);
+          Container c = slice[index];
+          Container updated = c.add((char) rid);
+          // avoid useless write barrier
+          if (updated != c) {
+            slice[index] = updated;
+          }
+        }
+      } else {
+        throw new IllegalArgumentException(value + " too large");
+      }
+      rid++;
+      if (rid >>> 16 > key) {
+        append();
+      }
+    }
+
+    private boolean flush() {
+      if (mask != 0) {
+        append();
+        return true;
+      }
+      return false;
+    }
+
+    private void append() {
+      if (maskBuffer.capacity() - bufferPos < 8) {
+        maskBuffer = growBuffer(maskBuffer, maskBufferGrowth());
+        maskBuffer.position(0);
+      }
+      int maskWidth = Long.bitCount(rangeMask);
+      maskBuffer.putLong(bufferPos, mask);
+      bufferPos += maskWidth >>> 3;
+      for (Container container : slice) {
+        if (!container.isEmpty()) {
+          Container toSerialize = container.runOptimize();
+          int serializedSize = toSerialize.serializedSizeInBytes();
+          int type = (toSerialize instanceof BitmapContainer)
+              ? BITMAP
+              : (toSerialize instanceof RunContainer) ? RUN : ARRAY;
+          int required = serializedSize + (type == BITMAP ? 3 : 1);
+          if (containers.capacity() - serializedContainerSize < required) {
+            containers = growBuffer(containers, containerGrowth() * 1024);
+          }
+          containers.put(serializedContainerSize, (byte) type);
+          if (type == BITMAP) {
+            containers.putChar(serializedContainerSize + 1, (char) (container.getCardinality()));
+            containers.position(serializedContainerSize + 3);
+            toSerialize.writeArray(containers);
+            containers.position(0);
+            serializedContainerSize += required;
+          } else if (type == RUN) {
+            containers.position(serializedContainerSize + 1);
+            toSerialize.writeArray(containers);
+            containers.position(0);
+            serializedContainerSize += required;
+          } else {
+            containers.putChar(serializedContainerSize + 1, (char) (container.getCardinality()));
+            containers.position(serializedContainerSize + 3);
+            toSerialize.writeArray(containers);
+            containers.position(0);
+            serializedContainerSize += required;
+          }
+          container.clear(); // for reuse
+        }
+      }
+      mask = 0;
+      key++;
+    }
+
+    private int maskBufferGrowth() {
+      // 8 containers is space for ~0.5M rows, * the size in bytes of each mask
+      return GROWTH * (Long.bitCount(rangeMask) >>> 3);
+    }
+
+    private int containerGrowth() {
+      return GROWTH * slice.length;
+    }
+
+    private ByteBuffer growBuffer(ByteBuffer buffer, int growth) {
+      ByteBuffer newBuffer = bufferSupplier.apply(buffer.capacity() + growth);
+      int pos = buffer.position();
+      newBuffer.put(buffer);
+      buffer.position(pos);
+      bufferCleaner.accept(buffer);
+      return newBuffer;
+    }
+
+    private Container containerForSlice(int sliceNumber) {
+      if (sliceNumber >= 5) {
+        return new RunContainer();
+      }
+      return new BitmapContainer();
+    }
+
+    /**
+     * Produces a mask covering the smallest number of bytes required
+     * to represent the sliced max value.
+     *
+     * @param maxValue the maximum value this bitmap should support.
+     * @return a mask with a multiple of 8 contiguous bits set.
+     */
+    private static long rangeMaxForLimit(long maxValue) {
+      int lz = Long.numberOfLeadingZeros(maxValue);
+      return lz <= 8 ? -1L : (1L << ((64 - lz + 7) & -8)) - 1;
+    }
+  }
+}

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -552,6 +552,15 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
   }
 
   /**
+   * @see #add(long, long)
+   */
+  public static RoaringBitmap bitmapOfRange(long min, long max) {
+    RoaringBitmap bitmap = new RoaringBitmap();
+    bitmap.add(min, max);
+    return bitmap;
+  }
+
+  /**
    * Complements the bits in the given range, from rangeStart (inclusive) rangeEnd (exclusive). The
    * given bitmap is unchanged.
    *

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -16,6 +16,7 @@ import java.nio.CharBuffer;
 import java.util.Arrays;
 import java.util.Iterator;
 
+import static org.roaringbitmap.buffer.MappeableBitmapContainer.MAX_CAPACITY;
 
 
 /**
@@ -244,6 +245,26 @@ public final class MappeableArrayContainer extends MappeableContainer implements
   @Override
   public boolean isFull() {
     return false;
+  }
+
+  @Override
+  public void orInto(long[] bits) {
+    for (int i = 0; i < this.getCardinality(); ++i) {
+      char value = content.get(i);
+      bits[value >>> 6] |= (1L << value);
+    }
+  }
+
+  @Override
+  public void andInto(long[] bits) {
+    int prev = 0;
+    for (int i = 0; i < this.getCardinality(); ++i) {
+      int value = content.get(i);
+      Util.resetBitmapRange(bits, prev, value);
+      bits[value >>> 6] &= (1L << value);
+      prev = value + 1;
+    }
+    Util.resetBitmapRange(bits, prev, MAX_CAPACITY);
   }
 
   private int advance(CharIterator it) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -984,6 +984,20 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
   }
 
   @Override
+  public void orInto(long[] bits) {
+    for (int i = 0; i < bits.length; ++i) {
+      bits[i] |= bitmap.get(i);
+    }
+  }
+
+  @Override
+  public void andInto(long[] bits) {
+    for (int i = 0; i < bits.length; ++i) {
+      bits[i] &= bitmap.get(i);
+    }
+  }
+
+  @Override
   public MappeableContainer ior(final MappeableRunContainer x) {
     if (BufferUtil.isBackedBySimpleArray(this.bitmap)) {
       long[] b = this.bitmap.array();

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableContainer.java
@@ -66,6 +66,20 @@ public abstract class MappeableContainer implements Iterable<Character>, Cloneab
   public abstract boolean isFull();
 
   /**
+   * Computes the union of this container with the bits present in the array,
+   * modifying the array.
+   * @param bits a 1024 element array to be interpreted as a bit set
+   */
+  public abstract void orInto(long[] bits);
+
+  /**
+   * Computes the intersection of this container with the bits present in the array,
+   * modifying the array.
+   * @param bits a 1024 element array to be interpreted as a bit set
+   */
+  public abstract void andInto(long[] bits);
+
+  /**
    * Computes the bitwise AND of this container with another (intersection). This container as well
    * as the provided container are left unaffected.
    * 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.roaringbitmap.Util.*;
 import static org.roaringbitmap.buffer.MappeableBitmapContainer.MAX_CAPACITY;
 
 /**
@@ -1556,6 +1557,27 @@ public final class MappeableRunContainer extends MappeableContainer implements C
   @Override
   public boolean isFull() {
     return (this.nbrruns == 1) && (this.getValue(0) == 0) && (this.getLength(0) == 0xFFFF);
+  }
+
+  @Override
+  public void orInto(long[] bits) {
+    for (int r = 0; r < numberOfRuns(); ++r) {
+      int start = this.valueslength.charAt(r << 1);
+      int length = this.valueslength.charAt((r << 1) + 1);
+      setBitmapRange(bits, start, start + length + 1);
+    }
+  }
+
+  @Override
+  public void andInto(long[] bits) {
+    int prev = 0;
+    for (int r = 0; r < numberOfRuns(); ++r) {
+      int start = this.valueslength.charAt(r << 1);
+      int length = this.valueslength.charAt((r << 1) + 1);
+      resetBitmapRange(bits, prev, start);
+      prev = start + length + 1;
+    }
+    resetBitmapRange(bits, prev, MAX_CAPACITY);
   }
 
   public static MappeableRunContainer full() {

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/RangeBitmapTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/RangeBitmapTest.java
@@ -1,0 +1,378 @@
+package org.roaringbitmap;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+import java.util.function.LongSupplier;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.roaringbitmap.RangeBitmapTest.Distribution.*;
+
+public class RangeBitmapTest {
+
+  @ParameterizedTest
+  @ValueSource(ints = {0xFFFF, 0x10001, 100_000, 0x110001, 1_000_000})
+  public void testInsertContiguousValues(int size) {
+    RangeBitmap.Appender appender = RangeBitmap.appender(size);
+    LongStream.range(0, size).forEach(appender::add);
+    RangeBitmap range = appender.build();
+    assertEquals(RoaringBitmap.bitmapOfRange(0, size), range.lte(size));
+    for (long upper = 1; upper < size; upper *= 10) {
+      RoaringBitmap expected = RoaringBitmap.bitmapOfRange(0, upper + 1);
+      assertEquals(expected, range.lte(upper));
+      expected.flip(expected.last());
+      assertEquals(expected, range.lt(upper));
+    }
+    for (long lower = 1; lower < size; lower *= 10) {
+      RoaringBitmap expected = RoaringBitmap.bitmapOfRange(lower, size);
+      assertEquals(expected, range.gte(lower));
+      expected.flip(expected.first());
+      assertEquals(expected, range.gt(lower));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0xFFFF, 0x10001, 100_000, 0x110001, 1_000_000})
+  public void testInsertReversedContiguousValues(int size) {
+    RangeBitmap.Appender appender = RangeBitmap.appender(size);
+    LongStream.range(0, size).map(i -> size - i).forEach(appender::add);
+    RangeBitmap range = appender.build();
+    for (long upper = 1; upper < size; upper *= 10) {
+      RoaringBitmap expected = RoaringBitmap.bitmapOfRange(size - upper, size);
+      assertEquals(expected, range.lte(upper));
+      expected.flip(expected.first());
+      assertEquals(expected, range.lt(upper));
+    }
+    for (long lower = 1; lower < size; lower *= 10) {
+      RoaringBitmap expected = RoaringBitmap.bitmapOfRange(0, size + 1 - lower);
+      assertEquals(expected, range.gte(lower));
+      expected.flip(expected.last());
+      assertEquals(expected, range.gt(lower));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0xFFFF, 0x10001, 100_000, 0x110001, 1_000_000})
+  public void testLessThanZeroEmpty(int size) {
+    RangeBitmap.Appender appender = RangeBitmap.appender(size);
+    LongStream.range(0, 10).forEach(appender::add);
+    RangeBitmap range = appender.build();
+    RoaringBitmap expected = new RoaringBitmap();
+    assertEquals(expected, range.lt(0));
+    assertEquals(expected, range.lt(-1));
+  }
+
+  @Test
+  public void testInsertContiguousValuesAboveRange() {
+    RangeBitmap.Appender appender = RangeBitmap.appender(1_000_000);
+    LongStream.range(0, 1_000_000).forEach(appender::add);
+    RangeBitmap range = appender.build();
+    RoaringBitmap expected = RoaringBitmap.bitmapOfRange(0, 1_000_000);
+    assertEquals(expected, range.lte(999_999));
+    assertEquals(expected, range.lte(1_000_000));
+    assertEquals(expected, range.lt(1_000_000));
+    assertEquals(expected, range.lte(1_000_000_000));
+    assertEquals(expected, range.lt(1_000_000_000));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0xFFFF, 0x10001, 100_000, 0x110001, 1_000_000})
+  public void testInsertContiguousValuesAboveRangeReversed(int size) {
+    RangeBitmap.Appender appender = RangeBitmap.appender(size);
+    LongStream.range(0, size).map(i -> size - i).forEach(appender::add);
+    RangeBitmap range = appender.build();
+    assertEquals(RoaringBitmap.bitmapOfRange(0, size), range.lte(size));
+    assertEquals(RoaringBitmap.bitmapOfRange(0, size), range.lte(size + 1));
+    assertEquals(RoaringBitmap.bitmapOfRange(0, size), range.lte(size * 10L));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0xFFFF, 0x10001, 100_000, 0x110001, 1_000_000})
+  public void monotonicLTEResultCardinality(int size) {
+    RangeBitmap.Appender appender = RangeBitmap.appender(size);
+    LongStream.range(0, size).forEach(appender::add);
+    RangeBitmap range = appender.build();
+    int cardinality = 0;
+    for (int i = size - 2; i <= size + 2; ++i) {
+      int resultCardinality = range.lte(i).getCardinality();
+      assertTrue(resultCardinality >= cardinality);
+      cardinality = resultCardinality;
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0xFFFF, 0x10001, 100_000, 0x110001, 1_000_000})
+  public void monotonicLTEResultCardinalityReversed(int size) {
+    RangeBitmap.Appender appender = RangeBitmap.appender(size);
+    LongStream.range(0, size).map(i -> size - i).forEach(appender::add);
+    RangeBitmap range = appender.build();
+    int cardinality = 0;
+    for (int i = size - 2; i <= size + 2; ++i) {
+      int resultCardinality = range.lte(i).getCardinality();
+      assertTrue(resultCardinality >= cardinality);
+      cardinality = resultCardinality;
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0xFFFF, 0x10001, 100_000, 0x110001, 1_000_000})
+  public void monotonicGTResultCardinality(int size) {
+    RangeBitmap.Appender appender = RangeBitmap.appender(size);
+    LongStream.range(0, size).forEach(appender::add);
+    RangeBitmap range = appender.build();
+    int cardinality = size;
+    for (int i = size - 2; i <= size + 2; ++i) {
+      int resultCardinality = range.gt(i).getCardinality();
+      assertTrue(resultCardinality <= cardinality);
+      cardinality = resultCardinality;
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0xFFFF, 0x10001, 100_000, 0x110001, 1_000_000})
+  public void monotonicGTResultCardinalityReversed(int size) {
+    RangeBitmap.Appender appender = RangeBitmap.appender(size);
+    LongStream.range(0, size).map(i -> size - i).forEach(appender::add);
+    RangeBitmap range = appender.build();
+    int cardinality = size;
+    for (int i = size - 2; i <= size + 2; ++i) {
+      int resultCardinality = range.gt(i).getCardinality();
+      assertTrue(resultCardinality <= cardinality);
+      cardinality = resultCardinality;
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0xFFFF, 0x10000, 0x10001, 100_000, 0x110001, 1_000_000})
+  public void unionOfComplementsMatchesAll(int size) {
+    RangeBitmap.Appender appender = RangeBitmap.appender(size);
+    LongStream.range(0, size).forEach(appender::add);
+    RangeBitmap range = appender.build();
+    RoaringBitmap all = RoaringBitmap.bitmapOfRange(0, size);
+    for (int i = size - 2; i <= size + 2; ++i) {
+      assertEquals(all, RoaringBitmap.or(range.gte(i), range.lt(i)));
+    }
+  }
+
+  @Test
+  public void verifyBufferCleanerCalled() {
+    AtomicInteger cleanerInvocations = new AtomicInteger();
+    AtomicInteger supplierInvocations = new AtomicInteger();
+    Consumer<ByteBuffer> cleaner = buffer -> cleanerInvocations.incrementAndGet();
+    IntFunction<ByteBuffer> supplier = capacity -> {
+      supplierInvocations.incrementAndGet();
+      return ByteBuffer.allocate(capacity).order(LITTLE_ENDIAN);
+    };
+    RangeBitmap.Appender appender = RangeBitmap.appender(1_000_000, supplier, cleaner);
+    LongStream.range(0, 1_000_000).forEach(appender::add);
+    ByteBuffer target = ByteBuffer.allocate(appender.serializedSizeInBytes());
+    appender.serialize(target);
+    assertEquals(supplierInvocations.get() - 2, cleanerInvocations.get(),
+        "two internal buffers remain active and uncleaned at any time, the rest must be cleaned");
+    assertTrue(supplierInvocations.get() > 2, "this test requires more than 2 buffer allocations to ensure cleaning occurs");
+  }
+
+  @Test
+  public void testSerializeToBigEndianBuffer() {
+    RangeBitmap.Appender appender = RangeBitmap.appender(1_000_000);
+    LongStream.range(0, 1_000_000).forEach(appender::add);
+    ByteBuffer buffer = ByteBuffer.allocate(appender.serializedSizeInBytes());
+    appender.serialize(buffer);
+    buffer.flip();
+    RangeBitmap bitmap = RangeBitmap.map(buffer);
+  }
+
+  @ParameterizedTest
+  @MethodSource("distributions")
+  public void testAppenderReuseAfterClear(LongSupplier dist) {
+    RangeBitmap.Appender appender = RangeBitmap.appender(10_000_000);
+    long[] values = new long[100_000];
+    for (int i = 0; i < values.length; ++i) {
+      values[i] = Math.min(10_000_000, dist.getAsLong());
+    }
+    for (long value : values) {
+      appender.add(value);
+    }
+    RangeBitmap first = appender.build();
+    appender.clear();
+    for (long value : values) {
+      appender.add(value);
+    }
+    RangeBitmap second = appender.build();
+    // check the bitmaps answer queries identically
+    for (int upper = 1; upper < 1_000_000; upper *= 10) {
+      assertEquals(first.lte(upper), second.lte(upper));
+      assertEquals(first.gt(upper), second.gt(upper));
+    }
+  }
+
+  public static Stream<Arguments> distributions() {
+    return Stream.of(
+        NORMAL.of(42, 1_000, 100),
+        NORMAL.of(42, 10_000, 10),
+        NORMAL.of(42, 1_000_000, 1000),
+        UNIFORM.of(42, 0, 1_000_000),
+        UNIFORM.of(42, 500_000, 10_000_000),
+        EXP.of(42, 0.0001),
+        EXP.of(42, 0.9999)
+    ).map(Arguments::of);
+  }
+
+  @ParameterizedTest
+  @MethodSource("distributions")
+  public void testAgainstReferenceImplementation(LongSupplier dist) {
+    long maxValue = 10_000_000;
+    ReferenceImplementation.Builder builder = ReferenceImplementation.builder();
+    RangeBitmap.Appender appender = RangeBitmap.appender(maxValue);
+    LongStream.range(0, 1_000_000)
+        .map(i -> Math.min(dist.getAsLong(), maxValue))
+        .forEach(v -> {
+          builder.add(v);
+          appender.add(v);
+        });
+    ReferenceImplementation referenceImplementation = builder.seal();
+    RangeBitmap sut = appender.build();
+    assertAll(LongStream.range(0, 7).map(i -> (long) Math.pow(10, i)).mapToObj(threshold -> () -> assertEquals(referenceImplementation.lessThanOrEqualTo(threshold), sut.lte(threshold))));
+  }
+
+  @ParameterizedTest
+  @MethodSource("distributions")
+  @SuppressWarnings("unchecked")
+  public void testAgainstPrecomputed(LongSupplier dist) {
+    long maxValue = 10_000_000;
+    ReferenceImplementation.Builder builder = ReferenceImplementation.builder();
+    RangeBitmap.Appender appender = RangeBitmap.appender(maxValue);
+    RoaringBitmapWriter<RoaringBitmap>[] recorders =
+        LongStream.range(0, 7).map(i -> (long) Math.pow(10, i)).mapToObj(i -> RoaringBitmapWriter.writer().runCompress(true).get()).toArray(RoaringBitmapWriter[]::new);
+    LongStream.range(0, 1_000_000)
+        .forEach(i -> {
+          long v = Math.min(dist.getAsLong(), maxValue);
+          for (int p = 0; p < 7; ++p) {
+            if (v <= (long) Math.pow(10, p)) {
+              recorders[p].add((int) i);
+            }
+          }
+          builder.add(v);
+          appender.add(v);
+        });
+    RoaringBitmap[] precomputed = Arrays.stream(recorders).map(RoaringBitmapWriter::get).toArray(RoaringBitmap[]::new);
+    RoaringBitmap all = RoaringBitmap.bitmapOfRange(0, 1_000_000);
+    RangeBitmap sut = appender.build();
+    assertAll(IntStream.range(0, 7).mapToObj(i -> () -> assertEquals(precomputed[i], sut.lte((long) Math.pow(10, i)))));
+    assertAll(IntStream.range(0, 7).mapToObj(i -> () -> assertEquals(all, RoaringBitmap.or((sut.lte((long) Math.pow(10, i))), sut.gt((long) Math.pow(10, i))))));
+    assertAll(IntStream.range(0, 7).mapToObj(i -> () -> assertEquals(all, RoaringBitmap.or((sut.lt((long) Math.pow(10, i))), sut.gte((long) Math.pow(10, i))))));
+    assertAll(IntStream.range(0, 7).mapToObj(i -> () -> assertEquals(RoaringBitmap.andNot(all, precomputed[i]), sut.gt((long) Math.pow(10, i)))));
+  }
+
+  public static class ReferenceImplementation {
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    ReferenceImplementation(long maxRid, RoaringBitmap[] bitmaps) {
+      this.maxRid = maxRid;
+      this.bitmaps = bitmaps;
+    }
+
+    private final long maxRid;
+    private final RoaringBitmap[] bitmaps;
+
+    public RoaringBitmap lessThanOrEqualTo(long threshold) {
+      if (63 - Long.numberOfLeadingZeros(threshold) > bitmaps.length) {
+        return all();
+      }
+      RoaringBitmap bitmap = (threshold & 1) == 0 ? bitmaps[0].clone() : all();
+      long mask = 2;
+      for (int i = 1; i < bitmaps.length; ++i) {
+        if ((threshold & mask) != mask) {
+          bitmap.and(bitmaps[i]);
+        } else {
+          bitmap.or(bitmaps[i]);
+        }
+        mask <<= 1;
+      }
+      return bitmap;
+    }
+
+    private RoaringBitmap all() {
+      RoaringBitmap all = new RoaringBitmap();
+      all.add(0, maxRid);
+      return all;
+    }
+
+    private static final class Builder {
+
+      private final RoaringBitmapWriter<RoaringBitmap>[] writers;
+      private int rid = 0;
+      private long mask = 0;
+
+      @SuppressWarnings("unchecked")
+      public Builder() {
+        writers = new RoaringBitmapWriter[64];
+        Arrays.setAll(writers, i -> RoaringBitmapWriter.writer().runCompress(true).get());
+      }
+
+      public void add(long value) {
+        long bits = ~value;
+        mask |= value;
+        while (bits != 0) {
+          int index = Long.numberOfTrailingZeros(bits);
+          writers[index].add(rid);
+          bits &= (bits - 1);
+        }
+        rid++;
+      }
+
+      public ReferenceImplementation seal() {
+        int numDiscarded = Long.numberOfLeadingZeros(mask);
+        RoaringBitmap[] bitmaps = new RoaringBitmap[writers.length - numDiscarded];
+        for (int i = 0; i < bitmaps.length; ++i) {
+          bitmaps[i] = writers[i].get();
+        }
+        return new ReferenceImplementation(rid, bitmaps);
+      }
+    }
+  }
+
+  public enum Distribution {
+    UNIFORM {
+      LongSupplier of(long seed, double... params) {
+        long min = (long) params[0];
+        long max = (long) params[1];
+        SplittableRandom random = new SplittableRandom(seed);
+        return () -> random.nextLong(min, max);
+      }
+    },
+    NORMAL {
+      LongSupplier of(long seed, double... params) {
+        double mean = params[0];
+        double stddev = params[1];
+        Random random = new Random(seed);
+        return () -> (long) (stddev * random.nextGaussian() + mean);
+      }
+    },
+    EXP {
+      LongSupplier of(long seed, double... params) {
+        double rate = params[0];
+        SplittableRandom random = new SplittableRandom(seed);
+        return () -> (long) -(Math.log(random.nextDouble()) / rate);
+      }
+    };
+
+    abstract LongSupplier of(long seed, double... params);
+  }
+
+}

--- a/jmh/build.gradle.kts
+++ b/jmh/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     // tests and benchmarks both need dependencies: javaEWAH, extendedset, etc.
     listOf(
             project(":RoaringBitmap"),
+            project(":bsi"),
             "com.google.guava:guava:${deps["guava"]}",
             "com.googlecode.javaewah:JavaEWAH:1.0.8",
             "it.uniroma3.mat:extendedset:1.3.4",

--- a/jmh/src/jmh/java/org/roaringbitmap/rangebitmap/RangeBitmapBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/rangebitmap/RangeBitmapBenchmark.java
@@ -1,0 +1,195 @@
+package org.roaringbitmap.rangebitmap;
+
+import org.openjdk.jmh.annotations.*;
+import org.roaringbitmap.RangeBitmap;
+import org.roaringbitmap.RoaringBitmap;
+import org.roaringbitmap.RoaringBitmapWriter;
+import org.roaringbitmap.bsi.BitmapSliceIndex;
+import org.roaringbitmap.bsi.RoaringBitmapSliceIndex;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@Fork(value = 1, jvmArgsPrepend =
+    {
+        "-XX:-TieredCompilation",
+        "-XX:+UseSerialGC",
+        "-mx2G",
+        "-ms2G",
+        "-XX:+AlwaysPreTouch"
+    })
+@State(Scope.Benchmark)
+public class RangeBitmapBenchmark {
+
+  @Param({"NORMAL(100000,10)", "UNIFORM(0,100000)", "UNIFORM(1000000,1100000)", "EXP(0.0001)"})
+  String distribution;
+
+  @Param("10000000")
+  int rows;
+
+  @Param("42")
+  long seed;
+
+  long threshold;
+
+  private RangeBitmap rangeBitmap;
+  private Base2ReferenceImplementation referenceImplementation;
+  private RoaringBitmapSliceIndex bsi;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    LongSupplier data = Distribution.parse(seed, distribution);
+    long maxValue = Long.MIN_VALUE;
+    long[] values = new long[rows];
+    for (int i = 0; i < rows; ++i) {
+      values[i] = data.getAsLong();
+      maxValue = Math.max(values[i], maxValue);
+    }
+    bsi = new RoaringBitmapSliceIndex();
+    Base2ReferenceImplementation.Builder referenceImplementationBuilder = Base2ReferenceImplementation.builder();
+    RangeBitmap.Appender appender = RangeBitmap.appender(maxValue);
+    int lz = Long.numberOfLeadingZeros(maxValue);
+    long mask = (1L << lz) - 1;
+    int rid = 0;
+    for (long value : values) {
+      referenceImplementationBuilder.add(value);
+      appender.add(value);
+      bsi.setValue(rid++, (int)(value & mask));
+    }
+    this.referenceImplementation = referenceImplementationBuilder.seal();
+    this.rangeBitmap = appender.build();
+    this.threshold = maxValue >>> 1;
+  }
+
+  @Benchmark
+  public RoaringBitmap referenceBase2() {
+    // this is about as good as a user can do from outside the library
+    return referenceImplementation.lessThanOrEqualTo(threshold);
+  }
+
+  @Benchmark
+  public RoaringBitmap bsi() {
+    // this is about as good as a user can do from outside the library
+    return bsi.compare(BitmapSliceIndex.Operation.LE, (int)threshold, 0, null);
+  }
+
+  @Benchmark
+  public RoaringBitmap rangeBitmap() {
+    return rangeBitmap.lte(threshold);
+  }
+
+  public static class Base2ReferenceImplementation {
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    Base2ReferenceImplementation(long maxRid, RoaringBitmap[] bitmaps) {
+      this.maxRid = maxRid;
+      this.bitmaps = bitmaps;
+    }
+
+    private final long maxRid;
+    private final RoaringBitmap[] bitmaps;
+
+    public RoaringBitmap lessThanOrEqualTo(long threshold) {
+      if (63 - Long.numberOfLeadingZeros(threshold) > bitmaps.length) {
+        return all();
+      }
+      RoaringBitmap bitmap = (threshold & 1) == 0 ? bitmaps[0].clone() : all();
+      long mask = 2;
+      for (int i = 1; i < bitmaps.length; ++i) {
+        if ((threshold & mask) != mask) {
+          bitmap.and(bitmaps[i]);
+        } else {
+          bitmap.or(bitmaps[i]);
+        }
+        mask <<= 1;
+      }
+      return bitmap;
+    }
+
+    private RoaringBitmap all() {
+      RoaringBitmap all = new RoaringBitmap();
+      all.add(0, maxRid);
+      return all;
+    }
+
+    private static final class Builder {
+
+      private final RoaringBitmapWriter<RoaringBitmap>[] writers;
+      private int rid = 0;
+      private long mask = 0;
+
+      @SuppressWarnings("unchecked")
+      public Builder() {
+        writers = new RoaringBitmapWriter[64];
+        Arrays.setAll(writers, i -> RoaringBitmapWriter.writer().runCompress(true).get());
+      }
+
+      public void add(long value) {
+        long bits = ~value;
+        mask |= value;
+        while (bits != 0) {
+          int index = Long.numberOfTrailingZeros(bits);
+          writers[index].add(rid);
+          bits &= (bits - 1);
+        }
+        rid++;
+      }
+
+      public Base2ReferenceImplementation seal() {
+        int numDiscarded = Long.numberOfLeadingZeros(mask);
+        RoaringBitmap[] bitmaps = new RoaringBitmap[writers.length - numDiscarded];
+        for (int i = 0; i < bitmaps.length; ++i) {
+          bitmaps[i] = writers[i].get();
+        }
+        return new Base2ReferenceImplementation(rid, bitmaps);
+      }
+    }
+  }
+
+  public enum Distribution {
+    UNIFORM {
+      LongSupplier of(long seed, double... params) {
+        long min = (long) params[0];
+        long max = (long) params[1];
+        SplittableRandom random = new SplittableRandom(seed);
+        return () -> random.nextLong(min, max);
+      }
+    },
+    NORMAL {
+      LongSupplier of(long seed, double... params) {
+        double mean = params[0];
+        double stddev = params[1];
+        Random random = new Random(seed);
+        return () -> (long) (stddev * random.nextGaussian() + mean);
+      }
+    },
+    EXP {
+      LongSupplier of(long seed, double... params) {
+        double rate = params[0];
+        SplittableRandom random = new SplittableRandom(seed);
+        return () -> (long) -(Math.log(random.nextDouble()) / rate);
+      }
+    };
+
+    abstract LongSupplier of(long seed, double... params);
+
+    public static LongSupplier parse(long seed, String spec) {
+      int paramsStart = spec.indexOf('(');
+      int paramsEnd = spec.indexOf(')');
+      double[] params = Arrays.stream(spec.substring(paramsStart + 1, paramsEnd).split(","))
+          .mapToDouble(s -> Double.parseDouble(s.trim()))
+          .toArray();
+      String dist = spec.substring(0, paramsStart).toUpperCase();
+      return Distribution.valueOf(dist).of(seed, params);
+    }
+  }
+
+}


### PR DESCRIPTION
This is a data structure for range indexes (index things like time, normalised floating point numbers etc.). 

Example usage:


```java
// index times before 13:00 UTC tomorrow
var appender = RangeBitmap.appender(LocalDateTime.of(2021, 9, 3, 13, 0, 0, 0).toInstant(ZoneOffset.UTC).getEpochSecond());
timestamps.forEach(appender::add);
RangeBitmap bitmap = appender.build();
RoaringBitmap beforeNow = bitmap.lessThanOrEqualTo(LocalDateTime.now().toEpochSecond(UTC));
```

There are significant advantages to implementing within the library as opposed to using the API:

```
Benchmark                                                                    (distribution)     (max)  (seed)  Mode  Cnt        Score         Error   Units
RangeBitmapBenchmark.rangeBitmap                                          NORMAL(100000,10)  10000000      42  avgt    5      752.836 ±      55.413   us/op
RangeBitmapBenchmark.rangeBitmap:·gc.alloc.rate                           NORMAL(100000,10)  10000000      42  avgt    5       72.131 ±       5.632  MB/sec
RangeBitmapBenchmark.rangeBitmap:·gc.alloc.rate.norm                      NORMAL(100000,10)  10000000      42  avgt    5    85464.353 ±       0.213    B/op
RangeBitmapBenchmark.rangeBitmap:·gc.churn.Eden_Space                     NORMAL(100000,10)  10000000      42  avgt    5       72.501 ±     624.259  MB/sec
RangeBitmapBenchmark.rangeBitmap:·gc.churn.Eden_Space.norm                NORMAL(100000,10)  10000000      42  avgt    5    88304.328 ±  760326.896    B/op
RangeBitmapBenchmark.rangeBitmap:·gc.count                                NORMAL(100000,10)  10000000      42  avgt    5        1.000                counts
RangeBitmapBenchmark.rangeBitmap:·gc.time                                 NORMAL(100000,10)  10000000      42  avgt    5        9.000                    ms
RangeBitmapBenchmark.rangeBitmap                                          UNIFORM(0,100000)  10000000      42  avgt    5     1217.908 ±      64.425   us/op
RangeBitmapBenchmark.rangeBitmap:·gc.alloc.rate                           UNIFORM(0,100000)  10000000      42  avgt    5      661.575 ±      35.543  MB/sec
RangeBitmapBenchmark.rangeBitmap:·gc.alloc.rate.norm                      UNIFORM(0,100000)  10000000      42  avgt    5  1270176.519 ±       0.086    B/op
RangeBitmapBenchmark.rangeBitmap:·gc.churn.Eden_Space                     UNIFORM(0,100000)  10000000      42  avgt    5      651.656 ±     622.791  MB/sec
RangeBitmapBenchmark.rangeBitmap:·gc.churn.Eden_Space.norm                UNIFORM(0,100000)  10000000      42  avgt    5  1254282.469 ± 1234670.049    B/op
RangeBitmapBenchmark.rangeBitmap:·gc.churn.Survivor_Space                 UNIFORM(0,100000)  10000000      42  avgt    5        0.366 ±       0.941  MB/sec
RangeBitmapBenchmark.rangeBitmap:·gc.churn.Survivor_Space.norm            UNIFORM(0,100000)  10000000      42  avgt    5      707.009 ±    1828.905    B/op
RangeBitmapBenchmark.rangeBitmap:·gc.count                                UNIFORM(0,100000)  10000000      42  avgt    5        9.000                counts
RangeBitmapBenchmark.rangeBitmap:·gc.time                                 UNIFORM(0,100000)  10000000      42  avgt    5        6.000                    ms
RangeBitmapBenchmark.rangeBitmap                                   UNIFORM(1000000,1100000)  10000000      42  avgt    5     1482.346 ±     105.587   us/op
RangeBitmapBenchmark.rangeBitmap:·gc.alloc.rate                    UNIFORM(1000000,1100000)  10000000      42  avgt    5        6.183 ±       0.449  MB/sec
RangeBitmapBenchmark.rangeBitmap:·gc.alloc.rate.norm               UNIFORM(1000000,1100000)  10000000      42  avgt    5    14448.641 ±       0.165    B/op
RangeBitmapBenchmark.rangeBitmap:·gc.count                         UNIFORM(1000000,1100000)  10000000      42  avgt    5          ≈ 0                counts
RangeBitmapBenchmark.rangeBitmap                                                EXP(0.0001)  10000000      42  avgt    5     1504.368 ±      41.665   us/op
RangeBitmapBenchmark.rangeBitmap:·gc.alloc.rate                                 EXP(0.0001)  10000000      42  avgt    5       13.910 ±       0.404  MB/sec
RangeBitmapBenchmark.rangeBitmap:·gc.alloc.rate.norm                            EXP(0.0001)  10000000      42  avgt    5    32984.640 ±       0.162    B/op
RangeBitmapBenchmark.rangeBitmap:·gc.count                                      EXP(0.0001)  10000000      42  avgt    5          ≈ 0                counts
RangeBitmapBenchmark.referenceBase2                                       NORMAL(100000,10)  10000000      42  avgt    5     1093.482 ±      85.181   us/op
RangeBitmapBenchmark.referenceBase2:·gc.alloc.rate                        NORMAL(100000,10)  10000000      42  avgt    5      755.433 ±      59.194  MB/sec
RangeBitmapBenchmark.referenceBase2:·gc.alloc.rate.norm                   NORMAL(100000,10)  10000000      42  avgt    5  1300760.451 ±       0.051    B/op
RangeBitmapBenchmark.referenceBase2:·gc.churn.Eden_Space                  NORMAL(100000,10)  10000000      42  avgt    5      724.391 ±       5.809  MB/sec
RangeBitmapBenchmark.referenceBase2:·gc.churn.Eden_Space.norm             NORMAL(100000,10)  10000000      42  avgt    5  1247687.559 ±   89765.055    B/op
RangeBitmapBenchmark.referenceBase2:·gc.churn.Survivor_Space              NORMAL(100000,10)  10000000      42  avgt    5        2.472 ±      19.419  MB/sec
RangeBitmapBenchmark.referenceBase2:·gc.churn.Survivor_Space.norm         NORMAL(100000,10)  10000000      42  avgt    5     4359.252 ±   34331.807    B/op
RangeBitmapBenchmark.referenceBase2:·gc.count                             NORMAL(100000,10)  10000000      42  avgt    5       10.000                counts
RangeBitmapBenchmark.referenceBase2:·gc.time                              NORMAL(100000,10)  10000000      42  avgt    5       20.000                    ms
RangeBitmapBenchmark.referenceBase2                                       UNIFORM(0,100000)  10000000      42  avgt    5     4216.822 ±     214.656   us/op
RangeBitmapBenchmark.referenceBase2:·gc.alloc.rate                        UNIFORM(0,100000)  10000000      42  avgt    5      560.397 ±      28.877  MB/sec
RangeBitmapBenchmark.referenceBase2:·gc.alloc.rate.norm                   UNIFORM(0,100000)  10000000      42  avgt    5  3723017.741 ±       0.260    B/op
RangeBitmapBenchmark.referenceBase2:·gc.churn.Eden_Space                  UNIFORM(0,100000)  10000000      42  avgt    5      579.700 ±     766.679  MB/sec
RangeBitmapBenchmark.referenceBase2:·gc.churn.Eden_Space.norm             UNIFORM(0,100000)  10000000      42  avgt    5  3850077.803 ± 5074863.610    B/op
RangeBitmapBenchmark.referenceBase2:·gc.churn.Survivor_Space              UNIFORM(0,100000)  10000000      42  avgt    5        0.349 ±       1.351  MB/sec
RangeBitmapBenchmark.referenceBase2:·gc.churn.Survivor_Space.norm         UNIFORM(0,100000)  10000000      42  avgt    5     2318.829 ±    8939.734    B/op
RangeBitmapBenchmark.referenceBase2:·gc.count                             UNIFORM(0,100000)  10000000      42  avgt    5        8.000                counts
RangeBitmapBenchmark.referenceBase2:·gc.time                              UNIFORM(0,100000)  10000000      42  avgt    5        6.000                    ms
RangeBitmapBenchmark.referenceBase2                                UNIFORM(1000000,1100000)  10000000      42  avgt    5     2304.774 ±      62.134   us/op
RangeBitmapBenchmark.referenceBase2:·gc.alloc.rate                 UNIFORM(1000000,1100000)  10000000      42  avgt    5      351.128 ±      10.501  MB/sec
RangeBitmapBenchmark.referenceBase2:·gc.alloc.rate.norm            UNIFORM(1000000,1100000)  10000000      42  avgt    5  1275408.965 ±       0.140    B/op
RangeBitmapBenchmark.referenceBase2:·gc.churn.Eden_Space           UNIFORM(1000000,1100000)  10000000      42  avgt    5      361.762 ±       1.574  MB/sec
RangeBitmapBenchmark.referenceBase2:·gc.churn.Eden_Space.norm      UNIFORM(1000000,1100000)  10000000      42  avgt    5  1314099.162 ±   41663.771    B/op
RangeBitmapBenchmark.referenceBase2:·gc.churn.Survivor_Space       UNIFORM(1000000,1100000)  10000000      42  avgt    5        0.216 ±       0.798  MB/sec
RangeBitmapBenchmark.referenceBase2:·gc.churn.Survivor_Space.norm  UNIFORM(1000000,1100000)  10000000      42  avgt    5      782.939 ±    2897.336    B/op
RangeBitmapBenchmark.referenceBase2:·gc.count                      UNIFORM(1000000,1100000)  10000000      42  avgt    5        5.000                counts
RangeBitmapBenchmark.referenceBase2:·gc.time                       UNIFORM(1000000,1100000)  10000000      42  avgt    5        4.000                    ms
RangeBitmapBenchmark.referenceBase2                                             EXP(0.0001)  10000000      42  avgt    5     2551.804 ±      32.740   us/op
RangeBitmapBenchmark.referenceBase2:·gc.alloc.rate                              EXP(0.0001)  10000000      42  avgt    5      319.769 ±       4.897  MB/sec
RangeBitmapBenchmark.referenceBase2:·gc.alloc.rate.norm                         EXP(0.0001)  10000000      42  avgt    5  1285057.052 ±       0.145    B/op
RangeBitmapBenchmark.referenceBase2:·gc.churn.Eden_Space                        EXP(0.0001)  10000000      42  avgt    5      289.643 ±     623.484  MB/sec
RangeBitmapBenchmark.referenceBase2:·gc.churn.Eden_Space.norm                   EXP(0.0001)  10000000      42  avgt    5  1163503.004 ± 2504615.995    B/op
RangeBitmapBenchmark.referenceBase2:·gc.churn.Survivor_Space                    EXP(0.0001)  10000000      42  avgt    5        0.118 ±       0.827  MB/sec
RangeBitmapBenchmark.referenceBase2:·gc.churn.Survivor_Space.norm               EXP(0.0001)  10000000      42  avgt    5      476.088 ±    3324.196    B/op
RangeBitmapBenchmark.referenceBase2:·gc.count                                   EXP(0.0001)  10000000      42  avgt    5        4.000                counts
RangeBitmapBenchmark.referenceBase2:·gc.time                                    EXP(0.0001)  10000000      42  avgt    5        3.000                    ms
```

Values are appended into on-heap containers, but are serialised to a ByteBuffer when each 2^16 boundary is crossed. The user can provide the `ByteBuffer` suppliers and cleaners.