### PR TITLE
Fix add range around -1L in Roaring64NavigableMap and Roaring64Bitmap

### DIFF
--- a/.github/workflows/java8.yml
+++ b/.github/workflows/java8.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew assemble
       - name: Test with Gradle
-        run: ./gradlew test
+        run: ./gradlew test --stacktrace
       - name: Style check
         run: ./gradlew checkstyleMain

--- a/RoaringBitmap/build.gradle.kts
+++ b/RoaringBitmap/build.gradle.kts
@@ -21,11 +21,13 @@ tasks.test {
     // Define the memory requirements of tests, to prevent issues in CI while OK locally
     minHeapSize = "2G"
     maxHeapSize = "2G"
-    
+
     testLogging {
         // We exclude 'passed' events
         events( "skipped", "failed")
         showStackTraces = true
+        showExceptions = true
+        showCauses = true
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
         // Helps investigating OOM. But too verbose to be activated by default
         // showStandardStreams = true

--- a/RoaringBitmap/build.gradle.kts
+++ b/RoaringBitmap/build.gradle.kts
@@ -22,7 +22,12 @@ tasks.test {
         events( "skipped", "failed")
         showStackTraces = true
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-        // Helps investigating OOM
-        showStandardStreams = true
+        // Helps investigating OOM. But too verbose to be activated by default
+        // showStandardStreams = true
+
+        // Define the memory requirements of tests, to prevent issues in CI while OK locally
+        minHeapSize = "1G"
+        maxHeapSize = "1G"
+        jvmArgs = listOf("-XX:MaxPermSize=256m")
     }
 }

--- a/RoaringBitmap/build.gradle.kts
+++ b/RoaringBitmap/build.gradle.kts
@@ -22,5 +22,7 @@ tasks.test {
         events( "skipped", "failed")
         showStackTraces = true
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        // Helps investigating OOM
+        showStandardStreams = true
     }
 }

--- a/RoaringBitmap/build.gradle.kts
+++ b/RoaringBitmap/build.gradle.kts
@@ -26,8 +26,7 @@ tasks.test {
         // showStandardStreams = true
 
         // Define the memory requirements of tests, to prevent issues in CI while OK locally
-        minHeapSize = "1G"
-        maxHeapSize = "1G"
-        jvmArgs = listOf("-XX:MaxPermSize=256m")
+        minHeapSize = "2G"
+        maxHeapSize = "2G"
     }
 }

--- a/RoaringBitmap/build.gradle.kts
+++ b/RoaringBitmap/build.gradle.kts
@@ -17,6 +17,11 @@ tasks.test {
     mustRunAfter(tasks.checkstyleMain)
     useJUnitPlatform()
     failFast = true
+
+    // Define the memory requirements of tests, to prevent issues in CI while OK locally
+    minHeapSize = "2G"
+    maxHeapSize = "2G"
+    
     testLogging {
         // We exclude 'passed' events
         events( "skipped", "failed")
@@ -24,9 +29,5 @@ tasks.test {
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
         // Helps investigating OOM. But too verbose to be activated by default
         // showStandardStreams = true
-
-        // Define the memory requirements of tests, to prevent issues in CI while OK locally
-        minHeapSize = "2G"
-        maxHeapSize = "2G"
     }
 }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/LongUtils.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/LongUtils.java
@@ -164,4 +164,13 @@ public class LongUtils {
     high48[5] = (byte) ((num >>> 16) & 0xff);
     return high48;
   }
+
+  public static boolean isMaxHigh(byte[] high48) {
+    return high48[0] == -1 &&
+            high48[1] == -1 &&
+            high48[2] == -1 &&
+            high48[3] == -1 &&
+            high48[4] == -1 &&
+            high48[5] == -1;
+  }
 }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/LongUtils.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/LongUtils.java
@@ -173,11 +173,11 @@ public class LongUtils {
    * @return true if this the maximum high part
    */
   public static boolean isMaxHigh(byte[] high48) {
-    return high48[0] == -1 &&
-            high48[1] == -1 &&
-            high48[2] == -1 &&
-            high48[3] == -1 &&
-            high48[4] == -1 &&
-            high48[5] == -1;
+    return high48[0] == -1
+            && high48[1] == -1
+            && high48[2] == -1
+            && high48[3] == -1
+            && high48[4] == -1
+            && high48[5] == -1;
   }
 }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/LongUtils.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/LongUtils.java
