### PR TITLE
One pass range between

### DIFF
--- a/jmh/src/jmh/java/org/roaringbitmap/rangebitmap/RangeBitmapBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/rangebitmap/RangeBitmapBenchmark.java
@@ -89,6 +89,11 @@ public class RangeBitmapBenchmark {
   }
 
   @Benchmark
+  public RoaringBitmap rangeBitmapBetween() {
+    return rangeBitmap.between(threshold - 1, threshold + 1);
+  }
+
+  @Benchmark
   public RoaringBitmap rangeBitmapBetweenNonContextual() {
     RoaringBitmap gte = rangeBitmap.gte(threshold - 1);
     RoaringBitmap lte = rangeBitmap.lte(threshold + 1);


### PR DESCRIPTION
Allows {i : a <= x_i <= b} to be computed on a `RangeBitmap` in one pass, which is a little faster than the current API allows.

```
Benchmark                                                            (distribution)    (size)  Mode  Cnt          Score     Error  Units
RangeEvaluationBenchmark.rangeBitmap                                       EXP(0.5)  10000000  avgt    5       1876.066 ±  42.245  us/op
RangeEvaluationBenchmark.rangeBitmap:cardinality                           EXP(0.5)  10000000  avgt    5   37758060.000                #
RangeEvaluationBenchmark.rangeBitmap:rows                                  EXP(0.5)  10000000  avgt    5   11933890.000                #
RangeEvaluationBenchmark.rangeBitmap:serializedSize                        EXP(0.5)  10000000  avgt    5   22406230.000                #
RangeEvaluationBenchmark.rangeBitmap                                      EXP(0.01)  10000000  avgt    5       3613.357 ± 124.164  us/op
RangeEvaluationBenchmark.rangeBitmap:cardinality                          EXP(0.01)  10000000  avgt    5   49749530.000                #
RangeEvaluationBenchmark.rangeBitmap:rows                                 EXP(0.01)  10000000  avgt    5    2618600.000                #
RangeEvaluationBenchmark.rangeBitmap:serializedSize                       EXP(0.01)  10000000  avgt    5   57620185.000                #
RangeEvaluationBenchmark.rangeBitmap                                    EXP(0.0001)  10000000  avgt    5       5371.602 ± 853.890  us/op
RangeEvaluationBenchmark.rangeBitmap:cardinality                        EXP(0.0001)  10000000  avgt    5   49997540.000                #
RangeEvaluationBenchmark.rangeBitmap:rows                               EXP(0.0001)  10000000  avgt    5    2501040.000                #
RangeEvaluationBenchmark.rangeBitmap:serializedSize                     EXP(0.0001)  10000000  avgt    5  100592675.000                #
RangeEvaluationBenchmark.rangeBitmap                 UNIFORM(1635012703,1635016303)  10000000  avgt    5       3831.813 ± 240.186  us/op
RangeEvaluationBenchmark.rangeBitmap:cardinality     UNIFORM(1635012703,1635016303)  10000000  avgt    5   49986350.000                #
RangeEvaluationBenchmark.rangeBitmap:rows            UNIFORM(1635012703,1635016303)  10000000  avgt    5    2523015.000                #
RangeEvaluationBenchmark.rangeBitmap:serializedSize  UNIFORM(1635012703,1635016303)  10000000  avgt    5   75334955.000                #
```

```
Benchmark                                                            (distribution)    (size)  Mode  Cnt          Score     Error  Units
RangeEvaluationBenchmark.rangeBitmap                                       EXP(0.5)  10000000  avgt    5       1888.881 ±  52.011  us/op
RangeEvaluationBenchmark.rangeBitmap:cardinality                           EXP(0.5)  10000000  avgt    5   37758060.000                #
RangeEvaluationBenchmark.rangeBitmap:rows                                  EXP(0.5)  10000000  avgt    5   11933890.000                #
RangeEvaluationBenchmark.rangeBitmap:serializedSize                        EXP(0.5)  10000000  avgt    5   22406230.000                #
RangeEvaluationBenchmark.rangeBitmap                                      EXP(0.01)  10000000  avgt    5       3223.267 ±  59.161  us/op
RangeEvaluationBenchmark.rangeBitmap:cardinality                          EXP(0.01)  10000000  avgt    5   49749530.000                #
RangeEvaluationBenchmark.rangeBitmap:rows                                 EXP(0.01)  10000000  avgt    5    2618600.000                #
RangeEvaluationBenchmark.rangeBitmap:serializedSize                       EXP(0.01)  10000000  avgt    5   57620185.000                #
RangeEvaluationBenchmark.rangeBitmap                                    EXP(0.0001)  10000000  avgt    5       4332.634 ± 290.447  us/op
RangeEvaluationBenchmark.rangeBitmap:cardinality                        EXP(0.0001)  10000000  avgt    5   49997540.000                #
RangeEvaluationBenchmark.rangeBitmap:rows                               EXP(0.0001)  10000000  avgt    5    2501040.000                #
RangeEvaluationBenchmark.rangeBitmap:serializedSize                     EXP(0.0001)  10000000  avgt    5  100592675.000                #
RangeEvaluationBenchmark.rangeBitmap                 UNIFORM(1635012703,1635016303)  10000000  avgt    5       3322.318 ± 194.097  us/op
RangeEvaluationBenchmark.rangeBitmap:cardinality     UNIFORM(1635012703,1635016303)  10000000  avgt    5   49986350.000                #
RangeEvaluationBenchmark.rangeBitmap:rows            UNIFORM(1635012703,1635016303)  10000000  avgt    5    2523015.000                #
RangeEvaluationBenchmark.rangeBitmap:serializedSize  UNIFORM(1635012703,1635016303)  10000000  avgt    5   75334955.000                #
```