### PR TITLE
Bugfixes for forAllInRange with large integers.

### DIFF
--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestForAllInRange.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestForAllInRange.java
@@ -2,7 +2,11 @@ package org.roaringbitmap;
 
 import java.util.Arrays;
 
+import com.google.common.primitives.UnsignedInteger;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.roaringbitmap.ValidationRangeConsumer.Value;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -12,96 +16,113 @@ import static org.roaringbitmap.ValidationRangeConsumer.Value.PRESENT;
 
 public class TestForAllInRange {
 
-  @Test
-  public void testContinuous() {
+  static int POS_NEG_BOUNDARY = Integer.MAX_VALUE;
+  static int CONTAINER_BOUNDARY = BitmapContainer.MAX_CAPACITY;
+  static int CONTAINER_BOUNDARY_MINUS_FIVE = CONTAINER_BOUNDARY - 5;
+
+  private int uAdd(int l, int r) {
+    UnsignedInteger result = UnsignedInteger.fromIntBits(l).plus(UnsignedInteger.fromIntBits(r));
+    return result.intValue();
+  }
+
+  private long uAddL(int l, int r) {
+    UnsignedInteger result = UnsignedInteger.fromIntBits(l).plus(UnsignedInteger.fromIntBits(r));
+    return result.longValue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 65531, 65536, 2147483642, 2147483647, -2147483648, -2146958415})
+  public void testContinuous(int offset) {
     RoaringBitmap bitmap = new RoaringBitmap();
-    bitmap.add(100L, 10000L);
+    bitmap.add(uAddL(offset, 100), uAddL(offset, 10000));
 
     ValidationRangeConsumer consumer = ValidationRangeConsumer.validateContinuous(9900, PRESENT);
-    bitmap.forAllInRange(100, 9900, consumer);
+    bitmap.forAllInRange(uAdd(offset, 100), 9900, consumer);
     assertEquals(9900, consumer.getNumberOfValuesConsumed());
 
     ValidationRangeConsumer consumer2 = ValidationRangeConsumer.validateContinuous(1000, ABSENT);
-    bitmap.forAllInRange(10001, 1000, consumer2);
+    bitmap.forAllInRange(uAdd(offset, 10001), 1000, consumer2);
     assertEquals(1000, consumer2.getNumberOfValuesConsumed());
 
     ValidationRangeConsumer consumer3 = ValidationRangeConsumer.validate(new Value[]{
         ABSENT, ABSENT, PRESENT, PRESENT, PRESENT
     });
-    bitmap.forAllInRange(98, 5, consumer3);
+    bitmap.forAllInRange(uAdd(offset,98), 5, consumer3);
     assertEquals(5, consumer3.getNumberOfValuesConsumed());
 
     ValidationRangeConsumer consumer4 = ValidationRangeConsumer.validate(new Value[]{
         PRESENT, PRESENT, ABSENT, ABSENT, ABSENT
     });
-    bitmap.forAllInRange(9998, 5, consumer4);
+    bitmap.forAllInRange(uAdd(offset,9998), 5, consumer4);
     assertEquals(5, consumer4.getNumberOfValuesConsumed());
 
     bitmap = new RoaringBitmap();
-    bitmap.add(0L, 1000000L);
+    bitmap.add(uAddL(offset, 0), uAddL(offset, 1000000));
     ValidationRangeConsumer consumer5 = ValidationRangeConsumer.ofSize(1000000);
-    bitmap.forAllInRange(0, 1000000, consumer5);
+    bitmap.forAllInRange(uAdd(offset, 0), 1000000, consumer5);
     consumer5.assertAllPresent();
     bitmap.runOptimize();
     ValidationRangeConsumer consumer6 = ValidationRangeConsumer.ofSize(1000000);
-    bitmap.forAllInRange(0, 1000000, consumer6);
+    bitmap.forAllInRange(uAdd(offset, 0), 1000000, consumer6);
     consumer6.assertAllPresent();
 
     bitmap = new RoaringBitmap();
-    bitmap.add(100L, 10000L);
+    bitmap.add(uAddL(offset, 100), uAddL(offset,  10000));
     ValidationRangeConsumer consumer7 = ValidationRangeConsumer.ofSize(1000000);
-    bitmap.forAllInRange(10000, 1000000, consumer7);
+    bitmap.forAllInRange(uAdd(offset, 10000), 1000000, consumer7);
     consumer7.assertAllAbsent();
   }
 
-  @Test
-  public void testDense() {
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 65531, 65536, 2147483642, 2147483647, -2147483648, -2146958415})
+  public void testDense(int offset) {
     RoaringBitmap bitmap = new RoaringBitmap();
     Value[] expected = new Value[100000];
     Arrays.fill(expected, ABSENT);
     for (int k = 0; k < 100000; k += 3) {
-      bitmap.add(k);
+      bitmap.add(uAdd(offset, k));
       expected[k] = PRESENT;
     }
 
     ValidationRangeConsumer consumer = ValidationRangeConsumer.validate(expected);
-    bitmap.forAllInRange(0, 100000, consumer);
+    bitmap.forAllInRange(uAdd(offset, 0), 100000, consumer);
     assertEquals(100000, consumer.getNumberOfValuesConsumed());
 
     Value[] expectedSubRange = Arrays.copyOfRange(expected,2500, 6000);
     ValidationRangeConsumer consumer2 = ValidationRangeConsumer.validate(expectedSubRange);
-    bitmap.forAllInRange(2500, 3500, consumer2);
+    bitmap.forAllInRange(uAdd(offset, 2500), 3500, consumer2);
     assertEquals(3500, consumer2.getNumberOfValuesConsumed());
 
     ValidationRangeConsumer consumer3 = ValidationRangeConsumer.validate(new Value[]{
         expected[99997], expected[99998], expected[99999], ABSENT, ABSENT, ABSENT
     });
-    bitmap.forAllInRange(99997, 6, consumer3);
+    bitmap.forAllInRange(uAdd(offset, 99997), 6, consumer3);
     assertEquals(6, consumer3.getNumberOfValuesConsumed());
   }
 
 
