### PR TITLE
Add fallback for Roaring64Bitmap.getLongSizeAsBytes(), and introduced footprint benchmarks for 64b

### DIFF
--- a/RoaringBitmap/build.gradle.kts
+++ b/RoaringBitmap/build.gradle.kts
@@ -10,6 +10,8 @@ dependencies {
     testImplementation("org.apache.commons:commons-lang3:${deps["commons-lang"]}")
     testImplementation("com.esotericsoftware:kryo:5.0.0-RC6")
     testImplementation("com.fasterxml.jackson.core", "jackson-databind", "2.10.3")
+    testImplementation("org.assertj", "assertj-core", "3.23.1")
+    testImplementation("org.openjdk.jol", "jol-core", "0.16")
 }
 
 tasks.test {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Containers.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Containers.java
@@ -27,10 +27,6 @@ public class Containers {
   private static final int MAX_JVM_ARRAY_OFFSET = MAX_JVM_ARRAY_LENGTH - 1;
   private static final byte NULL_MARK = 0;
   private static final byte NOT_NULL_MARK = 1;
-  //TODO: when the containerArrays is dense enough we hold the remained not null
-  //containerIdx in this dense bitmap,and shrink the real containerArrays to hold
-  //all the not null containers.
-  private List<RoaringBitmap> denseContainerIdxList;
   private static final byte TRIMMED_MARK = -1;
   private static final byte NOT_TRIMMED_MARK = -2;
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/ImmutableLongBitmapDataProvider.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/ImmutableLongBitmapDataProvider.java
@@ -24,7 +24,7 @@ public interface ImmutableLongBitmapDataProvider {
    * @param x long value
    * @return whether the long value is included.
    */
-  public boolean contains(long x);
+  boolean contains(long x);
 
   /**
    * Returns the number of distinct integers added to the bitmap (e.g., number of bits set). This
@@ -32,7 +32,7 @@ public interface ImmutableLongBitmapDataProvider {
    *
    * @return the cardinality
    */
-  public long getLongCardinality();
+  long getLongCardinality();
 
   /**
    * Visit all values in the bitmap and pass them to the consumer.
@@ -54,7 +54,7 @@ public interface ImmutableLongBitmapDataProvider {
    * 
    * @param lc the consumer
    */
-  public void forEach(LongConsumer lc);
+  void forEach(LongConsumer lc);
 
   /**
    * For better performance, consider the Use the {@link #forEach forEach} method.
@@ -62,18 +62,18 @@ public interface ImmutableLongBitmapDataProvider {
    * @return a custom iterator over set bits, the bits are traversed in ascending sorted order
    */
   // RoaringBitmap proposes a PeekableLongIterator
-  public LongIterator getLongIterator();
+  LongIterator getLongIterator();
 
   /**
    * @return a custom iterator over set bits, the bits are traversed in descending sorted order
    */
   // RoaringBitmap proposes a PeekableLongIterator
-  public LongIterator getReverseLongIterator();
+  LongIterator getReverseLongIterator();
 
   /**
    * @return an Ordered, Distinct, Sorted and Sized IntStream in ascending order
    */
-  public default LongStream stream() {
+  default LongStream stream() {
     int characteristics = Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.SORTED 
         | Spliterator.SIZED;
     Spliterator.OfLong x = Spliterators.spliterator(new RoaringOfLong(getLongIterator()), 
@@ -84,7 +84,7 @@ public interface ImmutableLongBitmapDataProvider {
   /**
    * @return an Ordered, Distinct and Sized IntStream providing bits in descending sorted order
    */
-  public default LongStream reverseStream() {
+  default LongStream reverseStream() {
     int characteristics = Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.SIZED;
     Spliterator.OfLong x = Spliterators.spliterator(new RoaringOfLong(getLongIterator()), 
         getLongCardinality(), characteristics);
@@ -97,21 +97,21 @@ public interface ImmutableLongBitmapDataProvider {
    *
    * @return estimated memory usage.
    */
-  public int getSizeInBytes();
+  int getSizeInBytes();
 
   /**
    * Estimate of the memory usage of this data structure. Provides full 64-bit number.
    *
    * @return estimated memory usage.
    */
-  public long getLongSizeInBytes();
+  long getLongSizeInBytes();
 
   /**
    * Checks whether the bitmap is empty.
    *
    * @return true if this bitmap contains no set bit
    */
-  public boolean isEmpty();
+  boolean isEmpty();
 
   /**
    * Create a new bitmap of the same class, containing at most maxcardinality integers.
@@ -119,7 +119,7 @@ public interface ImmutableLongBitmapDataProvider {
    * @param x maximal cardinality
    * @return a new bitmap with cardinality no more than maxcardinality
    */
-  public ImmutableLongBitmapDataProvider limit(long x);
+  ImmutableLongBitmapDataProvider limit(long x);
 
   /**
    * Rank returns the number of integers that are smaller or equal to x (Rank(infinity) would be
@@ -131,7 +131,7 @@ public interface ImmutableLongBitmapDataProvider {
    *
    * @return the rank
    */
-  public long rankLong(long x);
+  long rankLong(long x);
 
   /**
    * Return the jth value stored in this bitmap.
@@ -140,7 +140,7 @@ public interface ImmutableLongBitmapDataProvider {
    *
    * @return the value
    */
-  public long select(long j);
+  long select(long j);
 
   /**
    * Serialize this bitmap.
@@ -150,7 +150,7 @@ public interface ImmutableLongBitmapDataProvider {
    * @param out the DataOutput stream
    * @throws IOException Signals that an I/O exception has occurred.
    */
-  public void serialize(DataOutput out) throws IOException;
+  void serialize(DataOutput out) throws IOException;
 
   /**
    * Report the number of bytes required to serialize this bitmap. This is the number of bytes
@@ -159,14 +159,14 @@ public interface ImmutableLongBitmapDataProvider {
    *
    * @return the size in bytes
    */
-  public long serializedSizeInBytes();
+  long serializedSizeInBytes();
 
   /**
    * Return the set values as an array. The integer values are in sorted order.
    *
    * @return array representing the set values.
    */
-  public long[] toArray();
+  long[] toArray();
 
     /**
    * An internal class to help provide streams.
@@ -174,7 +174,7 @@ public interface ImmutableLongBitmapDataProvider {
    * Does not match. Otherwise it would be easier to just make IntIterator 
    * implement PrimitiveIterator.OfInt. 
    */
-  static final class RoaringOfLong implements PrimitiveIterator.OfLong {
+  final class RoaringOfLong implements PrimitiveIterator.OfLong {
     private final LongIterator iterator;
 
     public RoaringOfLong(LongIterator iterator) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/ImmutableLongBitmapDataProvider.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/ImmutableLongBitmapDataProvider.java
@@ -187,9 +187,9 @@ public interface ImmutableLongBitmapDataProvider {
 
     /**
    * An internal class to help provide streams.
-   * Sad but true the interface of IntIterator and PrimitiveIterator.OfInt
-   * Does not match. Otherwise it would be easier to just make IntIterator 
-   * implement PrimitiveIterator.OfInt. 
+   * Sad but true the interface of LongIterator and PrimitiveIterator.OfLong
+   * Does not match. Otherwise it would be easier to just make LongIterator
+   * implement PrimitiveIterator.OfLong.
    */
   final class RoaringOfLong implements PrimitiveIterator.OfLong {
     private final LongIterator iterator;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/LongBitmapDataProvider.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/LongBitmapDataProvider.java
@@ -14,18 +14,18 @@ public interface LongBitmapDataProvider extends ImmutableLongBitmapDataProvider 
    *
    * @param x long value
    */
-  public void addLong(long x);
+  void addLong(long x);
 
   /**
    * If present remove the specified integers (effectively, sets its bit value to false)
    *
    * @param x long value representing the index in a bitmap
    */
-  public void removeLong(long x);
+  void removeLong(long x);
 
 
   /**
    * Recover allocated but unused memory.
    */
-  public void trim();
+  void trim();
 }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -530,12 +530,50 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
 
   @Override
   public int getSizeInBytes() {
-    throw new UnsupportedOperationException();
+    return (int) getLongSizeInBytes();
   }
 
+
+  /**
+   * Estimate of the memory usage of this data structure. This can be expected to be within 1% of
+   * the true memory usage in common usage scenarios.
+   * If exact measures are needed, we recommend using dedicated libraries
+   * such as ehcache-sizeofengine.
+   *
+   * In adversarial cases, this estimate may be 10x the actual memory usage. For example, if
+   * you insert a single random value in a bitmap, then over a 100 bytes may be used by the JVM
+   * whereas this function may return an estimate of 32 bytes.
+   *
+   * The same will be true in the "sparse" scenario where you have a small set of
+   * random-looking integers spanning a wide range of values.
+   *
+   * These are considered adversarial cases because, as a general rule,
+   * if your data looks like a set
+   * of random integers, Roaring bitmaps are probably not the right data structure.
+   *
+   * Note that you can serialize your Roaring Bitmaps to disk and then construct
+   * ImmutableRoaringBitmap instances from a ByteBuffer. In such cases, the Java heap
+   * usage will be significantly less than
+   * what is reported.
+   *
+   * If your main goal is to compress arrays of integers, there are other libraries
+   * that are maybe more appropriate
+   * such as JavaFastPFOR.
+   *
+   * Note, however, that in general, random integers (as produced by random number
+   * generators or hash functions) are not compressible.
+   * Trying to compress random data is an adversarial use case.
+   *
+   * @see <a href="https://github.com/lemire/JavaFastPFOR">JavaFastPFOR</a>
+   *
+   *
+   * @return estimated memory usage.
+   */
   @Override
   public long getLongSizeInBytes() {
-    throw new UnsupportedOperationException();
+    // 'serializedSizeInBytes' is a better than nothing estimation of the memory footprint
+    // It would generally be an optimistic estimator (by underestimating the size in memory)
+    return serializedSizeInBytes();
   }
 
   @Override

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
@@ -1,5 +1,6 @@
 package org.roaringbitmap;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/JolBenchmarksTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/JolBenchmarksTest.java
@@ -1,0 +1,133 @@
+package org.roaringbitmap.longlong;
+
+import com.google.common.primitives.Ints;
+import org.openjdk.jol.info.GraphLayout;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+/**
+ * This runs benchmarks over {@link Roaring64NavigableMap} memory layout, as suggested in
+ * https://github.com/RoaringBitmap/RoaringBitmap/issues/346
+ */
+// https://github.com/openjdk/jol
+// https://github.com/RoaringBitmap/RoaringBitmap/issues/346
+public class JolBenchmarksTest {
+
+	@SuppressWarnings("restriction")
+	public static void main(String[] args) {
+		// distinctHigherRadices();
+		// sameHigherRadix();
+		statisticsWithGrowingSizes();
+	}
+
+	private static void distinctHigherRadices() {
+		int valuesPerRadix = 1 << 16;
+		int distance = 2000;
+		Roaring64NavigableMap bitmapMap = new Roaring64NavigableMap();
+		long[] radices = new long[1024];
+		for (int i = 0; i < radices.length; ++i) {
+			radices[i] = ((long) i) << 48;
+		}
+		for (int i = 0; i < radices.length; i++) {
+			for (int j = 0; j < valuesPerRadix; ++j) {
+				bitmapMap.addLong(radices[i] | (j * distance));
+			}
+		}
+
+		long[] bitmapArray = bitmapMap.toArray();
+
+		Roaring64Bitmap bitmapArt = new Roaring64Bitmap();
+		bitmapArt.add(bitmapArray);
+
+		System.out.println("---distinctHigherRadices---");
+		System.out.println(GraphLayout.parseInstance(bitmapArray).toFootprint());
+
+		System.out.println("---");
+		System.out.println(GraphLayout.parseInstance(bitmapMap).toFootprint());
+		System.out.println(bitmapMap.getLongSizeInBytes());
+		bitmapMap.runOptimize();
+		System.out.println(GraphLayout.parseInstance(bitmapMap).toFootprint());
+		System.out.println(bitmapMap.getLongSizeInBytes());
+
+		System.out.println("---");
+		System.out.println(GraphLayout.parseInstance(bitmapArt).toFootprint());
+		System.out.println(bitmapArt.getLongSizeInBytes());
+		bitmapArt.runOptimize();
+		System.out.println(GraphLayout.parseInstance(bitmapArt).toFootprint());
+		System.out.println(bitmapArt.getLongSizeInBytes());
+	}
+
+	private static void sameHigherRadix() {
+		int numValues = (1 << 16) * 1024;
+		int distance = 2000;
+		Roaring64NavigableMap bitmap = new Roaring64NavigableMap();
+
+		long x = 0L;
+		for (int i = 0; i < numValues; i++) {
+			bitmap.addLong(x);
+			x += distance;
+		}
+
+		long[] array = bitmap.toArray();
+
+		Roaring64Bitmap bitmapOpt = new Roaring64Bitmap();
+		bitmapOpt.add(array);
+
+		System.out.println("---sameHigherRadix---");
+		System.out.println(GraphLayout.parseInstance(array).toFootprint());
+
+		System.out.println("---");
+		System.out.println(GraphLayout.parseInstance(bitmap).toFootprint());
+		bitmap.runOptimize();
+		System.out.println(GraphLayout.parseInstance(bitmap).toFootprint());
+
+		System.out.println("---");
+		System.out.println(GraphLayout.parseInstance(bitmapOpt).toFootprint());
+		bitmapOpt.runOptimize();
+		System.out.println(GraphLayout.parseInstance(bitmapOpt).toFootprint());
+	}
+
+	public static void statisticsWithGrowingSizes() {
+		Random r =  new Random();
+
+		// We re-use the bitmaps so that we accumulate the longs into them
+		// We then expect to have denser buckets (around 0)
+		Roaring64Bitmap bitmap64Art = new Roaring64Bitmap();
+		Roaring64NavigableMap bitmap64Map = new Roaring64NavigableMap();
+
+		for (long size = 0 ; size < 1024 ; size++) {
+			long max = (1L + size*size*size*size*size);
+			System.out.println(size + " in [-" + max + ", " + max + "[");
+
+			long fSize = size;
+			long[] array = IntStream.range(0, Ints.checkedCast(size))
+					.mapToLong(i -> i)
+					.flatMap(i -> LongStream.generate(() -> r.nextLong() % max).limit(fSize))
+					.toArray();
+
+			reportBitmapsMemory(array, bitmap64Art, bitmap64Map);
+		}
+	}
+
+	private static void reportBitmapsMemory(long[] array, LongBitmapDataProvider bitmap, LongBitmapDataProvider bitmap2) {
+		reportBitmapsMemory(array, bitmap);
+		reportBitmapsMemory(array, bitmap2);
+
+		if (!Arrays.equals(bitmap.toArray(), bitmap.toArray())) {
+			throw new IllegalStateException("Issue with: " + Arrays.toString(array));
+		}
+	}
+
+	private static void reportBitmapsMemory(long[] array, LongBitmapDataProvider bitmap) {
+		LongStream.of(array).forEach(bitmap::addLong);
+		long jolSize = GraphLayout.parseInstance(bitmap).totalSize();
+		long ownEstimation = bitmap.getLongSizeInBytes();
+		System.out.println(bitmap.getClass().getSimpleName()
+				+ ": " + String.format("%,d", jolSize) + "(real) vs "
+				+ String.format("%,d", ownEstimation) + "(estimated) "
+				+ (ownEstimation < jolSize ? "optimistic" : "pessimistic"));
+	}
+}

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.jupiter.api.function.Executable;
 import static org.roaringbitmap.Util.toUnsignedLong;
 
@@ -505,16 +507,9 @@ public class TestRoaring64Bitmap {
   public void testSerializationEmpty() throws IOException, ClassNotFoundException {
     final Roaring64Bitmap map = newDefaultCtor();
 
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
-      oos.writeObject(map);
-    }
+    TestRoaring64NavigableMap.checkSerializeBytes(map);
 
-    final Roaring64Bitmap clone;
-    try (ObjectInputStream ois =
-        new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-      clone = (Roaring64Bitmap) ois.readObject();
-    }
+    final Roaring64Bitmap clone = SerializationUtils.clone(map);
 
     // Check the test has not simply copied the ref
     assertNotSame(map, clone);
@@ -522,7 +517,7 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
-  public void testSerialization_ToBigEndianBuffer() throws IOException, ClassNotFoundException {
+  public void testSerialization_ToBigEndianBuffer() throws IOException {
     final Roaring64Bitmap map = newDefaultCtor();
     map.addLong(123);
     ByteBuffer buffer = ByteBuffer.allocate((int) map.serializedSizeInBytes())
@@ -536,16 +531,9 @@ public class TestRoaring64Bitmap {
     final Roaring64Bitmap map = newDefaultCtor();
     map.addLong(123);
 
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
-      oos.writeObject(map);
-    }
+    TestRoaring64NavigableMap.checkSerializeBytes(map);
 
-    final Roaring64Bitmap clone;
-    try (ObjectInputStream ois =
-        new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-      clone = (Roaring64Bitmap) ois.readObject();
-    }
+    final Roaring64Bitmap clone = SerializationUtils.clone(map);
 
     // Check the test has not simply copied the ref
     assertNotSame(map, clone);
@@ -559,16 +547,9 @@ public class TestRoaring64Bitmap {
     final Roaring64Bitmap map = newDefaultCtor();
     map.addLong(123);
 
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
-      oos.writeObject(map);
-    }
+    TestRoaring64NavigableMap.checkSerializeBytes(map);
 
-    final Roaring64Bitmap clone;
-    try (ObjectInputStream ois =
-        new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-      clone = (Roaring64Bitmap) ois.readObject();
-    }
+    final Roaring64Bitmap clone = SerializationUtils.clone(map);
 
     // Check the test has not simply copied the ref
     assertNotSame(map, clone);
@@ -584,17 +565,10 @@ public class TestRoaring64Bitmap {
     map.addLong(-123);
     map.addLong(123);
     map.addLong(Long.MAX_VALUE);
-    long sizeInByteL = map.serializedSizeInBytes();
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
-      oos.writeObject(map);
-    }
 
-    final Roaring64Bitmap clone;
-    try (ObjectInputStream ois =
-        new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-      clone = (Roaring64Bitmap) ois.readObject();
-    }
+    TestRoaring64NavigableMap.checkSerializeBytes(map);
+
+    final Roaring64Bitmap clone = SerializationUtils.clone(map);
 
     // Check the test has not simply copied the ref
     assertNotSame(map, clone);
@@ -602,7 +576,7 @@ public class TestRoaring64Bitmap {
     assertEquals(123, clone.select(0));
     assertEquals(Long.MAX_VALUE, clone.select(1));
     assertEquals(-123, clone.select(2));
-    int sizeInByteInt = (int) sizeInByteL;
+    int sizeInByteInt = map.getSizeInBytes();
     ByteBuffer byteBuffer = ByteBuffer.allocate(sizeInByteInt).order(ByteOrder.LITTLE_ENDIAN);
     map.serialize(byteBuffer);
     byteBuffer.flip();
@@ -1427,11 +1401,7 @@ public class TestRoaring64Bitmap {
     map.addLong(123);
     map.addLong(Long.MAX_VALUE);
 
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    try (DataOutputStream oos = new DataOutputStream(baos)) {
-      map.serialize(oos);
-    }
-    assertEquals(baos.toByteArray().length, map.serializedSizeInBytes());
+    TestRoaring64NavigableMap.checkSerializeBytes(map);
   }
 
   @Test
@@ -2200,5 +2170,14 @@ public class TestRoaring64Bitmap {
     }
     assertEquals(count, 7);
 
+  }
+
+  @Test
+  public void testRangeExtremeEnd() {
+    Roaring64Bitmap x = newDefaultCtor();
+    x.add(-3L, -1L);
+
+    Assertions.assertEquals(2L, x.getLongCardinality());
+    Assertions.assertArrayEquals(x.toArray(), new long[] {-3L, -2L});
   }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
@@ -63,6 +63,15 @@ public class TestRoaring64NavigableMap {
         Arrays.copyOf(bitmap.getSortedCumulatedCardinality(), expectedCardinalities.length));
   }
 
+  public static void checkSerializeBytes(ImmutableLongBitmapDataProvider bitmap) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream oos = new DataOutputStream(baos)) {
+      bitmap.serialize(oos);
+    }
+
+    assertEquals(baos.toByteArray().length, bitmap.serializedSizeInBytes());
+  }
+
   @Test
   public void testHelperCtor() {
     // RoaringIntPacking is not supposed to be instantiated. Add test for coverage
@@ -804,17 +813,20 @@ public class TestRoaring64NavigableMap {
   }
 
   @Test
-  public void testSerializationSizeInBytes() throws IOException, ClassNotFoundException {
+  public void testSerializationSizeInBytes_singleBucket() throws IOException, ClassNotFoundException {
     final Roaring64NavigableMap map = newDefaultCtor();
     map.addLong(123);
-    // map.addLong(Long.MAX_VALUE);
 
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    try (DataOutputStream oos = new DataOutputStream(baos)) {
-      map.serialize(oos);
-    }
+    checkSerializeBytes(map);
+  }
 
-    assertEquals(baos.toByteArray().length, map.serializedSizeInBytes());
+  @Test
+  public void testSerializationSizeInBytes_multipleBuckets() throws IOException, ClassNotFoundException {
+    final Roaring64NavigableMap map = newDefaultCtor();
+    map.addLong(123);
+    map.addLong(Long.MAX_VALUE);
+
+    checkSerializeBytes(map);
   }
 
   @Test


### PR DESCRIPTION
### SUMMARY
- Copy and extends footprint benchmarks from #346
- Simplify and refactor tests for . serializedSizeInBytes

### Automated Checks

- [ ] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [ ] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
