### PR TITLE
Add the implementation of IMemoryManager to allow users to pool char[] and long[] arrays

### DIFF
--- a/RoaringBitmap/build.gradle.kts
+++ b/RoaringBitmap/build.gradle.kts
@@ -12,15 +12,31 @@ dependencies {
     testImplementation("com.fasterxml.jackson.core", "jackson-databind", "2.10.3")
 }
 
+val allocationManagerTest = task<Test>("allocationManagerTest") {
+    // test needs to run in its own fork to ensure registration succeeds
+    filter {
+        //include specific method in any of the tests
+        includeTestsMatching("org.roaringbitmap.AllocationManagerTest")
+    }
+    useJUnitPlatform()
+    failFast = true
+}
+
 tasks.test {
+    dependsOn(allocationManagerTest)
     systemProperty("kryo.unsafe", "false")
     mustRunAfter(tasks.checkstyleMain)
     useJUnitPlatform()
     failFast = true
     testLogging {
         // We exclude 'passed' events
-        events( "skipped", "failed")
+        events("skipped", "failed")
         showStackTraces = true
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+    }
+    filter {
+        // must not run this test as registration of the allocation manager will fail,
+        // but if it succeeded it would cause other tests to fail
+        excludeTestsMatching("org.roaringbitmap.AllocationManagerTest")
     }
 }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/AllocationManager.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/AllocationManager.java
@@ -119,7 +119,7 @@ public final class AllocationManager {
     RegisteredAllocator.ALLOCATOR.free(object);
   }
 
