### PR TITLE
Roaring64Bitmap.forInRange correctness issues

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/BackwardShuttle.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/BackwardShuttle.java
@@ -32,7 +32,7 @@ public class BackwardShuttle extends AbstractShuttle {
 
   @Override
   protected boolean prefixMismatchIsInRunDirection(byte nodeValue, byte highValue) {
-    return nodeValue > highValue;
+    return Byte.toUnsignedInt(nodeValue) > Byte.toUnsignedInt(highValue);
   }
 
   @Override

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/ForwardShuttle.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/ForwardShuttle.java
@@ -32,7 +32,7 @@ public class ForwardShuttle extends AbstractShuttle {
 
   @Override
   protected boolean prefixMismatchIsInRunDirection(byte nodeValue, byte highValue) {
-    return nodeValue < highValue;
+    return Byte.toUnsignedInt(nodeValue) < Byte.toUnsignedInt(highValue);
   }
 
   @Override


### PR DESCRIPTION
### SUMMARY
- Added test cases for the issues described in #577 
- Fixed a signed byte comparison that should have been unsigned in the two shuttle implementations of the trie.

This fixes #577

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
