### PR TITLE
don't round up number of slices

### DIFF
--- a/RoaringBitmap/src/test/java/org/roaringbitmap/RangeBitmapTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/RangeBitmapTest.java
@@ -69,7 +69,7 @@ public class RangeBitmapTest {
   @ValueSource(ints = {0, 0xFFFF, 0x10001, 100_000, 0x110001, 1_000_000})
   public void testLessThanZeroEmpty(int size) {
     RangeBitmap.Appender appender = RangeBitmap.appender(size);
-    LongStream.range(0, 10).forEach(appender::add);
+    LongStream.range(0, Math.min(size, 10)).forEach(appender::add);
     RangeBitmap range = appender.build();
     RoaringBitmap expected = new RoaringBitmap();
     assertEquals(expected, range.lt(0));


### PR DESCRIPTION
`RangeBitmap` rounds the number of slices up to the nearest multiple of 8 because the masks need to be byte-aligned, but this is wasteful unless the required number of slices is a multiple of 8:

```
Benchmark                                   (distribution)    (rows)  (seed)  Mode  Cnt     Score     Error  Units
RangeBitmapBenchmark.rangeBitmap         NORMAL(100000,10)  10000000      42  avgt    5    14.507 ±   0.277  us/op
RangeBitmapBenchmark.rangeBitmap         UNIFORM(0,100000)  10000000      42  avgt    5  2180.766 ± 255.822  us/op
RangeBitmapBenchmark.rangeBitmap  UNIFORM(1000000,1100000)  10000000      42  avgt    5  2757.176 ±  90.761  us/op
RangeBitmapBenchmark.rangeBitmap               EXP(0.0001)  10000000      42  avgt    5  2196.845 ± 141.770  us/op
```

required number of slices:

```
Benchmark                                   (distribution)    (rows)  (seed)  Mode  Cnt     Score     Error  Units
RangeBitmapBenchmark.rangeBitmap         NORMAL(100000,10)  10000000      42  avgt    5     9.144 ±   0.087  us/op
RangeBitmapBenchmark.rangeBitmap         UNIFORM(0,100000)  10000000      42  avgt    5  1285.114 ±  32.379  us/op
RangeBitmapBenchmark.rangeBitmap  UNIFORM(1000000,1100000)  10000000      42  avgt    5  1586.148 ±  81.299  us/op
RangeBitmapBenchmark.rangeBitmap               EXP(0.0001)  10000000      42  avgt    5  2214.020 ± 327.998  us/op
```