-  static final class DefaultAllocator implements Allocator {
+  public static class DefaultAllocator implements Allocator {
 
     @Override
     public char[] allocateChars(int size) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/AllocationManager.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/AllocationManager.java
@@ -1,0 +1,181 @@
+package org.roaringbitmap;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+/**
+ * Provides A lazily initialised constant allocator. To override allocation,
+ * registration must take place before first use.
+ */
+public final class AllocationManager {
+
+  private static final AllocationManager INSTANCE = new AllocationManager();
+
+  private static final AtomicReferenceFieldUpdater<AllocationManager, Allocator> UPDATER =
+      AtomicReferenceFieldUpdater.newUpdater(AllocationManager.class, Allocator.class,
+          "providedAllocator");
+
+  private volatile Allocator providedAllocator;
+
+  private static final class RegisteredAllocator {
+    public static final Allocator ALLOCATOR;
+    static {
+      Allocator allocator = INSTANCE.providedAllocator;
+      if (allocator == null) {
+        allocator = new DefaultAllocator();
+        if (!UPDATER.compareAndSet(INSTANCE, null, allocator)) {
+          allocator = INSTANCE.providedAllocator;
+        }
+      }
+      ALLOCATOR = allocator;
+    }
+  }
+
+  /**
+   * Register an allocator. Must be registered before first use, otherwise registration will be
+   * unsuccessful
+   * @param allocator the allocator
+   * @return true if registration succeeded
+   */
+  public static boolean register(Allocator allocator) {
+    return UPDATER.compareAndSet(INSTANCE, null, allocator);
+  }
+
+  /**
+   * @see Allocator#allocateChars
+   */
+  public static char[] allocateChars(int size) {
+    return RegisteredAllocator.ALLOCATOR.allocateChars(size);
+  }
+
+  /**
+   * @see Allocator#allocateLongs
+   */
+  public static long[] allocateLongs(int size) {
+    return RegisteredAllocator.ALLOCATOR.allocateLongs(size);
+  }
+
+  /**
+   * @see Allocator#allocateObjects
+   */
+  public static Container[] allocateContainers(int size) {
+    return RegisteredAllocator.ALLOCATOR.allocateObjects(Container.class, size);
+  }
+
+  /**
+   * @see Allocator#copy
+   */
+  public static char[] copy(char[] chars) {
+    return RegisteredAllocator.ALLOCATOR.copy(chars);
+  }
+
+  /**
+   * @see Allocator#copy
+   */
+  public static char[] copy(char[] chars, int newSize) {
+    return RegisteredAllocator.ALLOCATOR.copy(chars, newSize);
+  }
+
+  /**
+   * @see Allocator#copy
+   */
+  public static long[] copy(long[] longs) {
+    return RegisteredAllocator.ALLOCATOR.copy(longs);
+  }
+
+  /**
+   * @see Allocator#copy
+   */
+  public static Container[] copy(Container[] containers) {
+    return RegisteredAllocator.ALLOCATOR.copy(containers);
+  }
+
+  /**
+   * @see Allocator#copy
+   */
+  public static Container[] copy(Container[] containers, int newSize) {
+    return RegisteredAllocator.ALLOCATOR.copy(containers, newSize);
+  }
+
+  /**
+   * @see Allocator#extend
+   */
+  public static char[] extend(char[] chars, int newSize) {
+    return RegisteredAllocator.ALLOCATOR.extend(chars, newSize);
+  }
+
+  /**
+   * @see Allocator#extend
+   */
+  public static Container[] extend(Container[] containers, int newSize) {
+    return RegisteredAllocator.ALLOCATOR.extend(containers, newSize);
+  }
+
+  /**
+   * @see Allocator#free
+   */
+  public static void free(Object object) {
+    RegisteredAllocator.ALLOCATOR.free(object);
+  }
+
+  static final class DefaultAllocator implements Allocator {
+
+    @Override
+    public char[] allocateChars(int size) {
+      return new char[size];
+    }
+
+    @Override
+    public long[] allocateLongs(int size) {
+      return new long[size];
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T[] allocateObjects(Class<T> clazz, int size) {
+      return (T[]) Array.newInstance(clazz, size);
+    }
+
+    @Override
+    public long[] copy(long[] longs) {
+      return Arrays.copyOf(longs, longs.length);
+    }
+
+    @Override
+    public char[] copy(char[] chars) {
+      return Arrays.copyOf(chars, chars.length);
+    }
+
+    @Override
+    public char[] copy(char[] chars, int newSize) {
+      return Arrays.copyOf(chars, newSize);
+    }
+
+    @Override
+    public <T> T[] copy(T[] objects) {
+      return Arrays.copyOf(objects, objects.length);
+    }
+
+    @Override
+    public <T> T[] copy(T[] objects, int newSize) {
+      return Arrays.copyOf(objects, newSize);
+    }
+
+    @Override
+    public char[] extend(char[] chars, int newSize) {
+      return Arrays.copyOf(chars, newSize);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T[] extend(T[] objects, int newSize) {
+      return Arrays.copyOf(objects, newSize);
+    }
+
+    @Override
+    public void free(Object object) {
+      // do nothing
+    }
+  }
+}

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/Allocator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/Allocator.java
@@ -1,0 +1,89 @@
+package org.roaringbitmap;
+
+public interface Allocator {
+
+  /**
+   * allocate a new array
+   * @param size the size of the array
+   * @return a newly allocated array which should be returned to the pool
+   */
+  char[] allocateChars(int size);
+
+  /**
+   * allocate a new array
+   * @param size the size of the array
+   * @return a newly allocated array which should be returned to the pool
+   */
+  long[] allocateLongs(int size);
+
+  /**
+   * Allocate a new array with the element type
+   * @param clazz the type of the elements
+   * @param size the size of the array
+   * @param <T> the type of the elements
+   * @return a newly allocated array which should be returned to the pool
+   */
+  <T> T[] allocateObjects(Class<T> clazz, int size);
+
+  /**
+   * Copies the array, does not free the input
+   * @param longs the array to be copied but not freed
+   * @return a newly allocated array which should be returned to the pool
+   */
+  long[] copy(long[] longs);
+
+  /**
+   * Copies the array, does not free the input
+   * @param chars the array to be copied but not freed
+   * @return a newly allocated array which should be returned to the pool
+   */
+  char[] copy(char[] chars);
+
+  /**
+   * Copies the array, does not free the input
+   * @param chars the array to be copied but not freed
+   * @param newSize the size of the new array
+   * @return a newly allocated array which should be returned to the pool
+   */
+  char[] copy(char[] chars, int newSize);
+
+  /**
+   * Copies the array, does not free the input
+   * @param objects to be copied but not freed
+   * @param <T> the type of the elements
+   * @return a newly allocated array which should be returned to the pool
+   */
+  <T> T[] copy(T[] objects);
+
+  /**
+   * Copies the array, does not free the input
+   * @param objects to be copied but not freed
+   * @param <T> the type of the elements
+   * @param newSize the size of the new array
+   * @return a newly allocated array which should be returned to the pool
+   */
+  <T> T[] copy(T[] objects, int newSize);
+
+  /**
+   * Copy and free the array, return a new array
+   * @param chars array which will be freed
+   * @param newSize the size of the new array
+   * @return a newly allocated array which should be returned to the pool
+   */
+  char[] extend(char[] chars, int newSize);
+
+  /**
+   * Copy and free the array, return a new array
+   * @param objects objects which will be freed
+   * @param newSize the size of the newly allocated array
+   * @param <T> the type
+   * @return a newly allocated array which should be returned to the pool
+   */
+  <T> T[] extend(T[] objects, int newSize);
+
+  /**
+   * free the object
+   * @param object the object to free, must not be used afterwards.
+   */
+  void free(Object object);
+}

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/Container.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/Container.java
@@ -17,7 +17,7 @@ import java.util.NoSuchElementException;
  * Base container class.
  */
 public abstract class Container implements Iterable<Character>, Cloneable, Externalizable,
-        WordStorage<Container> {
+        WordStorage<Container>, AutoCloseable {
 
   /**
    * Create a container initialized with a range of consecutive values
@@ -190,9 +190,23 @@ public abstract class Container implements Iterable<Character>, Cloneable, Exter
    */
   public Container orNot(Container x, int endOfRange) {
     if (endOfRange < 0x10000) {
-      return or(x.not(0, endOfRange).iremove(endOfRange, 0x10000));
+      Container not = x.not(0, endOfRange);
+      Container removed = not.iremove(endOfRange, 0x10000);
+      if (not != removed) {
+        not.close();
+      }
+      Container answer = or(removed);
+      if (answer != removed) {
+        removed.close();
+      }
+      return answer;
     }
-    return or(x.not(0, 0x10000));
+    Container not = x.not(0, 0x10000);
+    Container answer = or(not);
+    if (not != answer) {
+      not.close();
+    }
+    return answer;
   }
 
   /**
@@ -1032,4 +1046,7 @@ public abstract class Container implements Iterable<Character>, Cloneable, Exter
       throw new NoSuchElementException("Empty " + getContainerName());
     }
   }
+
+  @Override
+  public abstract void close();
 }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -16,6 +16,7 @@ import java.nio.CharBuffer;
 import java.util.Arrays;
 import java.util.Iterator;
 
+import static org.roaringbitmap.AllocationManager.allocateChars;
 import static org.roaringbitmap.buffer.MappeableBitmapContainer.MAX_CAPACITY;
 
 
@@ -1571,7 +1572,7 @@ public final class MappeableArrayContainer extends MappeableContainer implements
    * @return copy of the content as a char array
    */
   public char[] toShortArray() {
-    char[] answer = new char[cardinality];
+    char[] answer = allocateChars(cardinality);
     content.rewind();
     content.get(answer);
     return answer;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/pool/ArrayPool.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/pool/ArrayPool.java
@@ -1,0 +1,76 @@
+package org.roaringbitmap.pool;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Non thread safe implementation of a pool of arrays of different sizes
+ */
+public abstract class ArrayPool<T> {
+
+  //Keyed object pool mapping the size to the pool of objects
+  private final Map<Integer, SimpleObjectPool<T>> keyedObjectPool;
+  private final Function<Integer, SimpleObjectPool<T>> createPoolFunction;
+
+  /**
+   * @param createObject the function that, given a size, creates an array of type T
+   */
+  public ArrayPool(Function<Integer, T> createObject) {
+    this.keyedObjectPool = new HashMap<>();
+    this.createPoolFunction = integer -> new SimpleObjectPool<>(new IObjectFactory<T>() {
+      @Override
+      public T create() {
+        return createObject.apply(integer);
+      }
+
+      @Override
+      public void destroy(T t) {
+        //Do nothing
+      }
+
+      @Override
+      public boolean validate(T t) {
+        reset(t);
+        return getSize(t) == integer;
+      }
+    });
+  }
+
+  /**
+   * Requests an object of specified size.
+   *
+   * @return An object having the requested size
+   */
+  public T take(int size) {
+    try {
+      return keyedObjectPool.computeIfAbsent(size, createPoolFunction).borrowObject();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Frees the current object once done from being used. This object will be added to the pool for
+   * future reuse
+   *
+   * @param current current object to return to the pool
+   */
+  public void free(T current) {
+    try {
+      keyedObjectPool.get(getSize(current)).returnObject(current);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Returns the size of the provided object
+   */
+  protected abstract int getSize(T current);
+
+  /**
+   * Returns the size of the provided object
+   */
+  protected abstract void reset(T current);
+}

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/pool/CharArrayPool.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/pool/CharArrayPool.java
@@ -1,0 +1,22 @@
+package org.roaringbitmap.pool;
+
+import java.util.Arrays;
+
+public class CharArrayPool extends ArrayPool<char[]> {
+
+  public static final CharArrayPool INSTANCE = new CharArrayPool();
+
+  private CharArrayPool() {
+    super(char[]::new);
+  }
+
+  @Override
+  protected int getSize(char[] current) {
+    return current.length;
+  }
+
+  @Override
+  protected void reset(char[] current) {
+    Arrays.fill(current, (char) 0);
+  }
+}

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/pool/IObjectFactory.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/pool/IObjectFactory.java
@@ -1,0 +1,22 @@
+package org.roaringbitmap.pool;
+
+/**
+ * Object factory used to create poolable objects
+ */
+public interface IObjectFactory<T> {
+
+  /**
+   * Creates a new poolable object
+   */
+  T create();
+
+  /**
+   * Destroys the poolable object
+   */
+  void destroy(T t);
+
+  /**
+   * Validates the object if it is still valid before putting it back in the pool
+   */
+  boolean validate(T t);
+}

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/pool/LongArrayPool.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/pool/LongArrayPool.java
@@ -1,0 +1,22 @@
+package org.roaringbitmap.pool;
+
+import java.util.Arrays;
+
+public class LongArrayPool extends ArrayPool<long[]> {
+
+  public static final LongArrayPool INSTANCE = new LongArrayPool();
+
+  private LongArrayPool() {
+    super(long[]::new);
+  }
+
+  @Override
+  protected int getSize(long[] current) {
+    return current.length;
+  }
+
+  @Override
+  protected void reset(long[] current) {
+    Arrays.fill(current, 0);
+  }
+}

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/pool/ObjectPoolAllocator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/pool/ObjectPoolAllocator.java
@@ -1,0 +1,55 @@
+package org.roaringbitmap.pool;
+
+import org.roaringbitmap.AllocationManager.DefaultAllocator;
+
+public class ObjectPoolAllocator extends DefaultAllocator {
+
+  public static final ObjectPoolAllocator INSTANCE = new ObjectPoolAllocator();
+
+  @Override
+  public char[] allocateChars(int size) {
+    return CharArrayPool.INSTANCE.take(size);
+  }
+
+  @Override
+  public long[] allocateLongs(int size) {
+    return LongArrayPool.INSTANCE.take(size);
+  }
+
+  @Override
+  public long[] copy(long[] longs) {
+    long[] copy = allocateLongs(longs.length);
+    System.arraycopy(longs, 0, copy, 0, longs.length);
+    return copy;
+  }
+
+  @Override
+  public char[] copy(char[] chars) {
+    char[] copy = allocateChars(chars.length);
+    System.arraycopy(chars, 0, copy, 0, chars.length);
+    return copy;
+  }
+
+  @Override
+  public char[] copy(char[] chars, int newSize) {
+    char[] copy = allocateChars(newSize);
+    System.arraycopy(chars, 0, copy, 0, Math.min(newSize, chars.length));
+    return copy;
+  }
+
+  @Override
+  public char[] extend(char[] chars, int newSize) {
+    return copy(chars, newSize);
+  }
+
+  @Override
+  public void free(Object object) {
+    if (object instanceof long[]) {
+      LongArrayPool.INSTANCE.free((long[]) object);
+    } else if (object instanceof char[]) {
+      CharArrayPool.INSTANCE.free((char[]) object);
+    } else {
+      super.free(object);
+    }
+  }
+}

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/pool/SimpleObjectPool.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/pool/SimpleObjectPool.java
@@ -1,0 +1,64 @@
+package org.roaringbitmap.pool;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+/**
+ * Non thread-safe dummy object pool that uses a queue
+ *
+ * @param <T> The type to store in the queue
+ */
+public class SimpleObjectPool<T> {
+
+  private final IObjectFactory<T> objectFactory;
+  private final Queue<T> objectQueue;
+
+  public SimpleObjectPool(IObjectFactory<T> objectFactory) {
+    this.objectFactory = objectFactory;
+    this.objectQueue = new ArrayDeque<>();
+  }
+
+  public int getSize() {
+    return objectQueue.size();
+  }
+
+  /**
+   * Gets an existing object if possible, creates it otherwise
+   */
+  public T borrowObject() {
+    T freeObject = objectQueue.poll();
+
+    // if it is not valid destroy it and re-poll from queue
+    while (freeObject != null && !objectFactory.validate(freeObject)) {
+      objectFactory.destroy(freeObject);
+      freeObject = objectQueue.poll();
+    }
+
+    // create a new one if not found
+    if (freeObject == null) {
+      freeObject = objectFactory.create();
+    }
+    return freeObject;
+  }
+
+  /**
+   * Clears the pool from objects
+   */
+  public void clear() {
+    while (!objectQueue.isEmpty()) {
+      T obj = objectQueue.poll();
+      if (obj != null) {
+        objectFactory.destroy(obj);
+      }
+    }
+  }
+
+  /**
+   * Returns an object to the pool for future reuse
+   */
+  public void returnObject(T obj) {
+    if (!objectQueue.offer(obj)) {
+      objectFactory.destroy(obj);
+    }
+  }
+}

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/AllocationManagerTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/AllocationManagerTest.java
@@ -1,0 +1,347 @@
+package org.roaringbitmap;
+
+import com.google.common.collect.Sets;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.roaringbitmap.AllocationManager.register;
+import static org.roaringbitmap.SeededTestData.TestDataSet.testCase;
+
+public class AllocationManagerTest {
+
+  private static final ReferenceCountingAllocator referenceCounter = new ReferenceCountingAllocator();
+
+  @BeforeAll
+  public static void before() {
+    assertTrue(register(referenceCounter));
+  }
+
+  @AfterEach
+  public void clear() {
+    referenceCounter.printLeaks();
+    referenceCounter.clear();
+  }
+
+  @Test
+  public void testAllocationsBalance() {
+    try (RoaringBitmap bitmap = new RoaringBitmap()) {
+      for (int i = 0; i < 1 << 16; i += 2) {
+        bitmap.add(i);
+      }
+      for (int i = 1 << 16; i < 1 << 17; i++) {
+        bitmap.add(i);
+      }
+      for (int i = 1 << 17; i < (1 << 17) + 4096; i++) {
+        bitmap.add(i);
+      }
+      bitmap.runOptimize();
+      for (int j = 1; j < 4096; j++) {
+        for (int i = (1 << 18) + j; i < 1 << 25; i += 1 << 16) {
+          bitmap.add(i);
+        }
+      }
+      bitmap.runOptimize();
+    }
+
+    referenceCounter.assertBalanced(long[].class);
+    referenceCounter.assertBalanced(char[].class);
+    referenceCounter.assertBalanced(Container.class);
+  }
+
+  @Test
+  public void testBalanceAfterOps() {
+    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+         RoaringBitmap right = testCase().withArrayAt(0).withRunAt(1).withBitmapAt(2).build()) {
+      ops(left, right);
+    }
+    clear();
+    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+         RoaringBitmap right = testCase().withRunAt(0).withBitmapAt(1).withArrayAt(2).build()) {
+      ops(left, right);
+    }
+    clear();
+    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+         RoaringBitmap right = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build()) {
+      ops(left, right);
+    }
+    clear();
+//    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+//         RoaringBitmap right = testCase().withArrayAt(1).withRunAt(2).withBitmapAt(3).build()) {
+//      ops(left, right);
+//    }
+//    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+//         RoaringBitmap right = testCase().withRunAt(1).withBitmapAt(2).withArrayAt(3).build()) {
+//      ops(left, right);
+//    }
+//    clear();
+//    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+//         RoaringBitmap right = testCase().withBitmapAt(1).withArrayAt(2).withRunAt(3).build()) {
+//      ops(left, right);
+//    }
+//    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+//         RoaringBitmap right = testCase().withArrayAt(2).withRunAt(3).withBitmapAt(4).build()) {
+//      ops(left, right);
+//    }
+//    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+//         RoaringBitmap right = testCase().withRunAt(2).withBitmapAt(3).withArrayAt(4).build()) {
+//      ops(left, right);
+//    }
+//    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+//         RoaringBitmap right = testCase().withBitmapAt(2).withArrayAt(3).withRunAt(4).build()) {
+//      ops(left, right);
+//    }
+//    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+//         RoaringBitmap right = testCase().withArrayAt(3).withRunAt(4).withBitmapAt(5).build()) {
+//      ops(left, right);
+//    }
+//    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+//         RoaringBitmap right = testCase().withRunAt(3).withBitmapAt(4).withArrayAt(5).build()) {
+//      ops(left, right);
+//    }
+//    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+//         RoaringBitmap right = testCase().withBitmapAt(3).withArrayAt(4).withRunAt(5).build()) {
+//      ops(left, right);
+//    }
+    referenceCounter.assertBalanced(long[].class);
+    referenceCounter.assertBalanced(char[].class);
+    referenceCounter.assertBalanced(Container.class);
+  }
+
+  private void ops(RoaringBitmap left, RoaringBitmap right) {
+    try (RoaringBitmap and = RoaringBitmap.and(left, right);
+         RoaringBitmap andNot = RoaringBitmap.andNot(left, right);
+         RoaringBitmap or = RoaringBitmap.or(left, right);
+         RoaringBitmap xor = RoaringBitmap.xor(left, right);
+         RoaringBitmap orNot = RoaringBitmap.orNot(left, right, 10_000_000)) {
+
+    }
+    left.and(right);
+    left.or(right);
+    left.xor(right);
+    left.andNot(right);
+    left.orNot(right, 10_000_000);
+    left.flip(0, 10_000_000L);
+    right.flip(0, 10_000_000L);
+    try (RoaringBitmap xor2 = RoaringBitmap.xor(left, right)) {
+      left.and(xor2);
+      xor2.andNot(left);
+      right.or(xor2);
+    }
+    left.and(right);
+    try (RoaringBitmap andNot2 = RoaringBitmap.andNot(left, right)) {
+      left.and(andNot2);
+      left.xor(right);
+      left.add(100000, 10_000_000_00L);
+      left.xor(andNot2);
+      left.flip(0, 1L << 20);
+      left.and(right);
+    }
+  }
+
+  @Test
+  public void testCardinalities() {
+    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+         RoaringBitmap right = testCase().withArrayAt(0).withRunAt(1).withBitmapAt(2).build()) {
+      cardinalities(left, right);
+    }
+    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+         RoaringBitmap right = testCase().withRunAt(0).withBitmapAt(1).withArrayAt(2).build()) {
+      cardinalities(left, right);
+    }
+    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+         RoaringBitmap right = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build()) {
+      cardinalities(left, right);
+    }
+    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+         RoaringBitmap right = testCase().withArrayAt(1).withRunAt(2).withBitmapAt(3).build()) {
+      cardinalities(left, right);
+    }
+    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+         RoaringBitmap right = testCase().withRunAt(1).withBitmapAt(2).withArrayAt(3).build()) {
+      cardinalities(left, right);
+    }
+    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+         RoaringBitmap right = testCase().withBitmapAt(1).withArrayAt(2).withRunAt(3).build()) {
+      cardinalities(left, right);
+    }
+    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+         RoaringBitmap right = testCase().withArrayAt(2).withRunAt(3).withBitmapAt(4).build()) {
+      cardinalities(left, right);
+    }
+    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+         RoaringBitmap right = testCase().withRunAt(2).withBitmapAt(3).withArrayAt(4).build()) {
+      cardinalities(left, right);
+    }
+    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+         RoaringBitmap right = testCase().withBitmapAt(2).withArrayAt(3).withRunAt(4).build()) {
+      cardinalities(left, right);
+    }
+    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+         RoaringBitmap right = testCase().withArrayAt(3).withRunAt(4).withBitmapAt(5).build()) {
+      cardinalities(left, right);
+    }
+    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+         RoaringBitmap right = testCase().withRunAt(3).withBitmapAt(4).withArrayAt(5).build()) {
+      cardinalities(left, right);
+    }
+    try (RoaringBitmap left = testCase().withBitmapAt(0).withArrayAt(1).withRunAt(2).build();
+         RoaringBitmap right = testCase().withBitmapAt(3).withArrayAt(4).withRunAt(5).build()) {
+      cardinalities(left, right);
+    }
+    referenceCounter.assertBalanced(long[].class);
+    referenceCounter.assertBalanced(char[].class);
+    referenceCounter.assertBalanced(Container.class);
+  }
+
+  private void cardinalities(RoaringBitmap left, RoaringBitmap right) {
+    RoaringBitmap.xorCardinality(left, right);
+    RoaringBitmap.andCardinality(left, right);
+    RoaringBitmap.orCardinality(left, right);
+    RoaringBitmap.andNotCardinality(left, right);
+    RoaringBitmap.xorCardinality(right, left);
+    RoaringBitmap.andCardinality(right, left);
+    RoaringBitmap.orCardinality(right, left);
+    RoaringBitmap.andNotCardinality(right, left);
+    try (RoaringBitmap xor1 = RoaringBitmap.xor(left, right);
+         RoaringBitmap xor2 = RoaringBitmap.xor(right, left)) {
+      RoaringBitmap.xorCardinality(xor1, xor2);
+      RoaringBitmap.andCardinality(xor1, xor2);
+      RoaringBitmap.orCardinality(xor1, xor2);
+      RoaringBitmap.andNotCardinality(xor1, xor2);
+    }
+  }
+
+
+  private static final class ReferenceCountingAllocator implements Allocator {
+
+    public void clear() {
+      allocated.clear();
+      freed.clear();
+    }
+
+    public void printLeaks() {
+      Sets.difference(allocated.keySet(), freed.keySet())
+          .stream()
+          .map(allocated::get)
+          .forEach(Throwable::printStackTrace);
+    }
+
+    public void assertBalanced(Class<?> clazz) {
+      assertEquals(0, counter.get(clazz).get(), clazz.getName());
+    }
+
+    private final AllocationManager.DefaultAllocator delegate = new AllocationManager.DefaultAllocator();
+
+    private static final ClassValue<AtomicInteger> counter = new ClassValue<AtomicInteger>() {
+      @Override
+      protected AtomicInteger computeValue(Class<?> type) {
+        return new AtomicInteger();
+      }
+    };
+
+    private final Map<Object, Throwable> allocated = new HashMap<>();
+    private final Map<Object, Throwable> freed = new HashMap<>();
+
+    @Override
+    public char[] allocateChars(int size) {
+      assertTrue(counter.get(char[].class).getAndAdd(size) >= 0);
+      return track(delegate.allocateChars(size));
+    }
+
+    @Override
+    public long[] allocateLongs(int size) {
+      assertTrue(counter.get(long[].class).getAndAdd(size) >= 0);
+      return track(delegate.allocateLongs(size));
+    }
+
+    @Override
+    public <T> T[] allocateObjects(Class<T> clazz, int size) {
+      assertTrue(counter.get(clazz).getAndAdd(size) >= 0);
+      return track(delegate.allocateObjects(clazz, size));
+    }
+
+    @Override
+    public long[] copy(long[] longs) {
+      assertTrue(counter.get(long[].class).getAndAdd(longs.length) >= 0);
+      return track(delegate.copy(longs));
+    }
+
+    @Override
+    public char[] copy(char[] chars) {
+      assertTrue(counter.get(char[].class).getAndAdd(chars.length) >= 0);
+      return track(delegate.copy(chars));
+    }
+
+    @Override
+    public char[] copy(char[] chars, int newSize) {
+      assertTrue(counter.get(char[].class).getAndAdd(newSize) >= 0);
+      return track(delegate.copy(chars, newSize));
+    }
+
+    @Override
+    public <T> T[] copy(T[] objects) {
+      assertTrue(counter.get(objects.getClass().getComponentType()).getAndAdd(objects.length) >= 0);
+      return track(delegate.copy(objects));
+    }
+
+    @Override
+    public <T> T[] copy(T[] objects, int newSize) {
+      assertTrue(counter.get(objects.getClass().getComponentType()).getAndAdd(newSize) >= 0);
+      return track(delegate.copy(objects, newSize));
+    }
+
+    @Override
+    public char[] extend(char[] chars, int newSize) {
+      free(chars);
+      assertTrue(counter.get(char[].class).getAndAdd(newSize) >= 0);
+      return track(delegate.extend(chars, newSize));
+    }
+
+    @Override
+    public <T> T[] extend(T[] objects, int newSize) {
+      free(objects);
+      assertTrue(counter.get(objects.getClass().getComponentType()).getAndAdd(newSize) >= 0);
+      return track(delegate.extend(objects, newSize));
+    }
+
+    @Override
+    public void free(Object object) {
+      String toString = object instanceof char[] ? Arrays.toString((char[]) object) : object.toString();
+      Throwable previouslyFreedAt;
+      if ((previouslyFreedAt = freed.putIfAbsent(object, new Throwable(toString))) != null) {
+        new Throwable(toString + " freed twice at:").printStackTrace(System.err);
+        System.err.println("first freed at:");
+        previouslyFreedAt.printStackTrace(System.err);
+        System.err.println("allocated at:");
+        allocated.get(object).printStackTrace(System.err);
+      }
+      assertTrue(allocated.containsKey(object), "freed but didn't allocate " + object);
+      if (object instanceof long[]) {
+        assertTrue(counter.get(long[].class).getAndAdd(-((long[]) object).length) >= 0);
+      } else if (object instanceof char[]) {
+        assertTrue(counter.get(char[].class).getAndAdd(-((char[]) object).length) >= 0);
+      } else {
+        assertTrue(counter.get(object.getClass().getComponentType()).getAndAdd(-((Object[]) object).length) >= 0, "" + ((Object[]) object).length);
+      }
+      delegate.free(object);
+    }
+
+    private <T> T track(T x) {
+      assertNull(allocated.putIfAbsent(x, new Throwable(String.valueOf(x))));
+      return x;
+    }
+
+    private char[] track(char[] x) {
+      assertNull(allocated.putIfAbsent(x, new Throwable(Arrays.toString(x))));
+      return x;
+    }
+  }
+}

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/pool/CharArrayPoolTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/pool/CharArrayPoolTest.java
@@ -1,0 +1,27 @@
+package org.roaringbitmap.pool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+public class CharArrayPoolTest {
+
+  @Test
+  public void testTakeFree() {
+    char[] array = CharArrayPool.INSTANCE.take(10);
+    assertEquals(10, array.length);
+    CharArrayPool.INSTANCE.free(array);
+
+    char[] array2 = CharArrayPool.INSTANCE.take(5);
+    assertEquals(5, array2.length);
+    assertNotSame(array, array2);
+    CharArrayPool.INSTANCE.free(array2);
+
+    char[] array3 = CharArrayPool.INSTANCE.take(10);
+    assertSame(array, array3);
+    CharArrayPool.INSTANCE.free(array3);
+  }
+
+}

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/pool/LongArrayPoolTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/pool/LongArrayPoolTest.java
@@ -1,0 +1,27 @@
+package org.roaringbitmap.pool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+public class LongArrayPoolTest {
+
+  @Test
+  public void testTakeFree() {
+    long[] array = LongArrayPool.INSTANCE.take(10);
+    assertEquals(10, array.length);
+    LongArrayPool.INSTANCE.free(array);
+
+    long[] array2 = LongArrayPool.INSTANCE.take(5);
+    assertEquals(5, array2.length);
+    assertNotSame(array, array2);
+    LongArrayPool.INSTANCE.free(array2);
+
+    long[] array3 = LongArrayPool.INSTANCE.take(10);
+    assertSame(array, array3);
+    LongArrayPool.INSTANCE.free(array3);
+  }
+
+}

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/pool/ObjectPoolAllocatorTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/pool/ObjectPoolAllocatorTest.java
@@ -1,0 +1,16 @@
+package org.roaringbitmap.pool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class ObjectPoolAllocatorTest {
+
+  @Test
+  public void testAllocateLongs() {
+    long[] longs = ObjectPoolAllocator.INSTANCE.allocateLongs(30);
+    assertEquals(30, longs.length);
+    ObjectPoolAllocator.INSTANCE.free(longs);
+  }
+
+}

