### PR TITLE
Added a performance hint.

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/FastAggregation.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/FastAggregation.java
@@ -292,6 +292,10 @@ public final class FastAggregation {
   /**
    * Compute overall AND between bitmaps two-by-two.
    *
+   * Performance hint: if you have very large and tiny bitmaps,
+   * it may be beneficial performance-wise to put a tiny bitmap
+   * in first position.
+   *
    * This function runs in linear time with respect to the number of bitmaps.
    *
    * @param bitmaps input bitmaps
@@ -311,6 +315,10 @@ public final class FastAggregation {
 
   /**
    * Compute overall AND between bitmaps two-by-two.
+   *
+   * Performance hint: if you have very large and tiny bitmaps,
+   * it may be beneficial performance-wise to put a tiny bitmap
+   * in first position.
    *
    * This function runs in linear time with respect to the number of bitmaps.
    *

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferFastAggregation.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferFastAggregation.java
@@ -334,6 +334,10 @@ public final class BufferFastAggregation {
 
   /**
    * Compute overall AND between bitmaps two-by-two.
+   *
+   * Performance hint: if you have very large and tiny bitmaps,
+   * it may be beneficial performance-wise to put a tiny bitmap
+   * in first position.
    * 
    * This function runs in linear time with respect to the number of bitmaps.
    *
@@ -357,6 +361,10 @@ public final class BufferFastAggregation {
 
   /**
    * Compute overall AND between bitmaps two-by-two.
+   *
+   * Performance hint: if you have very large and tiny bitmaps,
+   * it may be beneficial performance-wise to put a tiny bitmap
+   * in first position.
    * 
    * This function runs in linear time with respect to the number of bitmaps.
    *
@@ -377,6 +385,10 @@ public final class BufferFastAggregation {
 
   /**
    * Compute overall AND between bitmaps two-by-two.
+   *
+   * Performance hint: if you have very large and tiny bitmaps,
+   * it may be beneficial performance-wise to put a tiny bitmap
+   * in first position.
    * 
    * This function runs in linear time with respect to the number of bitmaps.
    *


### PR DESCRIPTION
When using `naive_and` aggregation, putting a tiny bitmap first can be beneficial. Let us communication this insight to the users.

Related to https://github.com/RoaringBitmap/RoaringBitmap/issues/608