### PR TITLE
Fix endian when serialize Roaring64NavigableMap

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
@@ -1177,7 +1177,7 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
     out.writeInt(highToBitmap.size());
 
     for (Entry<Integer, BitmapDataProvider> entry : highToBitmap.entrySet()) {
-      out.writeInt(entry.getKey().intValue());
+      out.writeInt(Integer.reverseBytes(entry.getKey().intValue()));
       entry.getValue().serialize(out);
     }
   }
@@ -1209,7 +1209,7 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
     }
 
     for (int i = 0; i < nbHighs; i++) {
-      int high = in.readInt();
+      int high = Integer.reverseBytes(in.readInt());
       BitmapDataProvider provider = newRoaringBitmap();
       if (provider instanceof RoaringBitmap) {
         ((RoaringBitmap) provider).deserialize(in);


### PR DESCRIPTION
### SUMMARY
Fix endian when serialize Roaring64NavigableMap.

In Cpp and Go versions, the little endian is used to serialize the keys of `highToBitmap`. However, in Java version, such keys are serialized using java's default big endian. To be compatible with other language versions, we should use little endian to serialize such keys.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
