### PR TITLE
simplify BatchIterators, fix bug in advanceIfNeeded

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBatchIterator.java
@@ -48,13 +48,10 @@ public final class RoaringBatchIterator implements BatchIterator {
 
   @Override
   public void advanceIfNeeded(int target) {
-    while (key >>> 16 < target >>> 16) {
+    while (null != iterator && key >>> 16 < target >>> 16) {
       nextContainer();
-      if (null == iterator) {
-        return;
-      }
     }
-    if (null != iterator) {
+    if (null != iterator && key >>> 16 == target >>> 16) {
       iterator.advanceIfNeeded((char) target);
       if (!iterator.hasNext()) {
         nextContainer();

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/RoaringBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/RoaringBatchIterator.java
@@ -36,13 +36,10 @@ public final class RoaringBatchIterator implements BatchIterator {
 
   @Override
   public void advanceIfNeeded(int target) {
-    while (key >>> 16 < target >>> 16) {
+    while (null != iterator && key >>> 16 < target >>> 16) {
       nextContainer();
-      if (null == iterator) {
-        return;
-      }
     }
-    if (null != iterator) {
+    if (null != iterator && key >>> 16 == target >>> 16) {
       iterator.advanceIfNeeded((char) target);
       if (!iterator.hasNext()) {
         nextContainer();

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitmapBatchIteratorTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitmapBatchIteratorTest.java
@@ -13,7 +13,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.roaringbitmap.RoaringBitmapWriter.writer;
 import static org.roaringbitmap.SeededTestData.TestDataSet.testCase;
 
@@ -168,6 +167,7 @@ public class RoaringBitmapBatchIteratorTest {
         assertEquals(batch[0], 8511);
         assertFalse(bi.hasNext());
     }
+
     @Test
     public void testTimelyTerminationAfterAdvanceIfNeeded() {
         RoaringBitmap bm = RoaringBitmap.bitmapOf(8511);
@@ -177,4 +177,17 @@ public class RoaringBitmapBatchIteratorTest {
         assertFalse(bi.hasNext());
     }
 
+    @Test
+    public void testBatchIteratorWithAdvanceIfNeeded() {
+        RoaringBitmap bitmap = RoaringBitmap.bitmapOf(3 << 16, (3 << 16) + 5, (3 << 16) + 10);
+        BatchIterator it = bitmap.getBatchIterator();
+        it.advanceIfNeeded(6);
+        assertTrue(it.hasNext());
+        int[] batch = new int[10];
+        int n = it.nextBatch(batch);
+        assertEquals(n, 3);
+        assertEquals(batch[0], 3 << 16);
+        assertEquals(batch[1], (3 << 16) + 5);
+        assertEquals(batch[2], (3 << 16) + 10);
+    }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/ImmutableRoaringBitmapBatchIteratorTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/ImmutableRoaringBitmapBatchIteratorTest.java
@@ -2,6 +2,7 @@ package org.roaringbitmap.buffer;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -14,8 +15,7 @@ import org.roaringbitmap.RoaringBitmapWriter;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.roaringbitmap.RoaringBitmapWriter.bufferWriter;
 import static org.roaringbitmap.SeededTestData.TestDataSet.testCase;
 
@@ -45,6 +45,7 @@ public class ImmutableRoaringBitmapBatchIteratorTest {
             MutableRoaringBitmap.bitmapOf(IntStream.range(0,127).toArray()),
             MutableRoaringBitmap.bitmapOf(IntStream.range(0,1024).toArray()),
             MutableRoaringBitmap.bitmapOf(IntStream.concat(IntStream.range(0,256), IntStream.range(1 << 16, (1 << 16) | 256)).toArray()),
+            ImmutableRoaringBitmap.bitmapOf(8511),
             new MutableRoaringBitmap()
         };
     }
@@ -158,4 +159,23 @@ public class ImmutableRoaringBitmapBatchIteratorTest {
         assertTrue(result.isEmpty());
     }
 
+    @Test
+    public void testTimelyTermination() {
+        ImmutableRoaringBitmap bm = ImmutableRoaringBitmap.bitmapOf(8511);
+        BatchIterator bi = bm.getBatchIterator();
+        int[] batch = new int[10];
+        assertTrue(bi.hasNext());
+        int n = bi.nextBatch(batch);
+        assertEquals(n, 1);
+        assertEquals(batch[0], 8511);
+        assertFalse(bi.hasNext());
+    }
+    @Test
+    public void testTimelyTerminationAfterAdvanceIfNeeded() {
+        ImmutableRoaringBitmap bm = ImmutableRoaringBitmap.bitmapOf(8511);
+        BatchIterator bi = bm.getBatchIterator();
+        assertTrue(bi.hasNext());
+        bi.advanceIfNeeded(8512);
+        assertFalse(bi.hasNext());
+    }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/ImmutableRoaringBitmapBatchIteratorTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/ImmutableRoaringBitmapBatchIteratorTest.java
@@ -178,4 +178,18 @@ public class ImmutableRoaringBitmapBatchIteratorTest {
         bi.advanceIfNeeded(8512);
         assertFalse(bi.hasNext());
     }
+
+    @Test
+    public void testBatchIteratorWithAdvanceIfNeeded() {
+        MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(3 << 16, (3 << 16) + 5, (3 << 16) + 10);
+        BatchIterator it = bitmap.getBatchIterator();
+        it.advanceIfNeeded(6);
+        assertTrue(it.hasNext());
+        int[] batch = new int[10];
+        int n = it.nextBatch(batch);
+        assertEquals(n, 3);
+        assertEquals(batch[0], 3 << 16);
+        assertEquals(batch[1], (3 << 16) + 5);
+        assertEquals(batch[2], (3 << 16) + 10);
+    }
 }


### PR DESCRIPTION
Currently the iterator can return true for `hasNext` after the last batch, before returning no data, after returning no data, `hasNext` returns false. This change simplifies the code and avoids this last pointless iteration.