@@ -165,6 +165,13 @@ public class LongUtils {
     return high48;
   }
 
+  /**
+   * checks if given high48 is the maximum possible one
+   * (e.g. it is the case for -1L, which is the maximum unsigned long)
+   *
+   * @param high48 the byte array
+   * @return true if this the maximum high part
+   */
   public static boolean isMaxHigh(byte[] high48) {
     return high48[0] == -1 &&
             high48[1] == -1 &&

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -696,8 +696,20 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
    *
    * @param rangeStart inclusive beginning of range
    * @param rangeEnd exclusive ending of range
+   * @deprecated as this may be confused with adding individual longs
    */
+  @Deprecated
   public void add(final long rangeStart, final long rangeEnd) {
+    addRange(rangeStart, rangeEnd);
+  }
+
+  /**
+   * Add to the current bitmap all longs in [rangeStart,rangeEnd).
+   *
+   * @param rangeStart inclusive beginning of range
+   * @param rangeEnd exclusive ending of range
+   */
+  public void addRange(final long rangeStart, final long rangeEnd) {
     if (rangeEnd == 0 || Long.compareUnsigned(rangeStart, rangeEnd) >= 0) {
       throw new IllegalArgumentException("Invalid range [" + rangeStart + "," + rangeEnd + ")");
     }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -736,6 +736,10 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
         Container freshContainer = Container.rangeOfOnes(containerStart, containerLast + 1);
         highLowContainer.put(startHighKey, freshContainer);
       }
+
+      if (LongUtils.isMaxHigh(startHighKey)) {
+        break;
+      }
       //increase the high
       rangeStartVal = rangeStartVal + (containerLast - containerStart) + 1;
       startHighKey = LongUtils.highPart(rangeStartVal);

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
@@ -173,27 +173,6 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
     }
   }
 
-  @Override
-  public Roaring64NavigableMap clone() {
-    try {
-      final Roaring64NavigableMap x = (Roaring64NavigableMap) super.clone();
-
-      NavigableMap<Integer, BitmapDataProvider> previousHighToBitmaps = highToBitmap;
-      if (signedLongs) {
-        highToBitmap = new TreeMap<>();
-      } else {
-        highToBitmap = new TreeMap<>(RoaringIntPacking.unsignedComparator());
-      }
-      previousHighToBitmaps.forEach((high, bitmap) -> highToBitmap.put(high, bitmap.clone()));
-
-      resetPerfHelpers();
-
-      return x;
-    } catch (final CloneNotSupportedException e) {
-      throw new RuntimeException("shouldn't happen with clone", e);
-    }
-  }
-
   /**
    * Add the value to the container (set the value to "true"), whether it already appears or not.
    *
@@ -1361,7 +1340,8 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
     int endLow = low(rangeEnd);
 
     int compareHigh = compare(startHigh, endHigh);
-    if (compareHigh > 0 || compareHigh == 0 && Util.toUnsignedLong(startLow) >= Util.toUnsignedLong(endLow)) {
+    if (compareHigh > 0
+            || compareHigh == 0 && Util.toUnsignedLong(startLow) >= Util.toUnsignedLong(endLow)) {
       throw new IllegalArgumentException("Invalid range [" + rangeStart + "," + rangeEnd + ")");
     }
 
@@ -1493,15 +1473,5 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
     }
 
     invalidateAboveHigh(high);
-  }
-
-  /**
-   * Add all long computed as the ints in the bitmap, bit-or with 'high << 32'
-   * @param high
-   * @param bitmap
-   */
-  public void add(int high, BitmapDataProvider bitmap) {
-    getHighToBitmap().put(high, bitmap);
-    resetPerfHelpers();
   }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