-  @Test
-  public void testSparse() {
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 65531, 65536, 2147483642, 2147483647, -2147483648, -2146958415})
+  public void testSparse(int offset) {
     RoaringBitmap bitmap = new RoaringBitmap();
     Value[] expected = new Value[100000];
     Arrays.fill(expected, ABSENT);
     for (int k = 0; k < 100000; k += 3000) {
-      bitmap.add(k);
+      bitmap.add(uAdd(offset, k));
       expected[k] = PRESENT;
     }
 
     ValidationRangeConsumer consumer = ValidationRangeConsumer.validate(expected);
-    bitmap.forAllInRange(0, 100000, consumer);
+    bitmap.forAllInRange(uAdd(offset, 0), 100000, consumer);
     assertEquals(100000, consumer.getNumberOfValuesConsumed());
 
     Value[] expectedSubRange = Arrays.copyOfRange(expected,2500, 6001);
     ValidationRangeConsumer consumer2 = ValidationRangeConsumer.validate(expectedSubRange);
-    bitmap.forAllInRange(2500, 3500, consumer2);
+    bitmap.forAllInRange(uAdd(offset, 2500), 3500, consumer2);
     assertEquals(3500, consumer2.getNumberOfValuesConsumed());
 
     ValidationRangeConsumer consumer3 = ValidationRangeConsumer.ofSize(1000);
-    bitmap.forAllInRange(2500, 1000, consumer3);
+    bitmap.forAllInRange(uAdd(offset, 2500), 1000, consumer3);
     consumer3.assertAllAbsentExcept(new int[] {3000 - 2500});
     assertEquals(1000, consumer3.getNumberOfValuesConsumed());
   }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestForAllInRange.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestForAllInRange.java
@@ -16,10 +16,6 @@ import static org.roaringbitmap.ValidationRangeConsumer.Value.PRESENT;
 
 public class TestForAllInRange {
 
-  static int POS_NEG_BOUNDARY = Integer.MAX_VALUE;
-  static int CONTAINER_BOUNDARY = BitmapContainer.MAX_CAPACITY;
-  static int CONTAINER_BOUNDARY_MINUS_FIVE = CONTAINER_BOUNDARY - 5;
-
   private int uAdd(int l, int r) {
     UnsignedInteger result = UnsignedInteger.fromIntBits(l).plus(UnsignedInteger.fromIntBits(r));
     return result.intValue();


### PR DESCRIPTION
### SUMMARY
- The `forAllInRange` implementation in `RoaringBitmap` was treating unsigned integers wrong.
- Added a bunch of parametrised tests to reproduce the issue. (Conveniently the range consumer being relative, makes it easy to write tests using offsets.)
- Changed all variable naming in the `forAllInRange` implementation such that vars that must be treated as unsigned always start with a `u`.
- Fixed all the places where unsigned ints were compared as signed.
- Also some more comments, assertions, and code cleanup to make this implementation easier to read/review.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
