### PR TITLE
We don't actually rely on automated coverage metrics.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@ import java.time.Duration
 plugins {
     id("net.researchgate.release") version "2.8.1"
     id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
-    id("com.github.kt3k.coveralls") version "2.8.4" apply false
     id("com.github.ben-manes.versions") version "0.38.0"
 }
 
@@ -22,8 +21,6 @@ subprojects {
     }
 
     apply(plugin = "java-library")
-    apply(plugin = "jacoco")
-    apply(plugin = "com.github.kt3k.coveralls")
 
     repositories {
         mavenCentral()
@@ -42,13 +39,6 @@ subprojects {
             options.isWarnings = true
             if (JavaVersion.current().isJava9Compatible) {
                 options.compilerArgs = listOf("--release", "8", "-Xlint:unchecked")
-            }
-        }
-
-        named<JacocoReport>("jacocoTestReport") {
-            reports {
-                // used by coveralls
-                xml.isEnabled = true
             }
         }
 


### PR DESCRIPTION
### SUMMARY
- This removes unneeded plugins that serve to compute our test coverage. We don't actually use these metrics in practice.
