### PR TITLE
Add details in logs about failed tests

### DIFF
--- a/RoaringBitmap/build.gradle.kts
+++ b/RoaringBitmap/build.gradle.kts
@@ -17,4 +17,10 @@ tasks.test {
     mustRunAfter(tasks.checkstyleMain)
     useJUnitPlatform()
     failFast = true
+    testLogging {
+        // We exclude 'passed' events
+        events( "skipped", "failed")
+        showStackTraces = true
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+    }
 }


### PR DESCRIPTION
### SUMMARY
- Additional logs in GitHub Actions logs in case of failure (e.g. memory failure observed in https://github.com/RoaringBitmap/RoaringBitmap/pull/529)

### Automated Checks

- [ ] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [ ] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
