### PR TITLE
tiny bit faster ixor

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -869,7 +869,8 @@ public final class BitmapContainer extends Container implements Cloneable {
   public Container ixor(BitmapContainer b2) {
     // do this first because we have to compute the xor no matter what, and this loop gets
     // vectorized and is faster than computing the cardinality or filling the array
-    for (int k = 0; k < this.bitmap.length & k < b2.bitmap.length; ++k) {
+    int overlap = Math.min(this.bitmap.length, b2.bitmap.length);
+    for (int k = 0; k < overlap; ++k) {
       this.bitmap[k] ^= b2.bitmap[k];
     }
     // now count the bits


### PR DESCRIPTION
### tiny bit faster ixor

Just trying to grab low hanging fruit. Usually iteration over arrays intersection is tiny bit faster when length is precomputed. I suspect that some optimizations might kick in or speculation is simpler for cpu.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.




### Before
```
First run

BitmapContainerXorBenchmark.stable                0.1            0.1  avgt    5  991.302 ± 22.959  ns/op
BitmapContainerXorBenchmark.stable                0.1            0.5  avgt    5  994.926 ± 18.556  ns/op
BitmapContainerXorBenchmark.stable                0.5            0.1  avgt    5  992.487 ± 29.335  ns/op
BitmapContainerXorBenchmark.stable                0.5            0.5  avgt    5  990.099 ± 36.600  ns/op
BitmapContainerXorBenchmark.tendToZero            0.1            0.1  avgt    5  352.635 ±  2.447  ns/op
BitmapContainerXorBenchmark.tendToZero            0.1            0.5  avgt    5  352.139 ±  3.527  ns/op
BitmapContainerXorBenchmark.tendToZero            0.5            0.1  avgt    5  352.703 ±  2.245  ns/op
BitmapContainerXorBenchmark.tendToZero            0.5            0.5  avgt    5  354.573 ±  3.929  ns/op

Second run

BitmapContainerXorBenchmark.stable                0.1            0.1  avgt    5   988.995 ± 11.178  ns/op
BitmapContainerXorBenchmark.stable                0.1            0.5  avgt    5   996.498 ± 17.584  ns/op
BitmapContainerXorBenchmark.stable                0.5            0.1  avgt    5   989.314 ± 20.298  ns/op
BitmapContainerXorBenchmark.stable                0.5            0.5  avgt    5  1000.039 ± 40.733  ns/op
BitmapContainerXorBenchmark.tendToZero            0.1            0.1  avgt    5   352.889 ±  3.744  ns/op
BitmapContainerXorBenchmark.tendToZero            0.1            0.5  avgt    5   352.334 ±  2.387  ns/op
BitmapContainerXorBenchmark.tendToZero            0.5            0.1  avgt    5   352.791 ±  5.620  ns/op
BitmapContainerXorBenchmark.tendToZero            0.5            0.5  avgt    5   355.086 ±  3.641  ns/op
```

### After
```
First run

BitmapContainerXorBenchmark.stable                0.1            0.1  avgt    5  963.569 ± 25.209  ns/op
BitmapContainerXorBenchmark.stable                0.1            0.5  avgt    5  959.099 ± 34.390  ns/op
BitmapContainerXorBenchmark.stable                0.5            0.1  avgt    5  962.489 ± 10.987  ns/op
BitmapContainerXorBenchmark.stable                0.5            0.5  avgt    5  955.437 ± 15.728  ns/op
BitmapContainerXorBenchmark.tendToZero            0.1            0.1  avgt    5  348.902 ±  1.730  ns/op
BitmapContainerXorBenchmark.tendToZero            0.1            0.5  avgt    5  349.555 ±  2.448  ns/op
BitmapContainerXorBenchmark.tendToZero            0.5            0.1  avgt    5  349.100 ±  2.971  ns/op
BitmapContainerXorBenchmark.tendToZero            0.5            0.5  avgt    5  348.761 ±  3.805  ns/op

Second run
BitmapContainerXorBenchmark.stable                0.1            0.1  avgt    5  955.079 ± 30.038  ns/op
BitmapContainerXorBenchmark.stable                0.1            0.5  avgt    5  957.798 ± 28.990  ns/op
BitmapContainerXorBenchmark.stable                0.5            0.1  avgt    5  959.044 ± 16.974  ns/op
BitmapContainerXorBenchmark.stable                0.5            0.5  avgt    5  961.701 ± 33.306  ns/op
BitmapContainerXorBenchmark.tendToZero            0.1            0.1  avgt    5  349.172 ±  2.128  ns/op
BitmapContainerXorBenchmark.tendToZero            0.1            0.5  avgt    5  353.089 ±  8.042  ns/op
BitmapContainerXorBenchmark.tendToZero            0.5            0.1  avgt    5  350.035 ± 10.288  ns/op
BitmapContainerXorBenchmark.tendToZero            0.5            0.5  avgt    5  348.494 ±  2.890  ns/op
```
