### PR TITLE
reset the prefix of the leaf node while inserting

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Art.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Art.java
@@ -16,6 +16,8 @@ public class Art {
   private Node root;
   private long keySize = 0;
 
+  private static byte[] EMPTY_BYTES = new byte[0];
+
   public Art() {
     root = null;
   }
@@ -205,6 +207,10 @@ public class Art {
       LeafNode leafNode = (LeafNode) node;
       byte[] prefix = leafNode.getKeyBytes();
       int commonPrefix = commonPrefixLength(prefix, depth, prefix.length, key, depth, key.length);
+      //The leaf node maybe was shrunk from some other node type before and
+      // contained an old prefixLength,so we reset it to 0 here.
+      leafNode.prefixLength = 0;
+      leafNode.prefix = EMPTY_BYTES;
       Node4 node4 = new Node4(commonPrefix);
       //copy common prefix
       node4.prefixLength = (byte) commonPrefix;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node4.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node4.java
@@ -118,7 +118,7 @@ public class Node4 extends Node {
       children[pos] = children[pos + 1];
     }
     if (count == 1) {
-      //shrink to leaf node
+      //shrink to the child node
       Node child = children[0];
       byte newLength = (byte) (child.prefixLength + this.prefixLength + 1);
       byte[] newPrefix = new byte[newLength];

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -1,5 +1,7 @@
 package org.roaringbitmap.longlong;
 
+import org.apache.commons.lang3.SerializationUtils;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -8,8 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-
-import org.apache.commons.lang3.SerializationUtils;
 import static org.roaringbitmap.Util.toUnsignedLong;
 
 import com.google.common.primitives.Ints;
@@ -2259,5 +2259,26 @@ public class TestRoaring64Bitmap {
 
     assertEquals(source.stream().min((l,r) -> Long.compareUnsigned(l, r)).get(), rb.first());
     assertEquals(source.stream().max((l,r) -> Long.compareUnsigned(l, r)).get(), rb.last());
+  }
+
+ @Test
+  public void testIssue619() {
+    long[] CLEANER_VALUES = {140664568792144l};
+    long[] ADDRESS_SPACE_VALUES = {140662937752432l};
+    Roaring64Bitmap addressSpace = new Roaring64Bitmap();
+    Roaring64Bitmap cleaner = new Roaring64Bitmap();
+    int iteration = 0;
+    cleaner.add(CLEANER_VALUES);
+    while (true) {
+      addressSpace.add(ADDRESS_SPACE_VALUES);
+      addressSpace.add(CLEANER_VALUES);
+      if (iteration == 33) {
+        //This test case can safely break here.
+        break;
+      }
+      addressSpace.andNot(cleaner);
+      iteration++;
+    }
+    assertEquals(2, addressSpace.getIntCardinality());
   }
 }


### PR DESCRIPTION
### SUMMARY
- The initial insert method of the Art does not consider a case that the leaf node was shrunk from some other node types, and just assume it is a fresh leaf node. That's wrong. So we add the logic to reset the leaf node's prefix information while inserting.


### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
