### PR TITLE
Improving documentation.

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -2114,6 +2114,19 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     return (int) getLongSizeInBytes() ;
   }
 
+  /**
+   * Compute the hashCode() of this bitmap.
+   *
+   * For performance reasons, this method deliberately violates the
+   * Java contract regarding hashCode/equals in the following manner:
+   * If the two bitmaps are equal *and* they have the same
+   * hasRunCompression() result, then they have the same hashCode().
+   *
+   * Thus, for the Java contract to be satisfied, you should either
+   * call runOptimize() on all your bitmaps, or on none of your bitmaps.
+   *
+   * @return the hash code
+   */
   @Override
   public int hashCode() {
     return highLowContainer.hashCode();

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -1443,7 +1443,19 @@ public class ImmutableRoaringBitmap
     return (int) getLongSizeInBytes() ;
   }
 
-
+  /**
+   * Compute the hashCode() of this bitmap.
+   *
+   * For performance reasons, this method deliberately violates the
+   * Java contract regarding hashCode/equals in the following manner:
+   * If the two bitmaps are equal *and* they have the same
+   * hasRunCompression() result, then they have the same hashCode().
+   *
+   * Thus, for the Java contract to be satisfied, you should either
+   * call runOptimize() on all your bitmaps, or on none of your bitmaps.
+   *
+   * @return the hash code
+   */
   @Override
   public int hashCode() {
     return highLowContainer.hashCode();


### PR DESCRIPTION
Strictly speaking, our bitmaps violate the Java contract. It is possible for two bitmaps to be "equal" while having a different hash code.

The reason why that is is that...

1. We decided that equals was "set equality". So it is not sensitive to runOptimize(). It makes sense, I suppose. It can be computed quickly. We have fast algorithms.

2. For the hashCode computation, if we want to it to be insensitive to the runOptimize(), we effectively have to redo the run compression, it seems and I cannot find an efficient way to do it. Now, if we only had arrays and run containers, it would not be too hard. You could hash a run like this... 
```Python
def fast(start, end):
    K = end + 1 - start
    return ((31**K-1)*(30*start+1)-30*K) // 900
```
and it would be equivalent to the array computation
```Python
def f(start, end):
    h = 0
    for i in range(start,end+1):
        h = 31 * h + i
    return h
```
But how do you deal with bitmap containers? It seems like you might have to iterate through every bit set... which is pretty terrible.


So if try to satisfy the contract, we will have slow hashes. Now hashes are typically used in a context where you want high speed. 

So the solution I am proposing is that we selectively break the equal/hashCode contract by telling users that they either need to always do "run" compression, or never.


What is the impact? If you use bitmaps as keys in a hash table, you might try to use two bitmaps that differ in their storage but are otherwise equal as sets. So you'd get as a result that the 'key' is not found. But this is  easily fixable by just calling "runCompress" before you use the bitmap if "runCompress" is used in the bitmaps that are hashed.