@@ -6,6 +6,7 @@ package org.roaringbitmap.buffer;
 
 
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -3936,5 +3937,16 @@ public class TestRoaringBitmap {
     // see https://github.com/RoaringBitmap/RoaringBitmap/issues/564
     assertEquals(-1, ImmutableRoaringBitmap.bitmapOf(27399807).previousValue(403042));
     assertEquals(-1, ImmutableRoaringBitmap.bitmapOf().previousValue(403042));
+  }
+
+  @Test
+  public void testRangeExtremeEnd() {
+    RoaringBitmap x = new RoaringBitmap();
+    long rangeStart =  (1L << 32) - 2;
+    long rangeEnd = (1L << 32);
+    x.add(rangeStart, rangeEnd);
+
+    Assertions.assertEquals(2L, x.getLongCardinality());
+    Assertions.assertArrayEquals(new int[] {-2, -1}, x.toArray());
   }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestLongUtils.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestLongUtils.java
@@ -1,0 +1,15 @@
+package org.roaringbitmap.longlong;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestLongUtils {
+  @Test
+  public void testHighPart() {
+      Assertions.assertFalse(LongUtils.isMaxHigh(LongUtils.highPart(0)));
+      Assertions.assertFalse(LongUtils.isMaxHigh(LongUtils.highPart(Long.MAX_VALUE)));
+      Assertions.assertFalse(LongUtils.isMaxHigh(LongUtils.highPart(Long.MIN_VALUE)));
+
+      Assertions.assertTrue(LongUtils.isMaxHigh(LongUtils.highPart(-1L)));
+  }
+}

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -2199,6 +2199,25 @@ public class TestRoaring64Bitmap {
         count++;
     }
     assertEquals(count, 7);
+  }
 
