### PR TITLE
ior fission + benchmark to show iand fission is unprofitable

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -780,12 +780,10 @@ public final class BitmapContainer extends Container implements Cloneable {
 
   @Override
   public Container ior(final BitmapContainer b2) {
-    this.cardinality = 0;
-    for (int k = 0; k < this.bitmap.length; k++) {
-      long w = this.bitmap[k] | b2.bitmap[k];
-      this.bitmap[k] = w;
-      this.cardinality += Long.bitCount(w);
+    for (int k = 0; k < this.bitmap.length & k < b2.bitmap.length; k++) {
+      this.bitmap[k] |= b2.bitmap[k];
     }
+    computeCardinality();
     if (isFull()) {
       return RunContainer.full();
     }

--- a/jmh/src/jmh/java/org/roaringbitmap/aggregation/and/BitmapContainerAndBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/aggregation/and/BitmapContainerAndBenchmark.java
@@ -1,0 +1,43 @@
+package org.roaringbitmap.aggregation.and;
+
+import org.openjdk.jmh.annotations.*;
+import org.roaringbitmap.BitmapContainer;
+import org.roaringbitmap.Container;
+
+import java.util.SplittableRandom;
+import java.util.concurrent.ThreadLocalRandom;
+
+@State(Scope.Benchmark)
+public class BitmapContainerAndBenchmark {
+
+  @Param({"0.1", "0.5"})
+  double thisDensity;
+  @Param({"0.1", "0.5"})
+  double thatDensity;
+
+  private BitmapContainer modified;
+  private BitmapContainer parameter;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    SplittableRandom random = new SplittableRandom(42);
+    modified = new BitmapContainer();
+    parameter = new BitmapContainer();
+    while (modified.getCardinality() < 0x10000 * thisDensity) {
+      modified.add((char) random.nextInt(0x10000));
+    }
+    while (parameter.getCardinality() < 0x10000 * thatDensity) {
+      parameter.add((char) random.nextInt(0x10000));
+    }
+  }
+
+  @Benchmark
+  public Container stable() {
+    return modified.clone().iand(parameter);
+  }
+
+  @Benchmark
+  public Container tendToZero() {
+    return modified.iand(parameter);
+  }
+}

--- a/jmh/src/jmh/java/org/roaringbitmap/aggregation/or/BitmapContainerOrBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/aggregation/or/BitmapContainerOrBenchmark.java
@@ -1,0 +1,43 @@
+package org.roaringbitmap.aggregation.or;
+
+import org.openjdk.jmh.annotations.*;
+import org.roaringbitmap.BitmapContainer;
+import org.roaringbitmap.Container;
+
+import java.util.SplittableRandom;
+import java.util.concurrent.ThreadLocalRandom;
+
+@State(Scope.Benchmark)
+public class BitmapContainerOrBenchmark {
+
+  @Param({"0.1", "0.5"})
+  double thisDensity;
+  @Param({"0.1", "0.5"})
+  double thatDensity;
+
+  private BitmapContainer modified;
+  private BitmapContainer parameter;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    SplittableRandom random = new SplittableRandom(42);
+    modified = new BitmapContainer();
+    parameter = new BitmapContainer();
+    while (modified.getCardinality() < 0x10000 * thisDensity) {
+      modified.add((char) random.nextInt(0x10000));
+    }
+    while (parameter.getCardinality() < 0x10000 * thatDensity) {
+      parameter.add((char) random.nextInt(0x10000));
+    }
+  }
+
+  @Benchmark
+  public Container stable() {
+    return modified.clone().ior(parameter);
+  }
+
+  @Benchmark
+  public Container tendToZero() {
+    return modified.ior(parameter);
+  }
+}


### PR DESCRIPTION
Speed up `ior`:

before
```
Benchmark                              (thatDensity)  (thisDensity)  Mode  Cnt     Score    Error  Units
BitmapContainerOrBenchmark.stable                0.1            0.1  avgt    5  1022.169 ± 42.764  ns/op
BitmapContainerOrBenchmark.stable                0.1            0.5  avgt    5  1023.257 ± 63.641  ns/op
BitmapContainerOrBenchmark.stable                0.5            0.1  avgt    5  1016.649 ± 41.469  ns/op
BitmapContainerOrBenchmark.stable                0.5            0.5  avgt    5  1020.667 ± 66.231  ns/op
BitmapContainerOrBenchmark.tendToZero            0.1            0.1  avgt    5   411.551 ± 13.539  ns/op
BitmapContainerOrBenchmark.tendToZero            0.1            0.5  avgt    5   410.931 ± 21.078  ns/op
BitmapContainerOrBenchmark.tendToZero            0.5            0.1  avgt    5   408.868 ±  1.472  ns/op
BitmapContainerOrBenchmark.tendToZero            0.5            0.5  avgt    5   411.139 ± 17.028  ns/op
```

after
```
Benchmark                              (thatDensity)  (thisDensity)  Mode  Cnt    Score    Error  Units
BitmapContainerOrBenchmark.stable                0.1            0.1  avgt    5  852.513 ± 25.221  ns/op
BitmapContainerOrBenchmark.stable                0.1            0.5  avgt    5  860.193 ± 13.692  ns/op
BitmapContainerOrBenchmark.stable                0.5            0.1  avgt    5  860.506 ± 11.027  ns/op
BitmapContainerOrBenchmark.stable                0.5            0.5  avgt    5  865.456 ± 43.538  ns/op
BitmapContainerOrBenchmark.tendToZero            0.1            0.1  avgt    5  326.623 ±  9.777  ns/op
BitmapContainerOrBenchmark.tendToZero            0.1            0.5  avgt    5  332.203 ± 18.366  ns/op
BitmapContainerOrBenchmark.tendToZero            0.5            0.1  avgt    5  327.621 ±  9.179  ns/op
BitmapContainerOrBenchmark.tendToZero            0.5            0.5  avgt    5  324.546 ±  1.616  ns/op
```

Show the same thing doesn't work for `iand` whenever an array is materialised (this is what should be optimised for)

before
```
Benchmark                               (thatDensity)  (thisDensity)  Mode  Cnt     Score     Error  Units
BitmapContainerAndBenchmark.stable                0.1            0.1  avgt    5  2768.557 ±  27.729  ns/op
BitmapContainerAndBenchmark.stable                0.1            0.5  avgt    5  4176.572 ±  36.572  ns/op
BitmapContainerAndBenchmark.stable                0.5            0.1  avgt    5  4697.707 ± 153.624  ns/op
BitmapContainerAndBenchmark.stable                0.5            0.5  avgt    5   898.776 ±  16.378  ns/op
BitmapContainerAndBenchmark.tendToZero            0.1            0.1  avgt    5  1771.341 ±  18.681  ns/op
BitmapContainerAndBenchmark.tendToZero            0.1            0.5  avgt    5  3959.568 ±  57.410  ns/op
BitmapContainerAndBenchmark.tendToZero            0.5            0.1  avgt    5  3957.309 ± 103.017  ns/op
BitmapContainerAndBenchmark.tendToZero            0.5            0.5  avgt    5   420.588 ±   1.777  ns/op
```

after (deleted code)
```
Benchmark                               (thatDensity)  (thisDensity)  Mode  Cnt     Score    Error  Units
BitmapContainerAndBenchmark.stable                0.1            0.1  avgt    5  2192.006 ± 25.172  ns/op
BitmapContainerAndBenchmark.stable                0.1            0.5  avgt    5  4627.247 ± 28.953  ns/op
BitmapContainerAndBenchmark.stable                0.5            0.1  avgt    5  5786.044 ± 45.021  ns/op
BitmapContainerAndBenchmark.stable                0.5            0.5  avgt    5   907.093 ± 15.054  ns/op
BitmapContainerAndBenchmark.tendToZero            0.1            0.1  avgt    5  1610.726 ± 35.906  ns/op
BitmapContainerAndBenchmark.tendToZero            0.1            0.5  avgt    5  4080.217 ± 67.021  ns/op
BitmapContainerAndBenchmark.tendToZero            0.5            0.1  avgt    5  4282.733 ± 75.307  ns/op
BitmapContainerAndBenchmark.tendToZero            0.5            0.5  avgt    5   328.276 ± 19.706  ns/op
```