### PR TITLE
Check if bitmap's cardinality exceeds threshold quickly

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -1889,6 +1889,22 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     return (int) getLongCardinality();
   }
 
+  /**
+   * Returns true if the bitmap's cardinality exceeds the threshold.
+   * @param threshold threshold
+   * @return true if the cardinality exceeds the threshold.
+   */
+  public boolean cardinalityExceeds(long threshold) {
+    long size = 0;
+    for (int i = 0; i < this.highLowContainer.size(); i++) {
+      size += this.highLowContainer.getContainerAtIndex(i).getCardinality();
+      if (size > threshold) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   @Override
   public void forEach(IntConsumer ic) {
     for (int i = 0; i < this.highLowContainer.size(); i++) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -1289,6 +1289,22 @@ public class ImmutableRoaringBitmap
     return (int) getLongCardinality();
   }
 
+  /**
+   * Returns true if the bitmap's cardinality exceeds the threshold.
+   * @param threshold threshold
+   * @return true if the cardinality exceeds the threshold.
+   */
+  public boolean cardinalityExceeds(long threshold) {
+    long size = 0;
+    for (int i = 0; i < this.highLowContainer.size(); i++) {
+      size += this.highLowContainer.getContainerAtIndex(i).getCardinality();
+      if (size > threshold) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   @Override
   public void forEach(IntConsumer ic) {
     for (int i = 0; i < this.highLowContainer.size(); i++) {

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -5377,4 +5377,25 @@ public class TestRoaringBitmap {
             bitmap.deserialize(new DataInputStream(new ByteArrayInputStream(new byte[4])), new byte[8]);
         });
     }
+
+    @Test
+    public void testCardinalityExceeds() {
+        RoaringBitmap bitmap = new RoaringBitmap();
+        long runLength = 20_000L;
+        bitmap.add(0L, runLength);
+        for (int i = (1 << 16) + 1; i < 1 << 17; i+= 2) {
+            bitmap.add(i);
+        }
+        long bitmapCount = 1 << 15;
+        bitmap.add((1 << 17) | 1);
+        bitmap.add((1 << 17) | 2);
+        bitmap.add((1 << 17) | 3);
+        long arrayCount = 3;
+        bitmap.runOptimize();
+        assertFalse(bitmap.cardinalityExceeds(Integer.MAX_VALUE));
+        assertFalse(bitmap.cardinalityExceeds(runLength + bitmapCount + arrayCount));
+        assertTrue(bitmap.cardinalityExceeds(runLength + bitmapCount + 1));
+        assertTrue(bitmap.cardinalityExceeds(runLength + bitmapCount - 1));
+        assertTrue(bitmap.cardinalityExceeds(runLength - 1));
+    }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
@@ -3894,4 +3894,25 @@ public class TestRoaringBitmap {
       bitmap.deserialize(new DataInputStream(new ByteArrayInputStream(new byte[4])));
     });
   }
+
+  @Test
+  public void testCardinalityExceeds() {
+    MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+    long runLength = 20_000L;
+    bitmap.add(0L, runLength);
+    for (int i = (1 << 16) + 1; i < 1 << 17; i+= 2) {
+      bitmap.add(i);
+    }
+    long bitmapCount = 1 << 15;
+    bitmap.add((1 << 17) | 1);
+    bitmap.add((1 << 17) | 2);
+    bitmap.add((1 << 17) | 3);
+    long arrayCount = 3;
+    bitmap.runOptimize();
+    assertFalse(bitmap.cardinalityExceeds(Integer.MAX_VALUE));
+    assertFalse(bitmap.cardinalityExceeds(runLength + bitmapCount + arrayCount));
+    assertTrue(bitmap.cardinalityExceeds(runLength + bitmapCount + 1));
+    assertTrue(bitmap.cardinalityExceeds(runLength + bitmapCount - 1));
+    assertTrue(bitmap.cardinalityExceeds(runLength - 1));
+  }
 }


### PR DESCRIPTION
This means it isn't necessary to compute the full cardinality to check the bitmap has more than `x` bits set.
