### PR TITLE
Fix RangeBitmap issue when all slices should be skipped

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RangeBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RangeBitmap.java
@@ -729,11 +729,15 @@ public final class RangeBitmap {
       // most significant absent bit in the threshold for which there is no container;
       // everything before this is wasted work, so we just skip over the containers
       int skipLow = 64 - Long.numberOfLeadingZeros(((~lower & ~containerMask) & mask));
-      if (skipLow > 0) {
+      if (skipLow == 64) {
+        lower = 0L;
+      } else if (skipLow > 0) {
         lower &= -(1L << skipLow);
       }
       int skipHigh = 64 - Long.numberOfLeadingZeros(((~upper & ~containerMask) & mask));
-      if (skipHigh > 0) {
+      if (skipHigh == 64) {
+        upper = 0L;
+      } else if (skipHigh > 0) {
         upper &= -(1L << skipHigh);
       }
       setupFirstSlice(upper, high, (int) remaining, skipHigh == 0);

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RangeBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RangeBitmap.java
@@ -741,9 +741,12 @@ public final class RangeBitmap {
       if ((containerMask & 1) == 1) {
         skipContainer();
       }
-      for (int slice = 1; slice < Long.bitCount(mask); ++slice) {
-        if ((containerMask >>> slice & 1) == 1) {
-          int flags = (int) (((upper >>> slice) & 1) | (((lower >>> slice) & 1) << 1));
+      containerMask >>>= 1;
+      upper >>>= 1;
+      lower >>>= 1;
+      for (; containerMask != 0; containerMask >>>= 1, upper >>>= 1, lower >>>= 1) {
+        if ((containerMask & 1) == 1) {
+          int flags = (int) ((upper & 1) | ((lower & 1) << 1));
           switch (flags) {
             case 0: // both absent
               andLowAndHigh();

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/RangeBitmapTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/RangeBitmapTest.java
@@ -736,6 +736,25 @@ public class RangeBitmapTest {
     assertEquals(accumulator.build().betweenCardinality(value, value), count);
   }
 
+  @Test
+  public void regressionTestIssue586() {
+    // see https://github.com/RoaringBitmap/RoaringBitmap/issues/586
+    assertAll(
+            () -> regresssionTestIssue586(0x0FFFFFFFFFFFFFFL, 0xFFFFFFFFFFFFFF0L, 0xFFFFFFFFFFFFFF0L),
+            () -> regresssionTestIssue586(0x0FFFFFFFFFFFFFFFL, 0xFFFFFFFFFFFFFFF0L, 0xFFFFFFFFFFFFFFF0L),
+            () -> regresssionTestIssue586(0x0FFFFFFFFFFFFFFFL, 0xFFFFFFFFFFFFFFF1L, 0xFFFFFFFFFFFFFFF0L),
+            () -> regresssionTestIssue586(0, 10_000_000_000L, 10_000_000L)
+    );
+  }
+
+  private static void regresssionTestIssue586(long low, long high, long value) {
+    RangeBitmap.Appender appender = RangeBitmap.appender(0xFFFFFFFFFFFFFFFFL);
+    appender.add(value);
+    RangeBitmap rangeBitmap = appender.build();
+    assertEquals(rangeBitmap.gte(low, rangeBitmap.lte(high)), rangeBitmap.between(low, high));
+    assertEquals(1, rangeBitmap.between(low, high).getCardinality());
+  }
+
   public static class ReferenceImplementation {
 
     public static Builder builder() {


### PR DESCRIPTION
### SUMMARY
Fixes #586

### Automated Checks

- [ ] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [ ] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
