### PR TITLE
IntIterator and LongIterator implement OfInt,OfLong

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BatchIntIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BatchIntIterator.java
@@ -38,7 +38,7 @@ public class BatchIntIterator implements IntIterator {
   }
 
   @Override
-  public int next() {
+  public int nextInt() {
     return buffer[i++];
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
@@ -109,7 +109,7 @@ public class BitSetUtil {
     }
     final IntIterator it = bitmap.getIntIterator();
     while (it.hasNext()) {
-      int val = it.next();
+      int val = it.nextInt();
       if (!bitset.get(val)) {
         return false;
       }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/FastRankRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/FastRankRoaringBitmap.java
@@ -326,7 +326,7 @@ public class FastRankRoaringBitmap extends RoaringBitmap {
     }
 
     @Override
-    public int next() {
+    public int nextInt() {
       final int x = iter.nextAsInt() | hs;
       if (!iter.hasNext()) {
         ++pos;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ImmutableBitmapDataProvider.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ImmutableBitmapDataProvider.java
@@ -313,7 +313,7 @@ public interface ImmutableBitmapDataProvider {
 
     @Override
     public int nextInt() {
-      return iterator.next();
+      return iterator.nextInt();
     }
 
     @Override

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/IntIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/IntIterator.java
@@ -19,15 +19,4 @@ public interface IntIterator extends Cloneable, OfInt {
    * @return a clone of the current iterator
    */
   IntIterator clone();
-
-  /**
-   * @return whether there is another value
-   */
-  boolean hasNext();
-
-  /**
-   * @return next integer value
-   */
-  int nextInt();
-
 }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/IntIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/IntIterator.java
@@ -4,13 +4,15 @@
 
 package org.roaringbitmap;
 
+import java.util.PrimitiveIterator.OfInt;
+
 /**
  * A simple iterator over integer values.
  * Using an IntIterator instead of Java's Iterator&lt;Integer&gt;
  * avoids the overhead of the Interger class: on some tests,
  * IntIterator is nearly twice as fast as Iterator&lt;Integer&gt;.
  */
-public interface IntIterator extends Cloneable {
+public interface IntIterator extends Cloneable, OfInt {
   /**
    * Creates a copy of the iterator.
    * 
@@ -26,6 +28,6 @@ public interface IntIterator extends Cloneable {
   /**
    * @return next integer value
    */
-  int next();
+  int nextInt();
 
 }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/IntIteratorFlyweight.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/IntIteratorFlyweight.java
@@ -64,7 +64,7 @@ public class IntIteratorFlyweight implements PeekableIntIterator {
   }
 
   @Override
-  public int next() {
+  public int nextInt() {
     int x = iter.nextAsInt() | hs;
     if (!iter.hasNext()) {
       ++pos;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ReverseIntIteratorFlyweight.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ReverseIntIteratorFlyweight.java
@@ -68,7 +68,7 @@ public class ReverseIntIteratorFlyweight implements IntIterator {
 
 
   @Override
-  public int next() {
+  public int nextInt() {
     final int x = iter.nextAsInt() | hs;
     if (!iter.hasNext()) {
       --pos;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -81,7 +81,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     }
 
     @Override
-    public int next() {
+    public int nextInt() {
       final int x = iter.nextAsInt() | hs;
       if (!iter.hasNext()) {
         ++pos;
@@ -151,7 +151,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     }
 
     @Override
-    public int next() {
+    public int nextInt() {
       final int x = iter.nextAsInt() | hs;
       if (!iter.hasNext()) {
         --pos;
@@ -3053,7 +3053,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     final IntIterator i = this.getIntIterator();
     answer.append("{");
     if (i.hasNext()) {
-      answer.append(i.next() & 0xFFFFFFFFL);
+      answer.append(i.nextInt() & 0xFFFFFFFFL);
     }
     while (i.hasNext()) {
       answer.append(",");
@@ -3062,7 +3062,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
         answer.append("...");
         break;
       }
-      answer.append(i.next() & 0xFFFFFFFFL);
+      answer.append(i.nextInt() & 0xFFFFFFFFL);
 
     }
     answer.append("}");

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferBitSetUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferBitSetUtil.java
@@ -115,7 +115,7 @@ public class BufferBitSetUtil {
     }
     final IntIterator it = bitmap.getIntIterator();
     while (it.hasNext()) {
-      int val = it.next();
+      int val = it.nextInt();
       if (!bitset.get(val)) {
         return false;
       }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferIntIteratorFlyweight.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferIntIteratorFlyweight.java
@@ -69,7 +69,7 @@ public class BufferIntIteratorFlyweight implements PeekableIntIterator {
   }
 
   @Override
-  public int next() {
+  public int nextInt() {
     int x = iter.nextAsInt() | hs;
     if (!iter.hasNext()) {
       ++pos;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferReverseIntIteratorFlyweight.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferReverseIntIteratorFlyweight.java
@@ -73,7 +73,7 @@ public class BufferReverseIntIteratorFlyweight implements IntIterator {
 
 
   @Override
-  public int next() {
+  public int nextInt() {
     final int x = iter.nextAsInt() | hs;
     if (!iter.hasNext()) {
       --pos;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -109,7 +109,7 @@ public class ImmutableRoaringBitmap
     }
 
     @Override
-    public int next() {
+    public int nextInt() {
       int x = iter.nextAsInt() | hs;
       if (!iter.hasNext()) {
         cp.advance();
@@ -187,7 +187,7 @@ public class ImmutableRoaringBitmap
     }
 
     @Override
-    public int next() {
+    public int nextInt() {
       int x = iter.nextAsInt() | hs;
       if (!iter.hasNext()) {
         cp.previous();
@@ -1907,7 +1907,7 @@ public class ImmutableRoaringBitmap
     final IntIterator i = this.getIntIterator();
     answer.append("{");
     if (i.hasNext()) {
-      answer.append(i.next() & 0xFFFFFFFFL);
+      answer.append(i.nextInt() & 0xFFFFFFFFL);
     }
     while (i.hasNext()) {
       answer.append(",");
@@ -1916,7 +1916,7 @@ public class ImmutableRoaringBitmap
         answer.append("...");
         break;
       }
-      answer.append(i.next() & 0xFFFFFFFFL);
+      answer.append(i.nextInt() & 0xFFFFFFFFL);
     }
     answer.append("}");
     return answer.toString();

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/ImmutableLongBitmapDataProvider.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/ImmutableLongBitmapDataProvider.java
@@ -183,7 +183,7 @@ public interface ImmutableLongBitmapDataProvider {
 
     @Override
     public long nextLong() {
-      return iterator.next();
+      return iterator.nextLong();
     }
 
     @Override

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/LongIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/LongIterator.java
@@ -3,27 +3,18 @@
  */
 package org.roaringbitmap.longlong;
 
+import java.util.PrimitiveIterator.OfLong;
+
 /**
  * A simple iterator over long values. Using an IntIterator instead of Java's Iterator&lt;Long&gt;
  * avoids the overhead of the Long class: on some tests, LongIterator is nearly twice as fast as
  * Iterator&lt;Long&gt;.
  */
-public interface LongIterator extends Cloneable {
+public interface LongIterator extends Cloneable, OfLong {
   /**
    * Creates a copy of the iterator.
    * 
    * @return a clone of the current iterator
    */
   LongIterator clone();
-
-  /**
-   * @return whether there is another value
-   */
-  boolean hasNext();
-
-  /**
-   * @return next long value
-   */
-  long next();
-
 }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -133,25 +133,7 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
    * @return a custom iterator over set bits, the bits are traversed in ascending sorted order
    */
   public Iterator<Long> iterator() {
-    final LongIterator it = getLongIterator();
-
-    return new Iterator<Long>() {
-
-      @Override
-      public boolean hasNext() {
-        return it.hasNext();
-      }
-
-      @Override
-      public Long next() {
-        return it.nextLong();
-      }
-
-      @Override
-      public void remove() {
-        throw new UnsupportedOperationException();
-      }
-    };
+    return getLongIterator();
   }
 
   @Override

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -144,7 +144,7 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
 
       @Override
       public Long next() {
-        return it.next();
+        return it.nextLong();
       }
 
       @Override
@@ -462,7 +462,7 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
     final LongIterator i = this.getLongIterator();
     answer.append("{");
     if (i.hasNext()) {
-      answer.append(i.next());
+      answer.append(i.nextLong());
     }
     while (i.hasNext()) {
       answer.append(",");
@@ -471,7 +471,7 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
         answer.append("...");
         break;
       }
-      answer.append(i.next());
+      answer.append(i.nextLong());
     }
     answer.append("}");
     return answer.toString();
@@ -650,7 +650,7 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
     LongIterator it = getLongIterator();
 
     while (it.hasNext()) {
-      array[pos++] = it.next();
+      array[pos++] = it.nextLong();
     }
     return array;
   }
@@ -868,7 +868,7 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
     }
 
     @Override
-    public long next() {
+    public long nextLong() {
       if (hasNext()) {
         char low = charIterator.next();
         return LongUtils.toLong(high, low);

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
@@ -414,26 +414,7 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
    * @return a custom iterator over set bits, the bits are traversed in ascending sorted order
    */
   public Iterator<Long> iterator() {
-    final LongIterator it = getLongIterator();
-
-    return new Iterator<Long>() {
-
-      @Override
-      public boolean hasNext() {
-        return it.hasNext();
-      }
-
-      @Override
-      public Long next() {
-        return it.next();
-      }
-
-      @Override
-      public void remove() {
-        // TODO?
-        throw new UnsupportedOperationException();
-      }
-    };
+    return getLongIterator();
   }
 
   @Override
@@ -970,9 +951,9 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
     answer.append("{");
     if (i.hasNext()) {
       if (signedLongs) {
-        answer.append(i.next());
+        answer.append(i.nextLong());
       } else {
-        answer.append(RoaringIntPacking.toUnsignedString(i.next()));
+        answer.append(RoaringIntPacking.toUnsignedString(i.nextLong()));
       }
     }
     while (i.hasNext()) {
@@ -983,9 +964,9 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
         break;
       }
       if (signedLongs) {
-        answer.append(i.next());
+        answer.append(i.nextLong());
       } else {
-        answer.append(RoaringIntPacking.toUnsignedString(i.next()));
+        answer.append(RoaringIntPacking.toUnsignedString(i.nextLong()));
       }
 
     }
@@ -1058,9 +1039,9 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
       }
 
       @Override
-      public long next() {
+      public long nextLong() {
         if (hasNext()) {
-          return RoaringIntPacking.pack(currentKey, currentIt.next());
+          return RoaringIntPacking.pack(currentKey, currentIt.nextInt());
         } else {
           throw new IllegalStateException("empty");
         }
@@ -1274,7 +1255,7 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
     LongIterator it = getLongIterator();
 
     while (it.hasNext()) {
-      array[pos++] = it.next();
+      array[pos++] = it.nextLong();
     }
     return array;
   }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitmapBatchIteratorTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitmapBatchIteratorTest.java
@@ -64,7 +64,7 @@ public class RoaringBitmapBatchIteratorTest {
         RoaringBitmapWriter<RoaringBitmap> w = writer().constantMemory()
                 .initialCapacity(bitmap.highLowContainer.size).get();
         while (it.hasNext()) {
-            w.add(it.next());
+            w.add(it.nextInt());
         }
         RoaringBitmap copy = w.get();
         assertEquals(bitmap, copy);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestIntIteratorFlyweight.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestIntIteratorFlyweight.java
@@ -29,7 +29,7 @@ public class TestIntIteratorFlyweight {
       if (!(size < values.length)) {
         values = Arrays.copyOf(values, values.length * 2);
       }
-      values[size++] = ints.next();
+      values[size++] = ints.nextInt();
     }
     return Ints.asList(Arrays.copyOf(values, size));
   }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestIteratorMemory.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestIteratorMemory.java
@@ -130,7 +130,7 @@ public class TestIteratorMemory {
       IntIterator intIterator = bitmap_a.getIntIterator();
       long result = 0;
       while (intIterator.hasNext()) {
-        result += intIterator.next();
+        result += intIterator.nextInt();
 
       }
       // A small check for iterator consistency
@@ -151,7 +151,7 @@ public class TestIteratorMemory {
 
       long result = 0;
       while (intIterator.hasNext()) {
-        result += intIterator.next();
+        result += intIterator.nextInt();
 
       }
       // A small check for iterator consistency

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestIterators.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestIterators.java
@@ -28,7 +28,7 @@ public class TestIterators {
       if (!(size < values.length)) {
         values = Arrays.copyOf(values, values.length * 2);
       }
-      values[size++] = ints.next();
+      values[size++] = ints.nextInt();
     }
     return Ints.asList(Arrays.copyOf(values, size));
   }
@@ -46,7 +46,7 @@ public class TestIterators {
       }
 
       @Override
-      public int next() {
+      public int nextInt() {
         return shorts.next();
       }
     });
@@ -124,12 +124,12 @@ public class TestIterators {
     pii = bitmap.getIntIterator();
     for(int i = 0; i < data.length; ++i) {
       pii.advanceIfNeeded(data[i]);
-      assertEquals(data[i], pii.next());
+      assertEquals(data[i], pii.nextInt());
     }
     pii = bitmap.getIntIterator();
     for(int i = 1; i < data.length; ++i) {
       pii.advanceIfNeeded(data[i-1]);
-      pii.next();
+      pii.nextInt();
       assertEquals(data[i],pii.peekNext() );
     }
     bitmap.getIntIterator().advanceIfNeeded(-1);// should not crash
@@ -146,7 +146,7 @@ public class TestIterators {
       PeekableIntIterator pii = bitmap.getIntIterator();
       pii.advanceIfNeeded(2 * i);
       assertEquals(pii.peekNext(), 2 * i);
-      assertEquals(pii.next(), 2 * i);
+      assertEquals(pii.nextInt(), 2 * i);
     }
   }
 
@@ -182,7 +182,7 @@ public class TestIterators {
       PeekableIntIterator pii = bitmap.getIntIterator();
       pii.advanceIfNeeded(i);
       assertEquals(pii.peekNext(), i);
-      assertEquals(pii.next(), i);
+      assertEquals(pii.nextInt(), i);
     }
   }
   
@@ -195,7 +195,7 @@ public class TestIterators {
       PeekableIntIterator it = b.getIntIterator();
       it.advanceIfNeeded(4096);
       while (it.hasNext()) {
-          it.next();
+          it.nextInt();
       }
   }
 
@@ -216,12 +216,12 @@ public class TestIterators {
     PeekableIntIterator bitIt = bitset.getIntIterator();
 
     assertEquals(2000000, bitIt.peekNext());
-    assertEquals(2000000, bitIt.next());
+    assertEquals(2000000, bitIt.nextInt());
 
     assertTrue(bitset.contains(2100000));
     bitIt.advanceIfNeeded(2100000);
     assertEquals(2100000, bitIt.peekNext());
-    assertEquals(2100000, bitIt.next());
+    assertEquals(2100000, bitIt.nextInt());
 
     // advancing to a value not in either range should go to the first value of second range
     assertFalse(bitset.contains(2300000));
@@ -232,7 +232,7 @@ public class TestIterators {
     assertTrue(bitset.contains(4000000));
     bitIt.advanceIfNeeded(4000000);
     assertEquals(4000000, bitIt.peekNext());
-    assertEquals(4000000, bitIt.next());
+    assertEquals(4000000, bitIt.nextInt());
   }
 
   @Test
@@ -246,12 +246,12 @@ public class TestIterators {
     PeekableIntIterator bitIt = bitset.getIntIterator();
 
     assertEquals(2000000, bitIt.peekNext());
-    assertEquals(2000000, bitIt.next());
+    assertEquals(2000000, bitIt.nextInt());
 
     assertTrue(bitset.contains(2100000));
     bitIt.advanceIfNeeded(2100000);
     assertEquals(2100000, bitIt.peekNext());
-    assertEquals(2100000, bitIt.next());
+    assertEquals(2100000, bitIt.nextInt());
 
     // advancing to a value not in any range but beyond second range
     // should go to the first value of third range
@@ -263,17 +263,17 @@ public class TestIterators {
     assertTrue(bitset.contains(6000000));
     bitIt.advanceIfNeeded(6000000);
     assertEquals(6000000, bitIt.peekNext());
-    assertEquals(6000000, bitIt.next());
+    assertEquals(6000000, bitIt.nextInt());
 
     // reset
     bitIt = bitset.getIntIterator();
 
     assertEquals(2000000, bitIt.peekNext());
-    assertEquals(2000000, bitIt.next());
+    assertEquals(2000000, bitIt.nextInt());
 
     bitIt.advanceIfNeeded(2100000);
     assertEquals(2100000, bitIt.peekNext());
-    assertEquals(2100000, bitIt.next());
+    assertEquals(2100000, bitIt.nextInt());
 
     // advancing to a value not in any range but beyond second range
     // should go to the first value of third range
@@ -284,6 +284,6 @@ public class TestIterators {
 
     bitIt.advanceIfNeeded(6000000);
     assertEquals(6000000, bitIt.peekNext());
-    assertEquals(6000000, bitIt.next());
+    assertEquals(6000000, bitIt.nextInt());
   }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRange.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRange.java
@@ -17,8 +17,8 @@ public class TestRange {
     rb.add(0);
     rb.flip(1L, 2L);
     IntIterator i = rb.getIntIterator();
-    assertEquals(0, i.next());
-    assertEquals(1, i.next());
+    assertEquals(0, i.nextInt());
+    assertEquals(1, i.nextInt());
     assertFalse(i.hasNext());
   }
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRankIterator.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRankIterator.java
@@ -56,7 +56,7 @@ public class TestRankIterator {
       int rank = iterator.peekNextRank();
       assertEquals(iterations, Util.toUnsignedLong(rank));
 
-      iterator.next();
+      iterator.nextInt();
     }
   }
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -101,7 +101,7 @@ public class TestRoaringBitmap {
         PeekableIntIterator it = bitmap.getIntIterator();
         it.advanceIfNeeded(100620278);
         assertTrue(it.hasNext());
-        assertEquals(101993170, it.next());
+        assertEquals(101993170, it.nextInt());
         assertFalse(it.hasNext());
     }
 
@@ -116,7 +116,7 @@ public class TestRoaringBitmap {
         it.wrap(bitmap);
         it.advanceIfNeeded(100620278);
         assertTrue(it.hasNext());
-        assertEquals(101993170, it.next());
+        assertEquals(101993170, it.nextInt());
         assertFalse(it.hasNext());
     }
 
@@ -899,9 +899,9 @@ public class TestRoaringBitmap {
 
         final IntIterator i = rb.getIntIterator();
         assertTrue(i.hasNext());
-        assertEquals(1, i.next());
+        assertEquals(1, i.nextInt());
         assertTrue(i.hasNext());
-        assertEquals(2 << 16, i.next());
+        assertEquals(2 << 16, i.nextInt());
         assertFalse(i.hasNext());
     }
 
@@ -2347,7 +2347,7 @@ public class TestRoaringBitmap {
 
         for (int i = 0; i < (4 << 16) - 1; ++i) {
             assertTrue(iterator.hasNext(), "Error on iteration " + i);
-            assertEquals(i, iterator.next());
+            assertEquals(i, iterator.nextInt());
         }
         assertFalse(iterator.hasNext());
     }
@@ -2421,7 +2421,7 @@ public class TestRoaringBitmap {
 
         for (int i = 0; i < (4 << 16) - 1; ++i) {
             assertTrue(iterator.hasNext(), "Error on iteration " + i);
-            assertEquals(i, iterator.next());
+            assertEquals(i, iterator.nextInt());
         }
         assertFalse(iterator.hasNext());
     }
@@ -2442,7 +2442,7 @@ public class TestRoaringBitmap {
         for (int i = 0; i < (5 << 16); ++i) {
             if ((i != (1 << 14)) && (i != (3 << 16))) {
                 assertTrue(iterator.hasNext(), "Error on iteration " + i);
-                assertEquals(i, iterator.next(), "Error on iteration " + i);
+                assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
             }
         }
         assertFalse(iterator.hasNext());
@@ -2462,7 +2462,7 @@ public class TestRoaringBitmap {
         final IntIterator iterator = rb.getIntIterator();
         for (int i = 0; i < (2 << 16) + (2 << 14); ++i) {
             assertTrue(iterator.hasNext(), "Error on iteration " + i);
-            assertEquals(i, iterator.next(), "Error on iteration " + i);
+            assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
         }
         assertFalse(iterator.hasNext());
     }
@@ -2484,7 +2484,7 @@ public class TestRoaringBitmap {
         final IntIterator iterator = rb.getIntIterator();
         for (int i = 0; i < (5 << 16); ++i) {
             assertTrue(iterator.hasNext(), "Error on iteration " + i);
-            assertEquals(i, iterator.next(), "Error on iteration " + i);
+            assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
         }
         assertFalse(iterator.hasNext());
     }
@@ -2509,20 +2509,20 @@ public class TestRoaringBitmap {
         final IntIterator iterator = rb.getIntIterator();
         for (int i = 0; i < (1 << 14); ++i) {
             assertTrue(iterator.hasNext(), "Error on iteration " + i);
-            assertEquals(i, iterator.next(), "Error on iteration " + i);
+            assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
         }
 
         assertTrue(iterator.hasNext());
-        assertEquals((1 << 16) - 1, iterator.next());
+        assertEquals((1 << 16) - 1, iterator.nextInt());
 
         assertTrue(iterator.hasNext());
-        assertEquals(1 << 16, iterator.next());
+        assertEquals(1 << 16, iterator.nextInt());
 
         assertTrue(iterator.hasNext());
-        assertEquals(2 << 16, iterator.next());
+        assertEquals(2 << 16, iterator.nextInt());
 
         assertTrue(iterator.hasNext());
-        assertEquals(3 << 16, iterator.next());
+        assertEquals(3 << 16, iterator.nextInt());
 
         assertFalse(iterator.hasNext());
     }
@@ -2991,7 +2991,7 @@ public class TestRoaringBitmap {
         RoaringBitmap copy2 = new RoaringBitmap();
         IntIterator i = rb.getIntIterator();
         while (i.hasNext()) {
-            copy2.add(i.next());
+            copy2.add(i.nextInt());
         }
         assertEquals(copy2, rb);
     }
@@ -3014,7 +3014,7 @@ public class TestRoaringBitmap {
         RoaringBitmap copy2 = new RoaringBitmap();
         IntIterator i = rb.getIntIterator();
         while (i.hasNext()) {
-            copy2.add(i.next());
+            copy2.add(i.nextInt());
         }
         assertEquals(copy2, rb);
     }
@@ -4541,7 +4541,7 @@ public class TestRoaringBitmap {
                 Set<Integer> actualResultSet = new TreeSet<>();
                 IntIterator intIterator = result.getIntIterator();
                 while (intIterator.hasNext()) {
-                    actualResultSet.add(intIterator.next());
+                    actualResultSet.add(intIterator.nextInt());
                 }
                 assertEquals(expectedResultSet, actualResultSet);
             }
@@ -4591,7 +4591,7 @@ public class TestRoaringBitmap {
                 Set<Integer> actualResultSet = new TreeSet<>();
                 IntIterator intIterator = result.getIntIterator();
                 while (intIterator.hasNext()) {
-                    actualResultSet.add(intIterator.next());
+                    actualResultSet.add(intIterator.nextInt());
                 }
                 assertEquals(expectedResultSet, actualResultSet);
             }
@@ -4640,7 +4640,7 @@ public class TestRoaringBitmap {
                 Set<Integer> actualResultSet = new TreeSet<>();
                 IntIterator intIterator = result.getIntIterator();
                 while (intIterator.hasNext()) {
-                    actualResultSet.add(intIterator.next());
+                    actualResultSet.add(intIterator.nextInt());
                 }
                 assertEquals(expectedResultSet, actualResultSet);
             }
@@ -4688,7 +4688,7 @@ public class TestRoaringBitmap {
                 Set<Integer> actualResultSet = new TreeSet<>();
                 IntIterator intIterator = result.getIntIterator();
                 while (intIterator.hasNext()) {
-                    actualResultSet.add(intIterator.next());
+                    actualResultSet.add(intIterator.nextInt());
                 }
                 assertEquals(expectedResultSet, actualResultSet);
             }
@@ -4742,7 +4742,7 @@ public class TestRoaringBitmap {
                 Set<Integer> actualResultSet = new TreeSet<>();
                 IntIterator intIterator = result.getIntIterator();
                 while (intIterator.hasNext()) {
-                    actualResultSet.add(intIterator.next());
+                    actualResultSet.add(intIterator.nextInt());
                 }
                 assertEquals(expectedResultSet, actualResultSet);
             }
@@ -4796,7 +4796,7 @@ public class TestRoaringBitmap {
                 Set<Integer> actualResultSet = new TreeSet<>();
                 IntIterator intIterator = result.getIntIterator();
                 while (intIterator.hasNext()) {
-                    actualResultSet.add(intIterator.next());
+                    actualResultSet.add(intIterator.nextInt());
                 }
                 assertEquals(expectedResultSet, actualResultSet);
             }
@@ -4846,7 +4846,7 @@ public class TestRoaringBitmap {
                 Set<Integer> actualResultSet = new TreeSet<>();
                 IntIterator intIterator = result.getIntIterator();
                 while (intIterator.hasNext()) {
-                    actualResultSet.add(intIterator.next());
+                    actualResultSet.add(intIterator.nextInt());
                 }
                 assertEquals(expectedResultSet, actualResultSet);
             }
@@ -4896,7 +4896,7 @@ public class TestRoaringBitmap {
                 Set<Integer> actualResultSet = new TreeSet<>();
                 IntIterator intIterator = result.getIntIterator();
                 while (intIterator.hasNext()) {
-                    actualResultSet.add(intIterator.next());
+                    actualResultSet.add(intIterator.nextInt());
                 }
                 assertEquals(expectedResultSet, actualResultSet);
             }
@@ -5185,8 +5185,8 @@ public class TestRoaringBitmap {
             IntIterator i = rb.getIntIterator();
             IntIterator j = rboff.getIntIterator();
             while (i.hasNext() && j.hasNext()) {
-                int val1 = i.next() + offset;
-                int val2 = j.next();
+                int val1 = i.nextInt() + offset;
+                int val2 = j.nextInt();
                 assertEquals(val1, val2);
             }
             assertEquals(i.hasNext(), j.hasNext());
@@ -5196,7 +5196,7 @@ public class TestRoaringBitmap {
             IntIterator i = rb.getIntIterator();
             IntIterator j = rboff.getIntIterator();
             while (i.hasNext() && j.hasNext()) {
-                assertEquals(i.next() + offset, j.next());
+                assertEquals(i.nextInt() + offset, j.nextInt());
             }
             assertEquals(i.hasNext(), j.hasNext());
         }
@@ -5241,8 +5241,8 @@ public class TestRoaringBitmap {
             IntIterator i = rb.getIntIterator();
             IntIterator j = rboff.getIntIterator();
             while (i.hasNext() && j.hasNext()) {
-                int val1 = i.next();
-                int val2 = j.next();
+                int val1 = i.nextInt();
+                int val2 = j.nextInt();
                 if (val1 != val2)
                     assertEquals(val1, val2);
             }
@@ -5254,7 +5254,7 @@ public class TestRoaringBitmap {
             IntIterator i = rb.getIntIterator();
             IntIterator j = rboff.getIntIterator();
             while (i.hasNext() && j.hasNext()) {
-                assertEquals(i.next(), j.next());
+                assertEquals(i.nextInt(), j.nextInt());
             }
             assertEquals(i.hasNext(), j.hasNext());
         }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmapOrNot.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmapOrNot.java
@@ -44,7 +44,7 @@ public class TestRoaringBitmapOrNot {
 
     for (int i = 0; i < (4 << 16) - 1; ++i) {
       assertTrue(iterator.hasNext());
-      assertEquals(i, iterator.next());
+      assertEquals(i, iterator.nextInt());
     }
     assertFalse(iterator.hasNext());
   }
@@ -68,7 +68,7 @@ public class TestRoaringBitmapOrNot {
 
     for (int i = 0; i < (4 << 16) - 1; ++i) {
       assertTrue(iterator.hasNext(), "Error on iteration " + i);
-      assertEquals(i, iterator.next());
+      assertEquals(i, iterator.nextInt());
     }
     assertFalse(iterator.hasNext());
   }
@@ -89,7 +89,7 @@ public class TestRoaringBitmapOrNot {
     for (int i = 0; i < (5 << 16); ++i) {
       if ((i != (1 << 14)) && (i != (3 << 16))) {
         assertTrue(iterator.hasNext(), "Error on iteration " + i);
-        assertEquals(i, iterator.next(), "Error on iteration " + i);
+        assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
       }
     }
     assertFalse(iterator.hasNext());
@@ -109,7 +109,7 @@ public class TestRoaringBitmapOrNot {
     final IntIterator iterator = rb.getIntIterator();
     for (int i = 0; i < (2 << 16) + (2 << 14); ++i) {
       assertTrue(iterator.hasNext(), "Error on iteration " + i);
-      assertEquals(i, iterator.next(), "Error on iteration " + i);
+      assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
     }
     assertFalse(iterator.hasNext());
   }
@@ -131,7 +131,7 @@ public class TestRoaringBitmapOrNot {
     final IntIterator iterator = rb.getIntIterator();
     for (int i = 0; i < (5 << 16); ++i) {
       assertTrue(iterator.hasNext(), "Error on iteration " + i);
-      assertEquals(i, iterator.next(), "Error on iteration " + i);
+      assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
     }
     assertFalse(iterator.hasNext());
   }
@@ -156,20 +156,20 @@ public class TestRoaringBitmapOrNot {
     final IntIterator iterator = rb.getIntIterator();
     for (int i = 0; i < (1 << 14); ++i) {
       assertTrue(iterator.hasNext(), "Error on iteration " + i);
-      assertEquals(i, iterator.next(), "Error on iteration " + i);
+      assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
     }
 
     assertTrue(iterator.hasNext());
-    assertEquals((1 << 16) - 1, iterator.next());
+    assertEquals((1 << 16) - 1, iterator.nextInt());
 
     assertTrue(iterator.hasNext());
-    assertEquals(1 << 16, iterator.next());
+    assertEquals(1 << 16, iterator.nextInt());
 
     assertTrue(iterator.hasNext());
-    assertEquals(2 << 16, iterator.next());
+    assertEquals(2 << 16, iterator.nextInt());
 
     assertTrue(iterator.hasNext());
-    assertEquals(3 << 16, iterator.next());
+    assertEquals(3 << 16, iterator.nextInt());
 
     assertFalse(iterator.hasNext());
   }
@@ -192,18 +192,18 @@ public class TestRoaringBitmapOrNot {
     final IntIterator iterator = rb.getIntIterator();
     for (int i = 0; i < (1 << 14); ++i) {
       assertTrue(iterator.hasNext(), "Error on iteration " + i);
-      assertEquals(i, iterator.next(), "Error on iteration " + i);
+      assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
     }
 
 
     assertTrue(iterator.hasNext());
-    assertEquals(1 << 16, iterator.next());
+    assertEquals(1 << 16, iterator.nextInt());
 
     assertTrue(iterator.hasNext());
-    assertEquals(2 << 16, iterator.next());
+    assertEquals(2 << 16, iterator.nextInt());
 
     assertTrue(iterator.hasNext());
-    assertEquals(3 << 16, iterator.next());
+    assertEquals(3 << 16, iterator.nextInt());
 
     assertFalse(iterator.hasNext());
   }
@@ -229,11 +229,11 @@ public class TestRoaringBitmapOrNot {
       final IntIterator iterator1 = answer1.getIntIterator();
       for (int i = 0; i < (1 << 14); ++i) {
         assertTrue(iterator1.hasNext(), "Error on iteration " + i);
-        assertEquals(i, iterator1.next(), "Error on iteration " + i);
+        assertEquals(i, iterator1.nextInt(), "Error on iteration " + i);
       }
-      assertEquals(1 << 16, iterator1.next());
-      assertEquals(2 << 16, iterator1.next());
-      assertEquals(3 << 16, iterator1.next());
+      assertEquals(1 << 16, iterator1.nextInt());
+      assertEquals(2 << 16, iterator1.nextInt());
+      assertEquals(3 << 16, iterator1.nextInt());
     }
 
     {
@@ -246,9 +246,9 @@ public class TestRoaringBitmapOrNot {
       final IntIterator iterator = answer.getIntIterator();
       for (int i = 0; i < (2 << 16) + 1; ++i) {
         assertTrue(iterator.hasNext(), "Error on iteration " + i);
-        assertEquals(i, iterator.next(), "Error on iteration " + i);
+        assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
       }
-      assertEquals(196608, iterator.next());
+      assertEquals(196608, iterator.nextInt());
     }
 
 
@@ -266,10 +266,10 @@ public class TestRoaringBitmapOrNot {
       for (int i = 0; i < (2 << 16) + 1; ++i) {
         if ((i != (1 << 16) + (1 << 13)) && (i != (1 << 16) + (1 << 14)) && (i != (1 << 16) + (1 << 15))) {
           assertTrue(iterator.hasNext(), "Error on iteration " + i);
-          assertEquals(i, iterator.next(), "Error on iteration " + i);
+          assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
         }
       }
-      assertEquals(196608, iterator.next());
+      assertEquals(196608, iterator.nextInt());
     }
 
     {
@@ -287,7 +287,7 @@ public class TestRoaringBitmapOrNot {
       for (int i = 0; i < (5 << 16); ++i) {
         if (i != (4 << 16)) {
           assertTrue(iterator.hasNext(), "Error on iteration " + i);
-          assertEquals(i, iterator.next(), "Error on iteration " + i);
+          assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
         }
       }
       assertFalse(iterator.hasNext(), "Number of elements " + (2 << 16));
@@ -308,7 +308,7 @@ public class TestRoaringBitmapOrNot {
       for (int i = 0; i < (5 << 16); ++i) {
         if (i != (2 << 16)) {
           assertTrue(iterator.hasNext(), "Error on iteration " + i);
-          assertEquals(i, iterator.next(), "Error on iteration " + i);
+          assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
         }
       }
       assertFalse(iterator.hasNext(), "Number of elements " + (2 << 16));

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
@@ -32,7 +32,7 @@ public class TestRunContainer {
     IntIterator x = m2.getReverseIntIterator();
     int count = 0;
     while(x.hasNext()) {
-      x.next();
+      x.nextInt();
       count++;
     }
     assertEquals(m2.getCardinality(), count);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestStreams.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestStreams.java
@@ -28,7 +28,7 @@ public class TestStreams {
       if (!(size < values.length)) {
         values = Arrays.copyOf(values, values.length * 2);
       }
-      values[size++] = ints.next();
+      values[size++] = ints.nextInt();
     }
     return Ints.asList(Arrays.copyOf(values, size));
   }
@@ -46,7 +46,7 @@ public class TestStreams {
       }
 
       @Override
-      public int next() {
+      public int nextInt() {
         return shorts.next();
       }
     });

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/ImmutableRoaringBitmapBatchIteratorTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/ImmutableRoaringBitmapBatchIteratorTest.java
@@ -67,7 +67,7 @@ public class ImmutableRoaringBitmapBatchIteratorTest {
         RoaringBitmapWriter<MutableRoaringBitmap> w = bufferWriter().constantMemory()
                 .initialCapacity(bitmap.highLowContainer.size()).get();
         while (it.hasNext()) {
-            w.add(it.next());
+            w.add(it.nextInt());
         }
         MutableRoaringBitmap copy = w.get();
         assertEquals(bitmap, copy);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
@@ -939,7 +939,7 @@ public class TestImmutableRoaringBitmap {
         Set<Integer> actualResultSet = new TreeSet<>();
         IntIterator intIterator = result.getIntIterator();
         while (intIterator.hasNext()) {
-          actualResultSet.add(intIterator.next());
+          actualResultSet.add(intIterator.nextInt());
         }
         assertEquals(expectedResultSet, actualResultSet);
       }
@@ -988,7 +988,7 @@ public class TestImmutableRoaringBitmap {
         Set<Integer> actualResultSet = new TreeSet<>();
         IntIterator intIterator = result.getIntIterator();
         while (intIterator.hasNext()) {
-          actualResultSet.add(intIterator.next());
+          actualResultSet.add(intIterator.nextInt());
         }
         assertEquals(expectedResultSet, actualResultSet);
       }
@@ -1042,7 +1042,7 @@ public class TestImmutableRoaringBitmap {
         Set<Integer> actualResultSet = new TreeSet<>();
         IntIterator intIterator = result.getIntIterator();
         while (intIterator.hasNext()) {
-          actualResultSet.add(intIterator.next());
+          actualResultSet.add(intIterator.nextInt());
         }
         assertEquals(expectedResultSet, actualResultSet);
       }
@@ -1091,7 +1091,7 @@ public class TestImmutableRoaringBitmap {
         Set<Integer> actualResultSet = new TreeSet<>();
         IntIterator intIterator = result.getIntIterator();
         while (intIterator.hasNext()) {
-          actualResultSet.add(intIterator.next());
+          actualResultSet.add(intIterator.nextInt());
         }
         assertEquals(expectedResultSet, actualResultSet);
       }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmapOrNot.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmapOrNot.java
@@ -43,7 +43,7 @@ public class TestImmutableRoaringBitmapOrNot {
 
         for (int i = 0; i < (4 << 16) - 1; ++i) {
             assertTrue(iterator.hasNext());
-            assertEquals(i, iterator.next());
+            assertEquals(i, iterator.nextInt());
         }
         assertFalse(iterator.hasNext());
     }
@@ -67,7 +67,7 @@ public class TestImmutableRoaringBitmapOrNot {
 
         for (int i = 0; i < (4 << 16) - 1; ++i) {
             assertTrue(iterator.hasNext(), "Error on iteration " + i);
-            assertEquals(i, iterator.next());
+            assertEquals(i, iterator.nextInt());
         }
         assertFalse(iterator.hasNext());
     }
@@ -88,7 +88,7 @@ public class TestImmutableRoaringBitmapOrNot {
         for (int i = 0; i < (5 << 16); ++i) {
             if ((i != (1 << 14)) && (i != (3 << 16))) {
                 assertTrue(iterator.hasNext(), "Error on iteration " + i);
-                assertEquals(i, iterator.next(), "Error on iteration " + i);
+                assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
             }
         }
         assertFalse(iterator.hasNext());
@@ -108,7 +108,7 @@ public class TestImmutableRoaringBitmapOrNot {
         IntIterator iterator = rb.getIntIterator();
         for (int i = 0; i < (2 << 16) + (2 << 14); ++i) {
             assertTrue(iterator.hasNext(), "Error on iteration " + i);
-            assertEquals(i, iterator.next(), "Error on iteration " + i);
+            assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
         }
         assertFalse(iterator.hasNext());
     }
@@ -130,7 +130,7 @@ public class TestImmutableRoaringBitmapOrNot {
         IntIterator iterator = rb.getIntIterator();
         for (int i = 0; i < (5 << 16); ++i) {
             assertTrue(iterator.hasNext(), "Error on iteration " + i);
-            assertEquals(i, iterator.next(), "Error on iteration " + i);
+            assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
         }
         assertFalse(iterator.hasNext());
     }
@@ -155,20 +155,20 @@ public class TestImmutableRoaringBitmapOrNot {
         IntIterator iterator = rb.getIntIterator();
         for (int i = 0; i < (1 << 14); ++i) {
             assertTrue(iterator.hasNext(), "Error on iteration " + i);
-            assertEquals(i, iterator.next(), "Error on iteration " + i);
+            assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
         }
 
         assertTrue(iterator.hasNext());
-        assertEquals((1 << 16) - 1, iterator.next());
+        assertEquals((1 << 16) - 1, iterator.nextInt());
 
         assertTrue(iterator.hasNext());
-        assertEquals(1 << 16, iterator.next());
+        assertEquals(1 << 16, iterator.nextInt());
 
         assertTrue(iterator.hasNext());
-        assertEquals(2 << 16, iterator.next());
+        assertEquals(2 << 16, iterator.nextInt());
 
         assertTrue(iterator.hasNext());
-        assertEquals(3 << 16, iterator.next());
+        assertEquals(3 << 16, iterator.nextInt());
 
         assertFalse(iterator.hasNext());
     }
@@ -191,18 +191,18 @@ public class TestImmutableRoaringBitmapOrNot {
         IntIterator iterator = rb.getIntIterator();
         for (int i = 0; i < (1 << 14); ++i) {
             assertTrue(iterator.hasNext(), "Error on iteration " + i);
-            assertEquals(i, iterator.next(), "Error on iteration " + i);
+            assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
         }
 
 
         assertTrue(iterator.hasNext());
-        assertEquals(1 << 16, iterator.next());
+        assertEquals(1 << 16, iterator.nextInt());
 
         assertTrue(iterator.hasNext());
-        assertEquals(2 << 16, iterator.next());
+        assertEquals(2 << 16, iterator.nextInt());
 
         assertTrue(iterator.hasNext());
-        assertEquals(3 << 16, iterator.next());
+        assertEquals(3 << 16, iterator.nextInt());
 
         assertFalse(iterator.hasNext());
     }
@@ -228,11 +228,11 @@ public class TestImmutableRoaringBitmapOrNot {
             IntIterator iterator1 = answer1.getIntIterator();
             for (int i = 0; i < (1 << 14); ++i) {
                 assertTrue(iterator1.hasNext(), "Error on iteration " + i);
-                assertEquals(i, iterator1.next(), "Error on iteration " + i);
+                assertEquals(i, iterator1.nextInt(), "Error on iteration " + i);
             }
-            assertEquals(1 << 16, iterator1.next());
-            assertEquals(2 << 16, iterator1.next());
-            assertEquals(3 << 16, iterator1.next());
+            assertEquals(1 << 16, iterator1.nextInt());
+            assertEquals(2 << 16, iterator1.nextInt());
+            assertEquals(3 << 16, iterator1.nextInt());
         }
 
         {
@@ -245,9 +245,9 @@ public class TestImmutableRoaringBitmapOrNot {
             IntIterator iterator = answer.getIntIterator();
             for (int i = 0; i < (2 << 16) + 1; ++i) {
                 assertTrue(iterator.hasNext(), "Error on iteration " + i);
-                assertEquals(i, iterator.next(), "Error on iteration " + i);
+                assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
             }
-            assertEquals(196608, iterator.next());
+            assertEquals(196608, iterator.nextInt());
         }
 
 
@@ -265,10 +265,10 @@ public class TestImmutableRoaringBitmapOrNot {
             for (int i = 0; i < (2 << 16) + 1; ++i) {
                 if ((i != (1 << 16) + (1 << 13)) && (i != (1 << 16) + (1 << 14)) && (i != (1 << 16) + (1 << 15))) {
                     assertTrue(iterator.hasNext(), "Error on iteration " + i);
-                    assertEquals(i, iterator.next(), "Error on iteration " + i);
+                    assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
                 }
             }
-            assertEquals(196608, iterator.next());
+            assertEquals(196608, iterator.nextInt());
         }
 
         {
@@ -286,7 +286,7 @@ public class TestImmutableRoaringBitmapOrNot {
             for (int i = 0; i < (5 << 16); ++i) {
                 if (i != (4 << 16)) {
                     assertTrue(iterator.hasNext(), "Error on iteration " + i);
-                    assertEquals(i, iterator.next(), "Error on iteration " + i);
+                    assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
                 }
             }
             assertFalse(iterator.hasNext(), "Number of elements " + (2 << 16));
@@ -307,7 +307,7 @@ public class TestImmutableRoaringBitmapOrNot {
             for (int i = 0; i < (5 << 16); ++i) {
                 if (i != (2 << 16)) {
                     assertTrue(iterator.hasNext(), "Error on iteration " + i);
-                    assertEquals(i, iterator.next(), "Error on iteration " + i);
+                    assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
                 }
             }
             assertFalse(iterator.hasNext(), "Number of elements " + (2 << 16));

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestIntIteratorFlyweight.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestIntIteratorFlyweight.java
@@ -28,7 +28,7 @@ public class TestIntIteratorFlyweight {
       if (!(size < values.length)) {
         values = Arrays.copyOf(values, values.length * 2);
       }
-      values[size++] = ints.next();
+      values[size++] = ints.nextInt();
     }
     return Ints.asList(Arrays.copyOf(values, size));
   }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestIterators.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestIterators.java
@@ -35,7 +35,7 @@ public class TestIterators {
       if (!(size < values.length)) {
         values = Arrays.copyOf(values, values.length * 2);
       }
-      values[size++] = ints.next();
+      values[size++] = ints.nextInt();
     }
     return Ints.asList(Arrays.copyOf(values, size));
   }
@@ -53,7 +53,7 @@ public class TestIterators {
       }
 
       @Override
-      public int next() {
+      public int nextInt() {
         return shorts.next();
       }
     });
@@ -214,12 +214,12 @@ public class TestIterators {
     pii = bitmap.getIntIterator();
     for(int i = 0; i < data.length; ++i) {
       pii.advanceIfNeeded(data[i]);
-      assertEquals(data[i], pii.next());
+      assertEquals(data[i], pii.nextInt());
     }
     pii = bitmap.getIntIterator();
     for(int i = 1; i < data.length; ++i) {
       pii.advanceIfNeeded(data[i-1]);
-      pii.next();
+      pii.nextInt();
       assertEquals(data[i],pii.peekNext() );
     }
     bitmap.getIntIterator().advanceIfNeeded(-1);
@@ -236,7 +236,7 @@ public class TestIterators {
       PeekableIntIterator pii = bitmap.getIntIterator();
       pii.advanceIfNeeded(2 * i);
       assertEquals(pii.peekNext(), 2 * i);
-      assertEquals(pii.next(), 2 * i);
+      assertEquals(pii.nextInt(), 2 * i);
     }
   }
 
@@ -249,7 +249,7 @@ public class TestIterators {
     PeekableIntIterator it = b.getIntIterator();
     it.advanceIfNeeded(4096);
     while (it.hasNext()) {
-      it.next();
+      it.nextInt();
     }
   }
 
@@ -263,7 +263,7 @@ public class TestIterators {
       PeekableIntIterator pii = bitmap.getIntIterator();
       pii.advanceIfNeeded(i);
       assertEquals(pii.peekNext(), i);
-      assertEquals(pii.next(), i);
+      assertEquals(pii.nextInt(), i);
     }
   }
   

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestMemoryMapping.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestMemoryMapping.java
@@ -567,7 +567,7 @@ public class TestMemoryMapping {
       oldvalue = -1;
       int card2 = 0;
       while (i.hasNext()) {
-        final int x = i.next();
+        final int x = i.nextInt();
         assertTrue(target.contains(x));
         if (x > oldvalue) {
           ++card2;
@@ -607,7 +607,7 @@ public class TestMemoryMapping {
       oldvalue = -1;
       int card2 = 0;
       while (i.hasNext()) {
-        final int x = i.next();
+        final int x = i.nextInt();
         assertTrue(ramtarget.contains(x));
         if (x > oldvalue) {
           ++card2;
@@ -637,7 +637,7 @@ public class TestMemoryMapping {
     MutableRoaringBitmap copy2 = new MutableRoaringBitmap();
     IntIterator i = rb.getIntIterator();
     while (i.hasNext()) {
-      copy2.add(i.next());
+      copy2.add(i.nextInt());
     }
     assertTrue(copy2.equals(rb));
     System.out.println("[TestMemoryMapping] testing a custom iterator copy  ok");

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRange.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRange.java
@@ -16,8 +16,8 @@ public class TestRange {
     rb.add(0);
     rb.flip(1L, 2L);
     IntIterator i = rb.getIntIterator();
-    assertEquals(0, i.next());
-    assertEquals(1, i.next());
+    assertEquals(0, i.nextInt());
+    assertEquals(1, i.nextInt());
     assertFalse(i.hasNext());
   }
   

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
@@ -123,7 +123,7 @@ public class TestRoaringBitmap {
         PeekableIntIterator it = bitmap.getIntIterator();
         it.advanceIfNeeded(100620278);
         assertTrue(it.hasNext());
-        assertEquals(101993170, it.next());
+        assertEquals(101993170, it.nextInt());
         assertFalse(it.hasNext());
 	}
 	
@@ -138,7 +138,7 @@ public class TestRoaringBitmap {
         it.wrap(bitmap);
         it.advanceIfNeeded(100620278);
         assertTrue(it.hasNext());
-        assertEquals(101993170, it.next());
+        assertEquals(101993170, it.nextInt());
         assertFalse(it.hasNext());
 	}
 	@Test
@@ -2376,7 +2376,7 @@ public class TestRoaringBitmap {
 
     for (int i = 0; i < (4 << 16) - 1; ++i) {
       assertTrue(iterator.hasNext(), "Error on iteration " + i);
-      assertEquals(i, iterator.next());
+      assertEquals(i, iterator.nextInt());
     }
     assertFalse(iterator.hasNext());
   }
@@ -2450,7 +2450,7 @@ public class TestRoaringBitmap {
 
     for (int i = 0; i < (4 << 16) - 1; ++i) {
       assertTrue(iterator.hasNext(), "Error on iteration " + i);
-      assertEquals(i, iterator.next());
+      assertEquals(i, iterator.nextInt());
     }
     assertFalse(iterator.hasNext());
   }
@@ -2471,7 +2471,7 @@ public class TestRoaringBitmap {
     for (int i = 0; i < (5 << 16); ++i) {
       if ((i != (1 << 14)) && (i != (3 << 16))) {
         assertTrue(iterator.hasNext(), "Error on iteration " + i);
-        assertEquals(i, iterator.next(), "Error on iteration " + i);
+        assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
       }
     }
     assertFalse(iterator.hasNext());
@@ -2491,7 +2491,7 @@ public class TestRoaringBitmap {
     final IntIterator iterator = rb.getIntIterator();
     for (int i = 0; i < (2 << 16) + (2 << 14); ++i) {
       assertTrue(iterator.hasNext(), "Error on iteration " + i);
-      assertEquals(i, iterator.next(), "Error on iteration " + i);
+      assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
     }
     assertFalse(iterator.hasNext());
   }
@@ -2513,7 +2513,7 @@ public class TestRoaringBitmap {
     final IntIterator iterator = rb.getIntIterator();
     for (int i = 0; i < (5 << 16); ++i) {
       assertTrue(iterator.hasNext(), "Error on iteration " + i);
-      assertEquals(i, iterator.next(), "Error on iteration " + i);
+      assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
     }
     assertFalse(iterator.hasNext());
   }
@@ -2538,20 +2538,20 @@ public class TestRoaringBitmap {
     final IntIterator iterator = rb.getIntIterator();
     for (int i = 0; i < (1 << 14); ++i) {
       assertTrue(iterator.hasNext(), "Error on iteration " + i);
-      assertEquals(i, iterator.next(), "Error on iteration " + i);
+      assertEquals(i, iterator.nextInt(), "Error on iteration " + i);
     }
 
     assertTrue(iterator.hasNext());
-    assertEquals((1 << 16) - 1, iterator.next());
+    assertEquals((1 << 16) - 1, iterator.nextInt());
 
     assertTrue(iterator.hasNext());
-    assertEquals(1 << 16, iterator.next());
+    assertEquals(1 << 16, iterator.nextInt());
 
     assertTrue(iterator.hasNext());
-    assertEquals(2 << 16, iterator.next());
+    assertEquals(2 << 16, iterator.nextInt());
 
     assertTrue(iterator.hasNext());
-    assertEquals(3 << 16, iterator.next());
+    assertEquals(3 << 16, iterator.nextInt());
 
     assertFalse(iterator.hasNext());
   }
@@ -2927,7 +2927,7 @@ public class TestRoaringBitmap {
       if (!is.hasNext()) {
         throw new RuntimeException("bug");
       }
-      int x = i.next();
+      int x = i.nextInt();
       copy2.add(x);
       int xs = is.next();
       if (x != xs) {
@@ -2962,7 +2962,7 @@ public class TestRoaringBitmap {
       if (!is.hasNext()) {
         throw new RuntimeException("bug");
       }
-      int x = i.next();
+      int x = i.nextInt();
       copy2.add(x);
       int xs = is.next();
       if (x != xs) {
@@ -3000,7 +3000,7 @@ public class TestRoaringBitmap {
       if (!is.hasNext()) {
         throw new RuntimeException("bug");
       }
-      int x = i.next();
+      int x = i.nextInt();
       copy2.add(x);
       int xs = is.next();
       if (x != xs) {
@@ -3035,7 +3035,7 @@ public class TestRoaringBitmap {
       if (!is.hasNext()) {
         throw new RuntimeException("bug");
       }
-      int x = i.next();
+      int x = i.nextInt();
       copy2.add(x);
       int xs = is.next();
       if (x != xs) {
@@ -3758,7 +3758,7 @@ public class TestRoaringBitmap {
       IntIterator i = rb.getIntIterator();
       IntIterator j = rboff.getIntIterator();
       while(i.hasNext() && j.hasNext()) {
-        assertTrue(i.next() + offset ==  j.next());  
+        assertTrue(i.nextInt() + offset ==  j.nextInt());  
       }System.out.println("offset = "+offset);
       assertTrue(i.hasNext() ==  j.hasNext());
     }
@@ -3767,7 +3767,7 @@ public class TestRoaringBitmap {
       IntIterator i = rb.getIntIterator();
       IntIterator j = rboff.getIntIterator();
       while(i.hasNext() && j.hasNext()) {
-      assertTrue(i.next() + offset ==  j.next());  
+      assertTrue(i.nextInt() + offset ==  j.nextInt());  
       }
       assertTrue(i.hasNext() ==  j.hasNext());
     }
@@ -3818,7 +3818,7 @@ public class TestRoaringBitmap {
       IntIterator i = rb.getIntIterator();
       IntIterator j = rboff.getIntIterator();
       while(i.hasNext() && j.hasNext()) {
-        assertTrue(i.next()  ==  j.next());
+        assertTrue(i.nextInt()  ==  j.nextInt());
       }
       assertTrue(i.hasNext() ==  j.hasNext());
     }
@@ -3834,7 +3834,7 @@ public class TestRoaringBitmap {
       IntIterator i = rb.getIntIterator();
       IntIterator j = rboff.getIntIterator();
       while(i.hasNext() && j.hasNext()) {
-        assertTrue(i.next() ==  j.next());
+        assertTrue(i.nextInt() ==  j.nextInt());
       }
       assertTrue(i.hasNext() ==  j.hasNext());
     }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRunContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRunContainer.java
@@ -55,7 +55,7 @@ public class TestRunContainer {
     IntIterator x = m2.getReverseIntIterator();
     int count = 0;
     while(x.hasNext()) {
-      x.next();
+      x.nextInt();
       count++;
     }
     assertEquals(m2.getCardinality(), count);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -65,7 +65,7 @@ public class TestRoaring64Bitmap {
     LongIterator longIterator = roaring64Bitmap.getLongIterator();
     int i = 0;
     while (longIterator.hasNext()) {
-      long actual = longIterator.next();
+      long actual = longIterator.nextLong();
       Assertions.assertTrue(source.contains(actual));
       i++;
     }
@@ -86,7 +86,7 @@ public class TestRoaring64Bitmap {
     LongIterator longIterator = roaring64Bitmap.getLongIterator();
     int i = 0;
     while (longIterator.hasNext()) {
-      long actual = longIterator.next();
+      long actual = longIterator.nextLong();
       Assertions.assertTrue(source.contains(actual));
       i++;
     }
@@ -143,7 +143,7 @@ public class TestRoaring64Bitmap {
 
     LongIterator iterator = map.getLongIterator();
     assertTrue(iterator.hasNext());
-    assertEquals(0, iterator.next());
+    assertEquals(0, iterator.nextLong());
     assertEquals(0, map.select(0));
     assertTrue(map.contains(0));
     assertFalse(iterator.hasNext());
@@ -166,7 +166,7 @@ public class TestRoaring64Bitmap {
 
     LongIterator iterator = map.getLongIterator();
     assertTrue(iterator.hasNext());
-    assertEquals(-1, iterator.next());
+    assertEquals(-1, iterator.nextLong());
     assertEquals(-1, map.select(0));
     assertTrue(map.contains(-1));
     assertFalse(iterator.hasNext());
@@ -191,11 +191,11 @@ public class TestRoaring64Bitmap {
 
     LongIterator iterator = map.getLongIterator();
     assertTrue(iterator.hasNext());
-    assertEquals(123, iterator.next());
+    assertEquals(123, iterator.nextLong());
     assertEquals(123, map.select(0));
     assertTrue(map.contains(123));
     assertTrue(iterator.hasNext());
-    assertEquals(234, iterator.next());
+    assertEquals(234, iterator.nextLong());
     assertEquals(234, map.select(1));
     assertTrue(map.contains(234));
     assertFalse(iterator.hasNext());
@@ -232,14 +232,14 @@ public class TestRoaring64Bitmap {
     Roaring64Bitmap map = newDefaultCtor();
     map.addLong(0);
     assertTrue(map.getLongIterator().hasNext());
-    assertEquals(0, map.getLongIterator().next());
+    assertEquals(0, map.getLongIterator().nextLong());
   }
 
   @Test
   public void testIterator_NextWithoutHasNext_Empty() {
     assertThrows(IllegalStateException.class, () -> {
       Roaring64Bitmap map = newDefaultCtor();
-      map.getLongIterator().next();
+      map.getLongIterator().nextLong();
     });
   }
 
@@ -249,7 +249,7 @@ public class TestRoaring64Bitmap {
     map.addLong(Long.MAX_VALUE);
     LongIterator iterator = map.getLongIterator();
     assertTrue(iterator.hasNext());
-    assertEquals(Long.MAX_VALUE, iterator.next());
+    assertEquals(Long.MAX_VALUE, iterator.nextLong());
     assertEquals(Long.MAX_VALUE, map.select(0));
     assertFalse(iterator.hasNext());
     assertEquals(1, map.getLongCardinality());
@@ -269,7 +269,7 @@ public class TestRoaring64Bitmap {
     map.addLong(Long.MIN_VALUE);
     LongIterator iterator = map.getLongIterator();
     assertTrue(iterator.hasNext());
-    assertEquals(Long.MIN_VALUE, iterator.next());
+    assertEquals(Long.MIN_VALUE, iterator.nextLong());
     assertEquals(Long.MIN_VALUE, map.select(0));
     assertFalse(iterator.hasNext());
     assertEquals(1, map.getLongCardinality());
@@ -291,13 +291,13 @@ public class TestRoaring64Bitmap {
     map.addLong(1);
     map.addLong(Long.MAX_VALUE);
     LongIterator iterator = map.getLongIterator();
-    assertEquals(0, iterator.next());
+    assertEquals(0, iterator.nextLong());
     assertEquals(0, map.select(0));
-    assertEquals(1, iterator.next());
+    assertEquals(1, iterator.nextLong());
     assertEquals(1, map.select(1));
-    assertEquals(Long.MAX_VALUE, iterator.next());
+    assertEquals(Long.MAX_VALUE, iterator.nextLong());
     assertEquals(Long.MAX_VALUE, map.select(2));
-    assertEquals(Long.MIN_VALUE, iterator.next());
+    assertEquals(Long.MIN_VALUE, iterator.nextLong());
     assertEquals(Long.MIN_VALUE, map.select(3));
     assertFalse(iterator.hasNext());
     assertEquals(4, map.getLongCardinality());
@@ -328,9 +328,9 @@ public class TestRoaring64Bitmap {
     map.addLong(234);
     LongIterator iterator = map.getReverseLongIterator();
     assertTrue(iterator.hasNext());
-    assertEquals(234, iterator.next());
+    assertEquals(234, iterator.nextLong());
     assertTrue(iterator.hasNext());
-    assertEquals(123, iterator.next());
+    assertEquals(123, iterator.nextLong());
     assertFalse(iterator.hasNext());
   }
 
@@ -342,9 +342,9 @@ public class TestRoaring64Bitmap {
     map.addLong(Long.MAX_VALUE);
     LongIterator iterator = map.getReverseLongIterator();
     assertTrue(iterator.hasNext());
-    assertEquals(Long.MAX_VALUE, iterator.next());
+    assertEquals(Long.MAX_VALUE, iterator.nextLong());
     assertTrue(iterator.hasNext());
-    assertEquals(123, iterator.next());
+    assertEquals(123, iterator.nextLong());
     assertFalse(iterator.hasNext());
   }
 
@@ -485,8 +485,8 @@ public class TestRoaring64Bitmap {
     map.addLong(positive);
     map.addLong(negative);
     LongIterator it = map.getLongIterator();
-    long first = it.next();
-    long last = it.next();
+    long first = it.nextLong();
+    long last = it.nextLong();
     assertEquals(positive, first);
     assertEquals(negative, last);
   }
@@ -1113,7 +1113,7 @@ public class TestRoaring64Bitmap {
     int a = 0xFFFFFFFF;  // -1 in two's compliment
     map.addInt(a);
     assertEquals(map.getIntCardinality(), 1);
-    long addedInt = map.getLongIterator().next();
+    long addedInt = map.getLongIterator().nextLong();
     assertEquals(0xFFFFFFFFL, addedInt);
   }
 
@@ -1549,12 +1549,12 @@ public class TestRoaring64Bitmap {
     pii = bitmap.getLongIterator();
     for(int i = 0; i < data.length; ++i) {
       pii.advanceIfNeeded(data[i]);
-      assertEquals(data[i], pii.next());
+      assertEquals(data[i], pii.nextLong());
     }
     pii = bitmap.getLongIterator();
     for(int i = 1; i < data.length; ++i) {
       pii.advanceIfNeeded(data[i-1]);
-      assertEquals(data[i-1], pii.next());
+      assertEquals(data[i-1], pii.nextLong());
       assertEquals(data[i], pii.peekNext());
     }
     bitmap.getLongIterator().advanceIfNeeded(-1); // should not crash
@@ -1575,7 +1575,7 @@ public class TestRoaring64Bitmap {
       long expected = 2 * i + Integer.MAX_VALUE;
       pii.advanceIfNeeded(expected);
       assertEquals(expected, pii.peekNext());
-      assertEquals(expected, pii.next());
+      assertEquals(expected, pii.nextLong());
     }
 
     // use iterator from
@@ -1583,7 +1583,7 @@ public class TestRoaring64Bitmap {
       long expected = 2 * i + Integer.MAX_VALUE;
       PeekableLongIterator pii = bitmap.getLongIteratorFrom(expected);
       assertEquals(expected, pii.peekNext());
-      assertEquals(expected, pii.next());
+      assertEquals(expected, pii.nextLong());
     }
   }
   
@@ -1608,7 +1608,7 @@ public class TestRoaring64Bitmap {
         long expected = 2 * i + base;
         pii.advanceIfNeeded(expected);
         assertEquals(expected, pii.peekNext());
-        assertEquals(expected, pii.next());
+        assertEquals(expected, pii.nextLong());
       }
 
       // use iterator from
@@ -1616,7 +1616,7 @@ public class TestRoaring64Bitmap {
         long expected = 2 * i + base;
         PeekableLongIterator pii = bitmap.getLongIteratorFrom(expected);
         assertEquals(expected, pii.peekNext());
-        assertEquals(expected, pii.next());
+        assertEquals(expected, pii.nextLong());
       }
     }
   }
@@ -1632,13 +1632,13 @@ public class TestRoaring64Bitmap {
       PeekableLongIterator pii = bitmap.getLongIterator();
       pii.advanceIfNeeded(i);
       assertEquals(i, pii.peekNext());
-      assertEquals(i, pii.next());
+      assertEquals(i, pii.nextLong());
     }
     // use iterator from
     for(int i = 4; i < 100000; ++i) {
       PeekableLongIterator pii = bitmap.getLongIteratorFrom(i);
       assertEquals(i, pii.peekNext());
-      assertEquals(i, pii.next());
+      assertEquals(i, pii.nextLong());
     }
   }
   
@@ -1665,12 +1665,12 @@ public class TestRoaring64Bitmap {
     pii = bitmap.getReverseLongIterator();
     for(int i = data.length -1; i >= 0 ; --i) {
       pii.advanceIfNeeded(data[i]);
-      assertEquals(data[i], pii.next());
+      assertEquals(data[i], pii.nextLong());
     }
     pii = bitmap.getReverseLongIterator();
     for(int i = data.length -2; i >= 0 ; --i) {
       pii.advanceIfNeeded(data[i+1]);
-      pii.next();
+      pii.nextLong();
       assertEquals(data[i],pii.peekNext() );
     }
     bitmap.getReverseLongIterator().advanceIfNeeded(-1);// should not crash
@@ -1690,7 +1690,7 @@ public class TestRoaring64Bitmap {
       PeekableLongIterator pii = bitmap.getReverseLongIterator();
       pii.advanceIfNeeded(expected);
       assertEquals(expected, pii.peekNext());
-      assertEquals(expected, pii.next());
+      assertEquals(expected, pii.nextLong());
     }
 
     // use iterator from
@@ -1698,7 +1698,7 @@ public class TestRoaring64Bitmap {
       long expected = 2 * i + Integer.MAX_VALUE;
       PeekableLongIterator pii = bitmap.getReverseLongIteratorFrom(expected);
       assertEquals(expected, pii.peekNext());
-      assertEquals(expected, pii.next());
+      assertEquals(expected, pii.nextLong());
     }
   }
   
@@ -1723,7 +1723,7 @@ public class TestRoaring64Bitmap {
         long expected = 2 * i + base;
         pii.advanceIfNeeded(expected);
         assertEquals(expected, pii.peekNext());
-        assertEquals(expected, pii.next());
+        assertEquals(expected, pii.nextLong());
       }
 
       // use iterator from
@@ -1731,7 +1731,7 @@ public class TestRoaring64Bitmap {
         long expected = 2 * i + base;
         PeekableLongIterator pii = bitmap.getReverseLongIteratorFrom(expected);
         assertEquals(expected, pii.peekNext());
-        assertEquals(expected, pii.next());
+        assertEquals(expected, pii.nextLong());
       }
     }
   }
@@ -1747,14 +1747,14 @@ public class TestRoaring64Bitmap {
       PeekableLongIterator pii = bitmap.getReverseLongIterator();
       pii.advanceIfNeeded(i);
       assertEquals(i, pii.peekNext());
-      assertEquals(i, pii.next());
+      assertEquals(i, pii.nextLong());
     }
 
     // use iterator from
     for(int i = 99999; i >= 4; --i) {
       PeekableLongIterator pii = bitmap.getReverseLongIteratorFrom(i);
       assertEquals(i, pii.peekNext());
-      assertEquals(i, pii.next());
+      assertEquals(i, pii.nextLong());
     }
   }
   
@@ -1785,12 +1785,12 @@ public class TestRoaring64Bitmap {
     PeekableLongIterator bitIt = bitset.getLongIterator();
 
     assertEquals(b1, bitIt.peekNext());
-    assertEquals(b1, bitIt.next());
+    assertEquals(b1, bitIt.nextLong());
 
     assertTrue(bitset.contains(p2));
     bitIt.advanceIfNeeded(p2);
     assertEquals(p2, bitIt.peekNext());
-    assertEquals(p2, bitIt.next());
+    assertEquals(p2, bitIt.nextLong());
 
     // advancing to a value not in either range should go to the first value of second range
     assertFalse(bitset.contains(pgap));
@@ -1803,7 +1803,7 @@ public class TestRoaring64Bitmap {
     assertTrue(bitset.contains(b2));
     bitIt.advanceIfNeeded(b2);
     assertEquals(b2, bitIt.peekNext());
-    assertEquals(b2, bitIt.next());
+    assertEquals(b2, bitIt.nextLong());
   }
 
   @Test
@@ -1829,12 +1829,12 @@ public class TestRoaring64Bitmap {
     PeekableLongIterator bitIt = bitset.getLongIterator();
 
     assertEquals(b1, bitIt.peekNext());
-    assertEquals(b1, bitIt.next());
+    assertEquals(b1, bitIt.nextLong());
 
     assertTrue(bitset.contains(p2));
     bitIt.advanceIfNeeded(p2);
     assertEquals(p2, bitIt.peekNext());
-    assertEquals(p2, bitIt.next());
+    assertEquals(p2, bitIt.nextLong());
 
     // advancing to a value not in any range but beyond second range
     // should go to the first value of third range
@@ -1848,7 +1848,7 @@ public class TestRoaring64Bitmap {
     assertTrue(bitset.contains(b3));
     bitIt.advanceIfNeeded(b3);
     assertEquals(b3, bitIt.peekNext());
-    assertEquals(b3, bitIt.next());
+    assertEquals(b3, bitIt.nextLong());
 
     // reset
     bitIt = bitset.getLongIterator();
@@ -1863,7 +1863,7 @@ public class TestRoaring64Bitmap {
 
     bitIt.advanceIfNeeded(b3);
     assertEquals(b3, bitIt.peekNext());
-    assertEquals(b3, bitIt.next());
+    assertEquals(b3, bitIt.nextLong());
   }
 
   @Test
@@ -1884,12 +1884,12 @@ public class TestRoaring64Bitmap {
     PeekableLongIterator bitIt = bitset.getReverseLongIterator();
 
     assertEquals(b2e - 1L, bitIt.peekNext());
-    assertEquals(b2e - 1L, bitIt.next());
+    assertEquals(b2e - 1L, bitIt.nextLong());
 
     assertTrue(bitset.contains(p2));
     bitIt.advanceIfNeeded(p2);
     assertEquals(p2, bitIt.peekNext());
-    assertEquals(p2, bitIt.next());
+    assertEquals(p2, bitIt.nextLong());
 
     // advancing to a value not in either range should go to the first value of second range
     assertFalse(bitset.contains(pgap));
@@ -1902,7 +1902,7 @@ public class TestRoaring64Bitmap {
     assertTrue(bitset.contains(b2));
     bitIt.advanceIfNeeded(b1e);
     assertEquals(b1e - 1L, bitIt.peekNext());
-    assertEquals(b1e - 1L, bitIt.next());
+    assertEquals(b1e - 1L, bitIt.nextLong());
   }
 
   @Test
@@ -1927,12 +1927,12 @@ public class TestRoaring64Bitmap {
     PeekableLongIterator bitIt = bitset.getReverseLongIterator();
 
     assertEquals(b3e - 1L, bitIt.peekNext());
-    assertEquals(b3e - 1L, bitIt.next());
+    assertEquals(b3e - 1L, bitIt.nextLong());
 
     assertTrue(bitset.contains(p3));
     bitIt.advanceIfNeeded(p3);
     assertEquals(p3, bitIt.peekNext());
-    assertEquals(p3, bitIt.next());
+    assertEquals(p3, bitIt.nextLong());
 
     // advancing to a value not in any range but beyond second range
     // should go to the first value of third range
@@ -1946,7 +1946,7 @@ public class TestRoaring64Bitmap {
     assertTrue(bitset.contains(b1));
     bitIt.advanceIfNeeded(b1e);
     assertEquals(b1e - 1L, bitIt.peekNext());
-    assertEquals(b1e - 1L, bitIt.next());
+    assertEquals(b1e - 1L, bitIt.nextLong());
 
     // reset
     bitIt = bitset.getReverseLongIterator();
@@ -1961,7 +1961,7 @@ public class TestRoaring64Bitmap {
 
     bitIt.advanceIfNeeded(b1e);
     assertEquals(b1e - 1L, bitIt.peekNext());
-    assertEquals(b1e - 1L, bitIt.next());
+    assertEquals(b1e - 1L, bitIt.nextLong());
   }
 
   @Test
@@ -2181,7 +2181,7 @@ public class TestRoaring64Bitmap {
     LongIterator it = rb.getLongIterator();
     int count = 0;
     while(it.hasNext()) {
-        it.next();
+        it.nextLong();
         count++;
     }
     assertEquals(count, 7);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
@@ -98,7 +98,7 @@ public class TestRoaring64NavigableMap {
       LongIterator iterator = map.getLongIterator();
 
       assertTrue(iterator.hasNext());
-      assertEquals(0, iterator.next());
+      assertEquals(0, iterator.nextLong());
       assertEquals(0, map.select(0));
       assertTrue(map.contains(0));
 
@@ -128,7 +128,7 @@ public class TestRoaring64NavigableMap {
       LongIterator iterator = map.getLongIterator();
 
       assertTrue(iterator.hasNext());
-      assertEquals(-1, iterator.next());
+      assertEquals(-1, iterator.nextLong());
       assertEquals(-1, map.select(0));
       assertTrue(map.contains(-1));
 
@@ -163,7 +163,7 @@ public class TestRoaring64NavigableMap {
       LongIterator iterator = map.getLongIterator();
 
       assertTrue(iterator.hasNext());
-      assertEquals(0, iterator.next());
+      assertEquals(0, iterator.nextLong());
       assertEquals(0, map.select(0));
       assertTrue(map.contains(0));
 
@@ -193,12 +193,12 @@ public class TestRoaring64NavigableMap {
       LongIterator iterator = map.getLongIterator();
 
       assertTrue(iterator.hasNext());
-      assertEquals(123, iterator.next());
+      assertEquals(123, iterator.nextLong());
       assertEquals(123, map.select(0));
       assertTrue(map.contains(123));
 
       assertTrue(iterator.hasNext());
-      assertEquals(234, iterator.next());
+      assertEquals(234, iterator.nextLong());
       assertEquals(234, map.select(1));
       assertTrue(map.contains(234));
 
@@ -264,7 +264,7 @@ public class TestRoaring64NavigableMap {
     map.addLong(0);
 
     assertTrue(map.getLongIterator().hasNext());
-    assertEquals(0, map.getLongIterator().next());
+    assertEquals(0, map.getLongIterator().nextLong());
   }
 
   @Test
@@ -272,7 +272,7 @@ public class TestRoaring64NavigableMap {
     assertThrows(IllegalStateException.class, () -> {
       Roaring64NavigableMap map = newDefaultCtor();
 
-      map.getLongIterator().next();
+      map.getLongIterator().nextLong();
     });
   }
 
@@ -285,7 +285,7 @@ public class TestRoaring64NavigableMap {
     {
       LongIterator iterator = map.getLongIterator();
       assertTrue(iterator.hasNext());
-      assertEquals(Long.MAX_VALUE, iterator.next());
+      assertEquals(Long.MAX_VALUE, iterator.nextLong());
       assertEquals(Long.MAX_VALUE, map.select(0));
       assertFalse(iterator.hasNext());
     }
@@ -312,7 +312,7 @@ public class TestRoaring64NavigableMap {
     {
       LongIterator iterator = map.getLongIterator();
       assertTrue(iterator.hasNext());
-      assertEquals(Long.MIN_VALUE, iterator.next());
+      assertEquals(Long.MIN_VALUE, iterator.nextLong());
       assertEquals(Long.MIN_VALUE, map.select(0));
       assertFalse(iterator.hasNext());
     }
@@ -340,13 +340,13 @@ public class TestRoaring64NavigableMap {
     {
       LongIterator iterator = map.getLongIterator();
       assertTrue(iterator.hasNext());
-      assertEquals(Long.MIN_VALUE, iterator.next());
+      assertEquals(Long.MIN_VALUE, iterator.nextLong());
       assertEquals(Long.MIN_VALUE, map.select(0));
-      assertEquals(0, iterator.next());
+      assertEquals(0, iterator.nextLong());
       assertEquals(0, map.select(1));
-      assertEquals(1, iterator.next());
+      assertEquals(1, iterator.nextLong());
       assertEquals(1, map.select(2));
-      assertEquals(Long.MAX_VALUE, iterator.next());
+      assertEquals(Long.MAX_VALUE, iterator.nextLong());
       assertEquals(Long.MAX_VALUE, map.select(3));
       assertFalse(iterator.hasNext());
     }
@@ -383,9 +383,9 @@ public class TestRoaring64NavigableMap {
     {
       LongIterator iterator = map.getReverseLongIterator();
       assertTrue(iterator.hasNext());
-      assertEquals(234, iterator.next());
+      assertEquals(234, iterator.nextLong());
       assertTrue(iterator.hasNext());
-      assertEquals(123, iterator.next());
+      assertEquals(123, iterator.nextLong());
       assertFalse(iterator.hasNext());
     }
   }
@@ -400,9 +400,9 @@ public class TestRoaring64NavigableMap {
     {
       LongIterator iterator = map.getReverseLongIterator();
       assertTrue(iterator.hasNext());
-      assertEquals(Long.MAX_VALUE, iterator.next());
+      assertEquals(Long.MAX_VALUE, iterator.nextLong());
       assertTrue(iterator.hasNext());
-      assertEquals(123, iterator.next());
+      assertEquals(123, iterator.nextLong());
       assertFalse(iterator.hasNext());
     }
   }
@@ -655,8 +655,8 @@ public class TestRoaring64NavigableMap {
     map.addLong(positive);
     map.addLong(negative);
     LongIterator it = map.getLongIterator();
-    long first = it.next();
-    long last = it.next();
+    long first = it.nextLong();
+    long last = it.nextLong();
     assertEquals(negative, first);
     assertEquals(positive, last);
   }
@@ -669,8 +669,8 @@ public class TestRoaring64NavigableMap {
     map.addLong(positive);
     map.addLong(negative);
     LongIterator it = map.getLongIterator();
-    long first = it.next();
-    long last = it.next();
+    long first = it.nextLong();
+    long last = it.nextLong();
     assertEquals(positive, first);
     assertEquals(negative, last);
   }

--- a/bsi/src/main/java/org/roaringbitmap/bsi/buffer/BitSliceIndexBase.java
+++ b/bsi/src/main/java/org/roaringbitmap/bsi/buffer/BitSliceIndexBase.java
@@ -321,7 +321,7 @@ public class BitSliceIndexBase {
       IntIterator i = F.getIntIterator();
       MutableRoaringBitmap turnoff = new MutableRoaringBitmap();
       while (i.hasNext() && n > 0) {
-        turnoff.add(i.next());
+        turnoff.add(i.nextInt());
         --n;
       }
       F.andNot(turnoff);

--- a/examples/src/main/java/Bitmap64.java
+++ b/examples/src/main/java/Bitmap64.java
@@ -8,6 +8,6 @@ public class Bitmap64 {
       System.out.println(r.contains(1)); // true
       System.out.println(r.contains(3)); // false
       LongIterator i = r.getLongIterator();
-      while(i.hasNext()) System.out.println(i.next());
+      while(i.hasNext()) System.out.println(i.nextLong());
   }
 }

--- a/examples/src/main/java/PagedIterator.java
+++ b/examples/src/main/java/PagedIterator.java
@@ -15,7 +15,7 @@ public class PagedIterator {
         while(i.hasNext()) {
           // we print a page
           for(int k = 0; (k < pageSize) && i.hasNext() ; k++) {
-            System.out.print(i.next()+" ");
+            System.out.print(i.nextInt()+" ");
           }
           System.out.println();
         }

--- a/fuzz-tests/src/test/java/org/roaringbitmap/BufferFuzzer.java
+++ b/fuzz-tests/src/test/java/org/roaringbitmap/BufferFuzzer.java
@@ -406,7 +406,7 @@ public class BufferFuzzer {
               IntIterator it = and.getBatchIterator().asIntIterator(new int[16]);
               int removed = 0;
               while (it.hasNext()) {
-                l.remove(it.next());
+                l.remove(it.nextInt());
                 ++removed;
               }
               return removed == intersection;
@@ -456,7 +456,7 @@ public class BufferFuzzer {
               IntIterator it = and.getBatchIterator().asIntIterator(new int[16]);
               l.remove(first, last + 1);
               while (it.hasNext()) {
-                long next = toUnsignedLong(it.next());
+                long next = toUnsignedLong(it.nextInt());
                 if (l.intersects(first, next) || (first != next && !r.intersects(first, next))) {
                   return false;
                 }

--- a/fuzz-tests/src/test/java/org/roaringbitmap/Fuzzer.java
+++ b/fuzz-tests/src/test/java/org/roaringbitmap/Fuzzer.java
@@ -421,7 +421,7 @@ public class Fuzzer {
               IntIterator it = and.getBatchIterator().asIntIterator(new int[16]);
               int removed = 0;
               while (it.hasNext()) {
-                l.remove(it.next());
+                l.remove(it.nextInt());
                 ++removed;
               }
               return removed == intersection;
@@ -471,7 +471,7 @@ public class Fuzzer {
               IntIterator it = and.getBatchIterator().asIntIterator(new int[16]);
               l.remove(first, last + 1);
               while (it.hasNext()) {
-                long next = toUnsignedLong(it.next());
+                long next = toUnsignedLong(it.nextInt());
                 if (l.intersects(first, next) || (first != next && !r.intersects(first, next))) {
                   return false;
                 }

--- a/jmh/src/jmh/java/org/roaringbitmap/iteration/BatchIteratorBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/iteration/BatchIteratorBenchmark.java
@@ -38,7 +38,7 @@ public class BatchIteratorBenchmark {
     int blackhole = 0;
     PeekableIntIterator it = bitmap.getIntIterator();
     while (it.hasNext()) {
-      blackhole ^= it.next();
+      blackhole ^= it.nextInt();
     }
     return blackhole;
   }
@@ -61,7 +61,7 @@ public class BatchIteratorBenchmark {
     int blackhole = 0;
     IntIterator it = bitmap.getBatchIterator().asIntIterator(buffer);
     while (it.hasNext()) {
-      blackhole ^= it.next();
+      blackhole ^= it.nextInt();
     }
     return blackhole;
   }

--- a/jmh/src/jmh/java/org/roaringbitmap/iteration/Concatenation.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/iteration/Concatenation.java
@@ -82,7 +82,7 @@ public class Concatenation {
       BitSetWithOffset bit = bitSets[i];
       PeekableIntIterator peekableIter = bit.bitmap.getIntIterator();
       while(peekableIter.hasNext()){
-        int currentBit = peekableIter.next();
+        int currentBit = peekableIter.nextInt();
         result.add(currentBit + bit.offset);
       }
     }

--- a/jmh/src/jmh/java/org/roaringbitmap/iteration/IteratorsBenchmark32.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/iteration/IteratorsBenchmark32.java
@@ -38,7 +38,7 @@ public class IteratorsBenchmark32 {
     IntIterator intIterator = benchmarkState.bitmap_a.getIntIterator();
     int result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextInt();
 
     }
     return result;
@@ -54,7 +54,7 @@ public class IteratorsBenchmark32 {
 
     int result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextInt();
 
     }
     return result;
@@ -79,7 +79,7 @@ public class IteratorsBenchmark32 {
     IntIterator intIterator = benchmarkState.bitmap_b.getIntIterator();
     int result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextInt();
 
     }
     return result;
@@ -95,7 +95,7 @@ public class IteratorsBenchmark32 {
 
     int result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextInt();
 
     }
     return result;
@@ -120,7 +120,7 @@ public class IteratorsBenchmark32 {
     IntIterator intIterator = benchmarkState.bitmap_c.getIntIterator();
     int result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextInt();
 
     }
     return result;
@@ -136,7 +136,7 @@ public class IteratorsBenchmark32 {
 
     int result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextInt();
 
     }
     return result;
@@ -149,7 +149,7 @@ public class IteratorsBenchmark32 {
     IntIterator intIterator = benchmarkState.bitmap_a.getReverseIntIterator();
     int result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextInt();
 
     }
     return result;
@@ -165,7 +165,7 @@ public class IteratorsBenchmark32 {
 
     int result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextInt();
 
     }
     return result;
@@ -178,7 +178,7 @@ public class IteratorsBenchmark32 {
     IntIterator intIterator = benchmarkState.bitmap_b.getReverseIntIterator();
     int result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextInt();
 
     }
     return result;
@@ -194,7 +194,7 @@ public class IteratorsBenchmark32 {
 
     int result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextInt();
 
     }
     return result;
@@ -207,7 +207,7 @@ public class IteratorsBenchmark32 {
     IntIterator intIterator = benchmarkState.bitmap_c.getReverseIntIterator();
     int result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextInt();
 
     }
     return result;
@@ -223,7 +223,7 @@ public class IteratorsBenchmark32 {
 
     int result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextInt();
 
     }
     return result;

--- a/jmh/src/jmh/java/org/roaringbitmap/iteration/IteratorsBenchmark64.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/iteration/IteratorsBenchmark64.java
@@ -39,7 +39,7 @@ public class IteratorsBenchmark64 {
     LongIterator intIterator = benchmarkState.bitmap_a.getLongIterator();
     long result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextLong();
 
     }
     return result;
@@ -63,7 +63,7 @@ public class IteratorsBenchmark64 {
     LongIterator intIterator = benchmarkState.bitmap_b.getLongIterator();
     long result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextLong();
 
     }
     return result;
@@ -87,7 +87,7 @@ public class IteratorsBenchmark64 {
     LongIterator intIterator = benchmarkState.bitmap_c.getLongIterator();
     long result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextLong();
 
     }
     return result;
@@ -100,7 +100,7 @@ public class IteratorsBenchmark64 {
     LongIterator intIterator = benchmarkState.bitmap_a.getReverseLongIterator();
     long result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextLong();
 
     }
     return result;
@@ -113,7 +113,7 @@ public class IteratorsBenchmark64 {
     LongIterator intIterator = benchmarkState.bitmap_b.getReverseLongIterator();
     long result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextLong();
 
     }
     return result;
@@ -126,7 +126,7 @@ public class IteratorsBenchmark64 {
     LongIterator intIterator = benchmarkState.bitmap_c.getReverseLongIterator();
     long result = 0;
     while (intIterator.hasNext()) {
-      result = intIterator.next();
+      result = intIterator.nextLong();
 
     }
     return result;

--- a/jmh/src/jmh/java/org/roaringbitmap/iteration/IteratorsBenchmarkRoaring64Bmp.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/iteration/IteratorsBenchmarkRoaring64Bmp.java
@@ -35,7 +35,7 @@ public class IteratorsBenchmarkRoaring64Bmp {
     LongIterator longIterator = benchmarkState.bitmap_a.getLongIterator();
     long result = 0;
     while (longIterator.hasNext()) {
-      result = longIterator.next();
+      result = longIterator.nextLong();
 
     }
     return result;
@@ -59,7 +59,7 @@ public class IteratorsBenchmarkRoaring64Bmp {
     LongIterator longIterator = benchmarkState.bitmap_b.getLongIterator();
     long result = 0;
     while (longIterator.hasNext()) {
-      result = longIterator.next();
+      result = longIterator.nextLong();
 
     }
     return result;
@@ -83,7 +83,7 @@ public class IteratorsBenchmarkRoaring64Bmp {
     LongIterator longIterator = benchmarkState.bitmap_c.getLongIterator();
     long result = 0;
     while (longIterator.hasNext()) {
-      result = longIterator.next();
+      result = longIterator.nextLong();
 
     }
     return result;
@@ -96,7 +96,7 @@ public class IteratorsBenchmarkRoaring64Bmp {
     LongIterator longIterator = benchmarkState.bitmap_a.getReverseLongIterator();
     long result = 0;
     while (longIterator.hasNext()) {
-      result = longIterator.next();
+      result = longIterator.nextLong();
 
     }
     return result;
@@ -108,7 +108,7 @@ public class IteratorsBenchmarkRoaring64Bmp {
     LongIterator longIterator = benchmarkState.bitmap_b.getReverseLongIterator();
     long result = 0;
     while (longIterator.hasNext()) {
-      result = longIterator.next();
+      result = longIterator.nextLong();
 
     }
     return result;
@@ -121,7 +121,7 @@ public class IteratorsBenchmarkRoaring64Bmp {
     LongIterator longIterator = benchmarkState.bitmap_c.getReverseLongIterator();
     long result = 0;
     while (longIterator.hasNext()) {
-      result = longIterator.next();
+      result = longIterator.nextLong();
 
     }
     return result;

--- a/jmh/src/jmh/java/org/roaringbitmap/realdata/RealDataBenchmarkIterate.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/realdata/RealDataBenchmarkIterate.java
@@ -27,4 +27,16 @@ public class RealDataBenchmarkIterate {
     return total;
   }
 
+  @Benchmark
+  public int iterateInt(RealDataBenchmarkState bs) {
+    int total = 0;
+    for (int k = 0; k < bs.bitmaps.size(); ++k) {
+      Bitmap bitmap = bs.bitmaps.get(k);
+      BitmapIterator i = bitmap.iterator();
+      while (i.hasNext()) {
+        total += i.nextInt();
+      }
+    }
+    return total;
+  }
 }

--- a/jmh/src/jmh/java/org/roaringbitmap/realdata/RealDataBenchmarkOr.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/realdata/RealDataBenchmarkOr.java
@@ -28,7 +28,7 @@ public class RealDataBenchmarkOr {
     for (int k = 0; k + 1 < bs.bitmaps.size(); ++k) {
       BitmapIterator i = bs.bitmaps.get(k).or(bs.bitmaps.get(k + 1)).iterator();
       if (i.hasNext()) {
-        total += i.next();
+        total += i.nextInt();
       }
     }
     return total;

--- a/jmh/src/jmh/java/org/roaringbitmap/realdata/RealDataBenchmarkReverseIterate.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/realdata/RealDataBenchmarkReverseIterate.java
@@ -21,7 +21,7 @@ public class RealDataBenchmarkReverseIterate {
       Bitmap bitmap = bs.bitmaps.get(k);
       BitmapIterator i = bitmap.reverseIterator();
       while (i.hasNext()) {
-        total += i.next();
+        total += i.nextInt();
       }
     }
     return total;

--- a/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/BitmapIterator.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/BitmapIterator.java
@@ -1,9 +1,9 @@
 package org.roaringbitmap.realdata.wrapper;
 
-public interface BitmapIterator {
+import java.util.PrimitiveIterator.OfInt;
+
+public interface BitmapIterator extends OfInt{
 
   boolean hasNext();
-
-  int next();
 
 }

--- a/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/ConciseSetIteratorWrapper.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/ConciseSetIteratorWrapper.java
@@ -16,8 +16,13 @@ final class ConciseSetIteratorWrapper implements BitmapIterator {
   }
 
   @Override
-  public int next() {
-    return iterator.nextInt();
+  public Integer next() {
+    return iterator.next();
+  }
+  
+  @Override
+  public int nextInt() {
+    return iterator.next();
   }
 
 }

--- a/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/ConciseSetIteratorWrapper.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/ConciseSetIteratorWrapper.java
@@ -17,7 +17,7 @@ final class ConciseSetIteratorWrapper implements BitmapIterator {
 
   @Override
   public int next() {
-    return iterator.next();
+    return iterator.nextInt();
   }
 
 }

--- a/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/EwahIteratorWrapper.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/EwahIteratorWrapper.java
@@ -16,7 +16,7 @@ final class EwahIteratorWrapper implements BitmapIterator {
   }
 
   @Override
-  public int next() {
+  public int nextInt() {
     return iterator.next();
   }
 

--- a/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/ImmutableRoaringBitmapWrapper.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/ImmutableRoaringBitmapWrapper.java
@@ -23,7 +23,7 @@ final class ImmutableRoaringBitmapWrapper implements Bitmap {
 
   @Override
   public int last() {
-    return bitmap.getReverseIntIterator().next();
+    return bitmap.getReverseIntIterator().nextInt();
   }
 
   @Override

--- a/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/RoaringBitmapWrapper.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/RoaringBitmapWrapper.java
@@ -23,7 +23,7 @@ final class RoaringBitmapWrapper implements Bitmap {
 
   @Override
   public int last() {
-    return bitmap.getReverseIntIterator().next();
+    return bitmap.getReverseIntIterator().nextInt();
   }
 
   @Override

--- a/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/RoaringIteratorWrapper.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/RoaringIteratorWrapper.java
@@ -16,7 +16,7 @@ final class RoaringIteratorWrapper implements BitmapIterator {
   }
 
   @Override
-  public int next() {
+  public int nextInt() {
     return iterator.nextInt();
   }
 

--- a/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/RoaringIteratorWrapper.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/realdata/wrapper/RoaringIteratorWrapper.java
@@ -17,7 +17,7 @@ final class RoaringIteratorWrapper implements BitmapIterator {
 
   @Override
   public int next() {
-    return iterator.next();
+    return iterator.nextInt();
   }
 
 }

--- a/jmh/src/jmh/java/org/roaringbitmap/spe150271/roaring/RealDataBenchmarkOr.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/spe150271/roaring/RealDataBenchmarkOr.java
@@ -28,7 +28,7 @@ public class RealDataBenchmarkOr {
     for (int k = 0; k + 1 < bs.bitmaps.size(); ++k) {
       BitmapIterator i = bs.bitmaps.get(k).or(bs.bitmaps.get(k + 1)).iterator();
       if (i.hasNext()) {
-        total += i.next();
+        total += i.nextInt();
       }
     }
     return total;

--- a/jmh/src/jmh/java/org/roaringbitmap/spe150271/runroaring/RealDataBenchmarkOr.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/spe150271/runroaring/RealDataBenchmarkOr.java
@@ -28,7 +28,7 @@ public class RealDataBenchmarkOr {
     for (int k = 0; k + 1 < bs.bitmaps.size(); ++k) {
       BitmapIterator i = bs.bitmaps.get(k).or(bs.bitmaps.get(k + 1)).iterator();
       if (i.hasNext()) {
-        total += i.next();
+        total += i.nextInt();
       }
     }
     return total;

--- a/jmh/src/test/java/org/roaringbitmap/realdata/RealDataBenchmarkIterateTest.java
+++ b/jmh/src/test/java/org/roaringbitmap/realdata/RealDataBenchmarkIterateTest.java
@@ -23,5 +23,6 @@ public class RealDataBenchmarkIterateTest extends RealDataBenchmarkSanityTest {
     int expected = EXPECTED_RESULTS.get(dataset);
     RealDataBenchmarkIterate bench = new RealDataBenchmarkIterate();
     assertEquals(expected, bench.iterate(bs));
+    assertEquals(expected, bench.iterateInt(bs));    
   }
 }


### PR DESCRIPTION
This makes it easier to use in standard library situations that expect and OfInt or OfLong. The downside is that while practicaly compatible due to autoboxing existing users of the next() method might be slowed down if they do not migrate to nextLong().

### SUMMARY
Since java 8 there has been an interface OfInt and OfLong that is similar to the IntIterator and LongIterator in ideas.
However instead of next returning the primitive, next returns an autoboxed one, with new methods nextInt/Long to return a primitive.

This pull request changes uses the two primitive Iterators to OfInt and OfLong. This makes it easier to interoperate with other code that expects these two interfaces. But with a significant downside that existing of `next()` may have a significant regression in performance.

I personally don't think this should be merged before the 0.10.x release series but wanted to open this pull request for discussion if and when such a patch should be merged.

Procedure to make this patch is trivial. Use rename re-factoring of the existing next to nextInt/Long methods then add the OfInt/Long to the existing Int/LongInterface. 

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
