### PR TITLE
add RangeBitmap.eq and RangeBitmap.neq

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,8 @@ RangeBitmap bitmap = appender.build();
 RoaringBitmap lessThan5 = bitmap.lt(5); // {0,1}
 RoaringBitmap greaterThanOrEqualTo1 = bitmap.gte(1); // {0, 1, 2}
 RoaringBitmap greaterThan1 = bitmap.gt(1); // {2}
+RoaringBitmap equalTo1 = bitmap.eq(1); // {0, 1}
+RoaringBitmap notEqualTo1 = bitmap.neq(1); // {2}
 ```
 
 `RangeBitmap` is can be written to disk and memory mapped:

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -266,6 +266,14 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     Util.resetBitmapRange(bits, prev, MAX_CAPACITY);
   }
 
+  @Override
+  public void removeFrom(long[] bits) {
+    for (int i = 0; i < this.getCardinality(); ++i) {
+      int value = content.get(i);
+      bits[value >>> 6] &= ~(1L << value);
+    }
+  }
+
   private int advance(CharIterator it) {
     if (it.hasNext()) {
       return (it.next());

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -998,6 +998,13 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
   }
 
   @Override
+  public void removeFrom(long[] bits) {
+    for (int i = 0; i < bits.length; ++i) {
+      bits[i] &= ~bitmap.get(i);
+    }
+  }
+
+  @Override
   public MappeableContainer ior(final MappeableRunContainer x) {
     if (BufferUtil.isBackedBySimpleArray(this.bitmap)) {
       long[] b = this.bitmap.array();

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableContainer.java
@@ -80,6 +80,13 @@ public abstract class MappeableContainer implements Iterable<Character>, Cloneab
   public abstract void andInto(long[] bits);
 
   /**
+   * Computes the intersection of the negation of this container with the bits present in the array,
+   * modifying the array.
+   * @param bits a 1024 element array to be interpreted as a bit set
+   */
+  public abstract void removeFrom(long[] bits);
+
+  /**
    * Computes the bitwise AND of this container with another (intersection). This container as well
    * as the provided container are left unaffected.
    * 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -1580,6 +1580,15 @@ public final class MappeableRunContainer extends MappeableContainer implements C
     resetBitmapRange(bits, prev, MAX_CAPACITY);
   }
 
+  @Override
+  public void removeFrom(long[] bits) {
+    for (int r = 0; r < numberOfRuns(); ++r) {
+      int start = this.valueslength.get(r << 1);
+      int length = this.valueslength.get((r << 1) + 1);
+      resetBitmapRange(bits, start, start + length + 1);
+    }
+  }
+
   public static MappeableRunContainer full() {
     return new MappeableRunContainer(0, 1 << 16);
   }


### PR DESCRIPTION
Adds `RangeBitmap.eq`, `RangeBitmap.eqCardinality`, `RangeBitmap.neq` and `RangeBitmap.neqCardinality`. These methods allow `RangeBitmap` to be used as a kind of compact inverted index which trades space for time.