### PR TITLE
Verifies issue 566.

### DIFF
--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -5405,4 +5405,26 @@ public class TestRoaringBitmap {
         assertTrue(bitmap.cardinalityExceeds(runLength + bitmapCount - 1));
         assertTrue(bitmap.cardinalityExceeds(runLength - 1));
     }
+
+    @Test
+    public void testIssue566() {
+        RoaringBitmap roaringBitMap = new RoaringBitmap();
+        BitSet bitSet = new BitSet(5000);
+        double prob = 0.001;
+        Random random = new Random();
+        for (int i = 0; i < 5000; i++) {
+            if (random.nextDouble() < prob) {
+                bitSet.set(i);
+                roaringBitMap.add(i);
+            }
+        }
+        long roaringbits = roaringBitMap.getSizeInBytes() * 8;
+        long bitsetbits = bitSet.size();
+        System.out.println("[issue566] cardinality: "+ roaringBitMap.getCardinality());
+        System.out.println("[issue566] bitset bits: "+ bitsetbits);
+        System.out.println("[issue566] bitset bits per entry: " + bitsetbits * 1.0 / bitSet.cardinality());
+        System.out.println("[issue566] RoaringBitmap bits: " + roaringbits);
+        System.out.println("[issue566] RoaringBitmap bits per entry: " + roaringbits * 1.0 / roaringBitMap.getCardinality());
+        assertTrue(roaringbits < bitsetbits);
+    }
 }


### PR DESCRIPTION
### SUMMARY

It adds the following test...

```Java
    public void testIssue566() {
        RoaringBitmap roaringBitMap = new RoaringBitmap();
        BitSet bitSet = new BitSet(5000);
        double prob = 0.001;
        Random random = new Random();
        for (int i = 0; i < 5000; i++) {
            if (random.nextDouble() < prob) {
                bitSet.set(i);
                roaringBitMap.add(i);
            }
        }
        long roaringbits = roaringBitMap.getSizeInBytes() * 8;
        long bitsetbits = bitSet.size();
        System.out.println("[issue566] cardinality: "+ roaringBitMap.getCardinality());
        System.out.println("[issue566] bitset bits: "+ bitsetbits);
        System.out.println("[issue566] bitset bits per entry: " + bitsetbits * 1.0 / bitSet.cardinality());
        System.out.println("[issue566] RoaringBitmap bits: " + roaringbits);
        System.out.println("[issue566] RoaringBitmap bits per entry: " + roaringbits * 1.0 / roaringBitMap.getCardinality());
        assertTrue(roaringbits < bitsetbits);
    }
```

The result is
```
[issue566] cardinality: 5
[issue566] bitset bits: 5056
[issue566] bitset bits per entry: 1011.2
[issue566] RoaringBitmap bits: 192
[issue566] RoaringBitmap bits per entry: 38.4
```

Fixes https://github.com/RoaringBitmap/RoaringBitmap/issues/566

### Automated Checks

- [X] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [X] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
