### PR TITLE
Trying to add and remove values from a Roaring64Bitmap

### DIFF
--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -33,6 +33,7 @@ import static org.roaringbitmap.ValidationRangeConsumer.Value.PRESENT;
 import org.roaringbitmap.art.LeafNode;
 import org.roaringbitmap.art.LeafNodeIterator;
 
+
 public class TestRoaring64Bitmap {
 
   private Roaring64Bitmap newDefaultCtor() {
@@ -2114,5 +2115,16 @@ public class TestRoaring64Bitmap {
     assertFalse(c.contains(275846320L));
     c.and(a);
     assertFalse(c.contains(275846320L));
+  }
+
+
+  @Test
+  public void testIssue558() {
+    Roaring64Bitmap rb = new Roaring64Bitmap();
+    Random random = new Random(1234);
+    for (int i = 0 ; i < 1000000; i++) {
+      rb.addLong(random.nextLong());
+      rb.removeLong(random.nextLong());
+    }
   }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -33,7 +33,6 @@ import static org.roaringbitmap.ValidationRangeConsumer.Value.PRESENT;
 import org.roaringbitmap.art.LeafNode;
 import org.roaringbitmap.art.LeafNodeIterator;
 
-
 public class TestRoaring64Bitmap {
 
   private Roaring64Bitmap newDefaultCtor() {


### PR DESCRIPTION
### SUMMARY
Issue https://github.com/RoaringBitmap/RoaringBitmap/issues/558 suggests that removing values at random from a Roaring64Bitmap object could lead to errors. We attempt to verify.

Fixes https://github.com/RoaringBitmap/RoaringBitmap/issues/558

### Automated Checks

- [X] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [X] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