+  @Test
+  public void testAddExtremes() {
+    Roaring64Bitmap x = new Roaring64Bitmap();
+    x.addLong(0L);
+    x.addLong(Long.MAX_VALUE);
+    x.addLong(-1L);
+
+    Assertions.assertEquals(3L, x.getLongCardinality());
+    Assertions.assertArrayEquals(x.toArray(), new long[] {0, Long.MAX_VALUE, -1L});
+  }
+
+  @Test
+  public void testRangeAroundLongMax() {
+    Roaring64Bitmap x = new Roaring64Bitmap();
+    x.addRange(Long.MAX_VALUE - 1L, Long.MAX_VALUE + 3L);
+
+    Assertions.assertEquals(4L, x.getLongCardinality());
+    Assertions.assertArrayEquals(x.toArray(), new long[] {Long.MAX_VALUE - 1L, Long.MAX_VALUE, Long.MIN_VALUE, Long.MIN_VALUE + 1L});
   }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -2227,6 +2227,6 @@ public class TestRoaring64Bitmap {
     x.addRange(-3L, -1L);
 
     Assertions.assertEquals(2L, x.getLongCardinality());
-    Assertions.assertArrayEquals(x.toArray(), new long[] {-3L, -2L});
+    Assertions.assertArrayEquals(new long[] {-3L, -2L}, x.toArray());
   }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -2224,7 +2224,7 @@ public class TestRoaring64Bitmap {
   @Test
   public void testRangeExtremeEnd() {
     Roaring64Bitmap x = newDefaultCtor();
-    x.add(-3L, -1L);
+    x.addRange(-3L, -1L);
 
     Assertions.assertEquals(2L, x.getLongCardinality());
     Assertions.assertArrayEquals(x.toArray(), new long[] {-3L, -2L});

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -2220,4 +2220,13 @@ public class TestRoaring64Bitmap {
     Assertions.assertEquals(4L, x.getLongCardinality());
     Assertions.assertArrayEquals(x.toArray(), new long[] {Long.MAX_VALUE - 1L, Long.MAX_VALUE, Long.MIN_VALUE, Long.MIN_VALUE + 1L});
   }
+
+  @Test
+  public void testRangeExtremeEnd() {
+    Roaring64Bitmap x = newDefaultCtor();
+    x.add(-3L, -1L);
+
+    Assertions.assertEquals(2L, x.getLongCardinality());
+    Assertions.assertArrayEquals(x.toArray(), new long[] {-3L, -2L});
+  }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
@@ -1657,7 +1657,7 @@ public class TestRoaring64NavigableMap {
     x.addLong(-1L);
 
     Assertions.assertEquals(3L, x.getLongCardinality());
-    Assertions.assertArrayEquals(x.toArray(), new long[] {0, Long.MAX_VALUE, -1L});
+    Assertions.assertArrayEquals(new long[] {0, Long.MAX_VALUE, -1L}, x.toArray());
   }
 
   @Test
@@ -1668,7 +1668,7 @@ public class TestRoaring64NavigableMap {
     x.addLong(-1L);
 
     Assertions.assertEquals(3L, x.getLongCardinality());
-    Assertions.assertArrayEquals(x.toArray(), new long[] {-1L, 0, Long.MAX_VALUE});
+    Assertions.assertArrayEquals(new long[] {-1L, 0, Long.MAX_VALUE}, x.toArray());
   }
 
   @Test
@@ -1677,7 +1677,7 @@ public class TestRoaring64NavigableMap {
     x.addRange(-3L, -1L);
 
     Assertions.assertEquals(2L, x.getLongCardinality());
-    Assertions.assertArrayEquals(x.toArray(), new long[] {-3L, -2L});
+    Assertions.assertArrayEquals(new long[] {-3L, -2L}, x.toArray());
   }
 
   @Test
@@ -1686,7 +1686,7 @@ public class TestRoaring64NavigableMap {
     x.addRange(-3L, -1L);
 
     Assertions.assertEquals(2L, x.getLongCardinality());
-    Assertions.assertArrayEquals(x.toArray(), new long[] {-3L, -2L});
+    Assertions.assertArrayEquals(new long[] {-3L, -2L}, x.toArray());
   }
 
   @Test
@@ -1696,7 +1696,7 @@ public class TestRoaring64NavigableMap {
 
     Assertions.assertEquals(4L, x.getLongCardinality());
     Assertions.assertEquals(1L, x.getHighToBitmap().size());
-    Assertions.assertArrayEquals(x.toArray(), new long[] {Integer.MAX_VALUE - 1L, Integer.MAX_VALUE, Integer.MAX_VALUE + 1L, Integer.MAX_VALUE + 2L});
+    Assertions.assertArrayEquals(new long[] {Integer.MAX_VALUE - 1L, Integer.MAX_VALUE, Integer.MAX_VALUE + 1L, Integer.MAX_VALUE + 2L}, x.toArray());
   }
 
   @Test
@@ -1707,7 +1707,7 @@ public class TestRoaring64NavigableMap {
 
     Assertions.assertEquals(4L, x.getLongCardinality());
     Assertions.assertEquals(2L, x.getHighToBitmap().size());
-    Assertions.assertArrayEquals(x.toArray(), new long[] {rangeStart, rangeStart+1L, rangeStart+2L, rangeStart+3L});
+    Assertions.assertArrayEquals(new long[] {rangeStart, rangeStart+1L, rangeStart+2L, rangeStart+3L}, x.toArray());
   }
 
   @Test
@@ -1716,7 +1716,7 @@ public class TestRoaring64NavigableMap {
     x.addRange(Long.MAX_VALUE - 1L, Long.MAX_VALUE + 3L);
 
     Assertions.assertEquals(4L, x.getLongCardinality());
-    Assertions.assertArrayEquals(x.toArray(), new long[] {Long.MAX_VALUE - 1L, Long.MAX_VALUE, Long.MIN_VALUE, Long.MIN_VALUE + 1L});
+    Assertions.assertArrayEquals(new long[] {Long.MAX_VALUE - 1L, Long.MAX_VALUE, Long.MIN_VALUE, Long.MIN_VALUE + 1L}, x.toArray());
   }
 
   @Test()


### PR DESCRIPTION
### SUMMARY
- Multiple fixes related to Roaring64NavigableMap.addRange, specific to high being bigger than Long.MAX_VALUE
- Add tests to confirm same behavior between Roaring64NavigableMap and Roaring64Bitmap
- Add Roaring64NavigableMap.addRange, to prevent confusion between Roaring64NavigableMap.add(long, long) and Roaring64NavigableMap.add(long...). Same for Roaring64Bitmap

### Automated Checks

- [ ] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [ ] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
