### PR TITLE
Use Path to assemble the local debug repo URI to hopefully be Windows compatible

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -142,7 +142,7 @@ subprojects.filter { listOf("RoaringBitmap", "shims", "bsi").contains(it.name) }
             repositories {
                 maven {
                     name = "localDebug"
-                    url = URI.create("file:///${project.buildDir}/repos/localDebug")
+                    url = project.buildDir.toPath().resolve("repos").resolve("localDebug").toUri()
                 }
             }
         }


### PR DESCRIPTION
### SUMMARY
Instead of building a `/` separated filesystem path as a string, use `Path#resolve`, which should use the host system's separator.

Should fix https://github.com/RoaringBitmap/RoaringBitmap/issues/571, but I do not have a Windows system to test on. 

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.

(note that `./gradlew check` should do both of those)