### PR TITLE
Extendedset renovation

### DIFF
--- a/jmh/build.gradle.kts
+++ b/jmh/build.gradle.kts
@@ -8,9 +8,7 @@ plugins {
 val deps: Map<String, String> by extra
 
 repositories {
-    maven {
-        url = URI("https://metamx.jfrog.io/artifactory/pub-libs-releases-local")
-    }
+    mavenCentral()
 }
 
 dependencies {
@@ -36,7 +34,7 @@ dependencies {
             project(":bsi"),
             "com.google.guava:guava:${deps["guava"]}",
             "com.googlecode.javaewah:JavaEWAH:1.0.8",
-            "it.uniroma3.mat:extendedset:1.3.4",
+            "io.druid:extendedset:0.12.3",
             "com.zaxxer:SparseBitSet:1.0",
             "me.lemire.integercompression:JavaFastPFOR:0.1.11"
     ).forEach {

--- a/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/BitmapFactory.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/BitmapFactory.java
@@ -11,14 +11,13 @@ import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.druid.extendedset.intset.ConciseSet;
+import io.druid.extendedset.intset.ImmutableConciseSet;
 import org.roaringbitmap.RoaringBitmap;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 
 import com.googlecode.javaewah.EWAHCompressedBitmap;
 import com.googlecode.javaewah32.EWAHCompressedBitmap32;
-
-import it.uniroma3.mat.extendedset.intset.ConciseSet;
-import it.uniroma3.mat.extendedset.intset.ImmutableConciseSet;
 
 public final class BitmapFactory {
 

--- a/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/ConciseSetIteratorWrapper.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/ConciseSetIteratorWrapper.java
@@ -1,13 +1,12 @@
 package org.roaringbitmap.realdata.wrapper;
 
-
-import it.uniroma3.mat.extendedset.intset.IntSet.IntIterator;
+import io.druid.extendedset.intset.IntSet;
 
 final class ConciseSetIteratorWrapper implements BitmapIterator {
 
-  private final IntIterator iterator;
+  private final IntSet.IntIterator iterator;
 
-  ConciseSetIteratorWrapper(IntIterator iterator) {
+  ConciseSetIteratorWrapper(IntSet.IntIterator iterator) {
     this.iterator = iterator;
   }
 

--- a/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/ConciseSetWrapper.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/ConciseSetWrapper.java
@@ -7,9 +7,8 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.PriorityQueue;
 
+import io.druid.extendedset.intset.ConciseSet;
 import org.roaringbitmap.IntConsumer;
-
-import it.uniroma3.mat.extendedset.intset.ConciseSet;
 
 final class ConciseSetWrapper implements Bitmap {
 

--- a/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/ImmutableConciseSetWrapper.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/ImmutableConciseSetWrapper.java
@@ -1,18 +1,17 @@
 package org.roaringbitmap.realdata.wrapper;
 
-
-import static it.uniroma3.mat.extendedset.intset.ImmutableConciseSet.intersection;
-import static it.uniroma3.mat.extendedset.intset.ImmutableConciseSet.union;
-
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.PriorityQueue;
 
+import io.druid.extendedset.intset.ImmutableConciseSet;
 import org.roaringbitmap.IntConsumer;
 
-import it.uniroma3.mat.extendedset.intset.ImmutableConciseSet;
+import static io.druid.extendedset.intset.ImmutableConciseSet.intersection;
+import static io.druid.extendedset.intset.ImmutableConciseSet.union;
+
 
 final class ImmutableConciseSetWrapper implements Bitmap {
 
@@ -149,7 +148,7 @@ final class ImmutableConciseSetWrapper implements Bitmap {
           while (pq.size() > 1) {
             ImmutableConciseSet x1 = pq.poll();
             ImmutableConciseSet x2 = pq.poll();
-            pq.add(ImmutableConciseSet.union(x1, x2));
+            pq.add(union(x1, x2));
           }
           bitmap = pq.poll();
         }

--- a/jmh/src/jmh/java/org/roaringbitmap/runcontainer/AllRunHorizontalOrBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/runcontainer/AllRunHorizontalOrBenchmark.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+import io.druid.extendedset.intset.ConciseSet;
+import io.druid.extendedset.intset.ImmutableConciseSet;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -16,9 +18,6 @@ import org.roaringbitmap.RoaringBitmap;
 
 import com.googlecode.javaewah.EWAHCompressedBitmap;
 import com.googlecode.javaewah32.EWAHCompressedBitmap32;
-
-import it.uniroma3.mat.extendedset.intset.ConciseSet;
-import it.uniroma3.mat.extendedset.intset.ImmutableConciseSet;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/jmh/src/jmh/java/org/roaringbitmap/runcontainer/RunArrayAndBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/runcontainer/RunArrayAndBenchmark.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+import io.druid.extendedset.intset.ConciseSet;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -12,8 +13,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.roaringbitmap.Container;
 import org.roaringbitmap.RoaringBitmap;
-
-import it.uniroma3.mat.extendedset.intset.ConciseSet;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/jmh/src/jmh/java/org/roaringbitmap/runcontainer/RunArrayAndNotBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/runcontainer/RunArrayAndNotBenchmark.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+import io.druid.extendedset.intset.ConciseSet;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -12,8 +13,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.roaringbitmap.Container;
 import org.roaringbitmap.RoaringBitmap;
-
-import it.uniroma3.mat.extendedset.intset.ConciseSet;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/jmh/src/jmh/java/org/roaringbitmap/runcontainer/RunArrayOrBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/runcontainer/RunArrayOrBenchmark.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+import io.druid.extendedset.intset.ConciseSet;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -12,8 +13,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.roaringbitmap.Container;
 import org.roaringbitmap.RoaringBitmap;
-
-import it.uniroma3.mat.extendedset.intset.ConciseSet;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/jmh/src/jmh/java/org/roaringbitmap/runcontainer/RunArrayXorBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/runcontainer/RunArrayXorBenchmark.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+import io.druid.extendedset.intset.ConciseSet;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -12,8 +13,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.roaringbitmap.Container;
 import org.roaringbitmap.RoaringBitmap;
-
-import it.uniroma3.mat.extendedset.intset.ConciseSet;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)


### PR DESCRIPTION
The version of extendedset used in the benchmarks no longer exists, but the code was maintained by the Apache Druid project for several years and is available on Maven Central. This change may prevent the results used in papers from being reproducible, but that's because the library tested against doesn't exist any more.