--- a/jmh/src/jmh/java/org/roaringbitmap/allocator/RealDataAllocatorBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/allocator/RealDataAllocatorBenchmark.java
@@ -1,0 +1,53 @@
+package org.roaringbitmap.allocator;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.roaringbitmap.RandomData;
+import org.roaringbitmap.RoaringBitmap;
+
+
+@State(Scope.Benchmark)
+public class RealDataAllocatorBenchmark {
+
+  private RoaringBitmap bitmap1;
+  private RoaringBitmap bitmap2;
+  private RoaringBitmap bitmap3;
+  private RoaringBitmap bitmap4;
+  private RoaringBitmap bitmap5;
+  private RoaringBitmap bitmap6;
+
+  @Setup
+  public void setup() {
+    //AllocationManager.register(ObjectPoolAllocator.INSTANCE);
+    bitmap1 = RandomData.randomBitmap(1 << 12, 0.2, 0.3);
+    bitmap2 = RandomData.randomBitmap(1 << 4, 0.2, 0.3);
+    bitmap3 = RandomData.randomBitmap(50, 0.5, 0.5);
+    bitmap4 = RandomData.randomBitmap(50, 0.5, 0.5);
+    bitmap5 = RandomData.randomBitmap(50, 0.5, 0.5);
+    bitmap6 = RandomData.randomBitmap(50, 0.5, 0.5);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public RoaringBitmap and() {
+    bitmap1.and(bitmap2);
+    bitmap1.andNot(bitmap3);
+    bitmap1.or(bitmap4);
+    bitmap1.xor(bitmap5);
+    bitmap1.remove(20L, 20000L);
+    bitmap1.flip(4000L, 40000L);
+
+    bitmap1.and(bitmap3);
+    bitmap1.andNot(bitmap4);
+    bitmap1.or(bitmap5);
+    bitmap1.xor(bitmap2);
+    return bitmap1;
+  }
+}


### PR DESCRIPTION

### SUMMARY
Inject the IMemoryManager instance whenever resources are created, and add close() methods to free allocated resources.
The default implementation changes nothing with how the library works, but users can implement their own manager which pools chars and longs.

Most changes are simple by just adding the memoryManager.

Discussion Thread: https://groups.google.com/g/roaring-bitmaps/c/V4-lRjraMJ0

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
