### PR TITLE
Verifying and fixing issue 623

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,9 +443,9 @@ Usage
 * Get java
 
 * ``./gradlew assemble`` will compile
-* ``./gradlew build`` will compile and run the  unit tests
+* ``./gradlew build`` will compile and run the unit tests
 * ``./gradlew test `` will run the tests
-* ``./gradlew :roaringbitmap:test --tests TestIterators.testIndexIterator4`` run just the test `TestIterators.testIndexIterator4`
+* ``./gradlew :roaringbitmap:test --tests TestIterators.testIndexIterator4`` runs just the test `TestIterators.testIndexIterator4`; `./gradlew -i :roaringbitmap:test --tests TestRoaringBitmap.issue623` runs just the test `issue623` in the class ` TestRoaringBitmap` while printing out to the console.
 * ``./gradlew  bsi:test --tests BufferBSITest.testEQ``  run just the test `BufferBSITest.testEQ` in the `bsi` submodule
 * ``./gradlew checkstyleMain`` will check that you abide by the code style and that the code compiles. We enforce a strict style so that there is no debate as to the proper way to format the code.
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -1653,7 +1653,6 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     if (begin < 0 || end - begin != span) {
       return false;
     }
-
     int min = (char)minimum;
     int sup = (char)supremum;
     if (firstKey == lastKey) {
@@ -1663,8 +1662,8 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     if (!highLowContainer.getContainerAtIndex(begin).contains(min, 1 << 16)) {
       return false;
     }
-    if (end < len && !highLowContainer.getContainerAtIndex(end)
-            .contains(0, (supremum & 0xFFFF) == 0 ? 0x10000 : sup)) {
+    if (sup != 0 && end < len && !highLowContainer.getContainerAtIndex(end)
+            .contains(0, sup)) {
       return false;
     }
     for (int i = begin + 1; i < end; ++i) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -1117,8 +1117,8 @@ public class ImmutableRoaringBitmap
     if (!highLowContainer.getContainerAtIndex(begin).contains(min, 1 << 16)) {
       return false;
     }
-    if (end < len && !highLowContainer.getContainerAtIndex(end)
-            .contains(0, (supremum & 0xFFFF) == 0 ? 0x10000 : sup)) {
+    if (sup != 0 && end < len && !highLowContainer.getContainerAtIndex(end)
+            .contains(0, sup)) {
       return false;
     }
     for (int i = begin + 1; i < end; ++i) {

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -5443,4 +5443,19 @@ public class TestRoaringBitmap {
         System.out.println("[issue566] RoaringBitmap bits per entry: " + roaringbits * 1.0 / roaringBitMap.getCardinality());
         assertTrue(roaringbits < bitsetbits);
     }
+    @Test
+    public void issue623() {
+        RoaringBitmap r = new RoaringBitmap();
+        r.add(65535);
+        r.add(65535+1);
+        assertTrue(r.contains(65535));
+        assertTrue(r.contains(65535 + 1));
+        assertTrue(r.contains(65535L, 65535L + 1));
+        for (long i = 1; i <= 10_000_000; i++) {
+            r.add(i, i + 1);
+        }
+        for (long i = 1; i <= 10_000_000; i++) {
+            assertTrue(r.contains(i, i + 1));
+        }
+    }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
@@ -3941,7 +3941,7 @@ public class TestRoaringBitmap {
 
   @Test
   public void testRangeExtremeEnd() {
-    RoaringBitmap x = new RoaringBitmap();
+    MutableRoaringBitmap x = new MutableRoaringBitmap();
     long rangeStart =  (1L << 32) - 2;
     long rangeEnd = (1L << 32);
     x.add(rangeStart, rangeEnd);
@@ -3949,4 +3949,20 @@ public class TestRoaringBitmap {
     Assertions.assertEquals(2L, x.getLongCardinality());
     Assertions.assertArrayEquals(new int[] {-2, -1}, x.toArray());
   }
+  @Test
+  public void issue623() {
+    MutableRoaringBitmap r = new MutableRoaringBitmap();
+    r.add(65535);
+    r.add(65535+1);
+    assertTrue(r.contains(65535));
+    assertTrue(r.contains(65535 + 1));
+    assertTrue(r.contains(65535L, 65535L + 1));
+    for (long i = 1; i <= 10_000_000; i++) {
+      r.add(i, i + 1);
+    }
+    for (long i = 1; i <= 10_000_000; i++) {
+      assertTrue(r.contains(i, i + 1));
+    }
+  }
+
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -1100,22 +1100,22 @@ public class TestRoaring64Bitmap {
   public void testAddInvalidRange() {
     Roaring64Bitmap map = new Roaring64Bitmap();
     // Zero edge-case
-    assertThrows(IllegalArgumentException.class, () -> map.add(0L, 0L));
+    assertThrows(IllegalArgumentException.class, () -> map.addRange(0L, 0L));
 
     // Same higher parts, different lower parts
-    assertThrows(IllegalArgumentException.class, () -> map.add(1L, 0L));
-    assertThrows(IllegalArgumentException.class, () -> map.add(-1, -2));
+    assertThrows(IllegalArgumentException.class, () -> map.addRange(1L, 0L));
+    assertThrows(IllegalArgumentException.class, () -> map.addRange(-1, -2));
 
     // Different higher parts
-    assertThrows(IllegalArgumentException.class, () -> map.add(Long.MAX_VALUE, 0L));
-    assertThrows(IllegalArgumentException.class, () -> map.add(Long.MIN_VALUE, Long.MAX_VALUE));
+    assertThrows(IllegalArgumentException.class, () -> map.addRange(Long.MAX_VALUE, 0L));
+    assertThrows(IllegalArgumentException.class, () -> map.addRange(Long.MIN_VALUE, Long.MAX_VALUE));
   }
 
   @Test
   public void testAddRangeSingleBucket() {
     Roaring64Bitmap map = newDefaultCtor();
 
-    map.add(5L, 12L);
+    map.addRange(5L, 12L);
     assertEquals(7L, map.getLongCardinality());
 
     assertEquals(5L, map.select(0));
@@ -1130,7 +1130,7 @@ public class TestRoaring64Bitmap {
 
     long end = toUnsignedLong(-1) + 1;
 
-    map.add(end - 2, end);
+    map.addRange(end - 2, end);
     assertEquals(2, map.getLongCardinality());
 
     assertEquals(end - 2, map.select(0));
@@ -1146,7 +1146,7 @@ public class TestRoaring64Bitmap {
 
     long from = RoaringIntPacking.pack(0, -1 - enableTrim);
     long to = from + 2 * enableTrim;
-    map.add(from, to);
+    map.addRange(from, to);
     int nbItems = (int) (to - from);
     assertEquals(nbItems, map.getLongCardinality());
 
@@ -1174,7 +1174,7 @@ public class TestRoaring64Bitmap {
     long outOfSingleRoaring = outOfRoaringBitmapRange - 3;
 
     // This should fill entirely one bitmap,and add one in the next bitmap
-    map.add(0, outOfSingleRoaring);
+    map.addRange(0, outOfSingleRoaring);
     assertEquals(outOfSingleRoaring, map.getLongCardinality());
 
     assertEquals(outOfSingleRoaring, map.getLongCardinality());
@@ -1600,7 +1600,7 @@ public class TestRoaring64Bitmap {
   @Test
   public void testSkipsRun() {
     Roaring64Bitmap bitmap = new Roaring64Bitmap();
-    bitmap.add(4L, 100000L);
+    bitmap.addRange(4L, 100000L);
     bitmap.runOptimize();
     // use advance
     for(int i = 4; i < 100000; ++i) {
@@ -1714,7 +1714,7 @@ public class TestRoaring64Bitmap {
   @Test
   public void testSkipsRunReverse() {
     Roaring64Bitmap bitmap = new Roaring64Bitmap();
-    bitmap.add(4L, 100000L);
+    bitmap.addRange(4L, 100000L);
     bitmap.runOptimize();
 
     // use advance
@@ -1754,8 +1754,8 @@ public class TestRoaring64Bitmap {
     long b2s = 100L;
     long b2e = b2 + b2s;
 
-    bitset.add(b1, b1e);
-    bitset.add(b2, b2e);
+    bitset.addRange(b1, b1e);
+    bitset.addRange(b2, b2e);
 
     PeekableLongIterator bitIt = bitset.getLongIterator();
 
@@ -1797,9 +1797,9 @@ public class TestRoaring64Bitmap {
     long b3 = 6000000000L;
     long b3e = b3 + runLength;
 
-    bitset.add(b1, b1e);
-    bitset.add(b2, b2e);
-    bitset.add(b3, b3e);
+    bitset.addRange(b1, b1e);
+    bitset.addRange(b2, b2e);
+    bitset.addRange(b3, b3e);
 
     PeekableLongIterator bitIt = bitset.getLongIterator();
 
@@ -1853,8 +1853,8 @@ public class TestRoaring64Bitmap {
     long p2 = b2 + (b2s / 2);
     long pgap = p2 - b1s;
 
-    bitset.add(b1, b1e);
-    bitset.add(b2, b2e);
+    bitset.addRange(b1, b1e);
+    bitset.addRange(b2, b2e);
 
     PeekableLongIterator bitIt = bitset.getReverseLongIterator();
 
@@ -1895,9 +1895,9 @@ public class TestRoaring64Bitmap {
     long b3 = 6000000000L;
     long b3e = b3 + runLength;
 
-    bitset.add(b1, b1e);
-    bitset.add(b2, b2e);
-    bitset.add(b3, b3e);
+    bitset.addRange(b1, b1e);
+    bitset.addRange(b2, b2e);
+    bitset.addRange(b3, b3e);
 
     PeekableLongIterator bitIt = bitset.getReverseLongIterator();
 
@@ -1942,7 +1942,7 @@ public class TestRoaring64Bitmap {
   @Test
   public void testLongTreatedAsUnsignedOnAdvance() {
     Roaring64Bitmap bitset = new Roaring64Bitmap();
-    bitset.add(Long.MAX_VALUE, Long.MIN_VALUE + 3);
+    bitset.addRange(Long.MAX_VALUE, Long.MIN_VALUE + 3);
 
     PeekableLongIterator bitIt = bitset.getLongIterator();
 
@@ -1956,7 +1956,7 @@ public class TestRoaring64Bitmap {
   @Test
   public void testLongTreatedAsUnsignedOnAdvanceReverse() {
     Roaring64Bitmap bitset = new Roaring64Bitmap();
-    bitset.add(Long.MAX_VALUE, Long.MIN_VALUE + 3);
+    bitset.addRange(Long.MAX_VALUE, Long.MIN_VALUE + 3);
 
     PeekableLongIterator bitIt = bitset.getReverseLongIterator();
 
@@ -2000,7 +2000,7 @@ public class TestRoaring64Bitmap {
   @Test
   public void testForAllInRangeContinuous() {
     Roaring64Bitmap bitmap = new Roaring64Bitmap();
-    bitmap.add(100L, 10000L);
+    bitmap.addRange(100L, 10000L);
 
     ValidationRangeConsumer consumer = ValidationRangeConsumer.validateContinuous(9900, PRESENT);
     bitmap.forAllInRange(100, 9900, consumer);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
@@ -1141,7 +1141,7 @@ public class TestRoaring64NavigableMap {
   public void testAddRange_SingleBucket_NotBuffer() {
     Roaring64NavigableMap map = newUnsignedHeap();
 
-    map.add(5L, 12L);
+    map.addRange(5L, 12L);
     assertEquals(7L, map.getLongCardinality());
 
     assertEquals(5L, map.select(0));
@@ -1153,7 +1153,7 @@ public class TestRoaring64NavigableMap {
   public void testAddRange_SingleBucket_Buffer() {
     Roaring64NavigableMap map = newSignedBuffered();
 
-    map.add(5L, 12L);
+    map.addRange(5L, 12L);
     assertEquals(7L, map.getLongCardinality());
 
     assertEquals(5L, map.select(0));
@@ -1168,7 +1168,7 @@ public class TestRoaring64NavigableMap {
 
     long end = Util.toUnsignedLong(-1) + 1;
 
-    map.add(end - 2, end);
+    map.addRange(end - 2, end);
     assertEquals(2, map.getLongCardinality());
 
     assertEquals(end - 2, map.select(0));
@@ -1184,7 +1184,7 @@ public class TestRoaring64NavigableMap {
 
     long from = RoaringIntPacking.pack(0, -1 - enableTrim);
     long to = from + 2 * enableTrim;
-    map.add(from, to);
+    map.addRange(from, to);
     int nbItems = (int) (to - from);
     assertEquals(nbItems, map.getLongCardinality());
 
@@ -1212,7 +1212,7 @@ public class TestRoaring64NavigableMap {
     long outOfSingleRoaring = outOfRoaringBitmapRange - 3;
 
     // This should fill entirely one bitmap,and add one in the next bitmap
-    map.add(0, outOfSingleRoaring);
+    map.addRange(0, outOfSingleRoaring);
     assertEquals(outOfSingleRoaring, map.getLongCardinality());
 
     assertEquals(outOfSingleRoaring, map.getLongCardinality());
@@ -1577,11 +1577,11 @@ public class TestRoaring64NavigableMap {
   public void testAndNot_ImplicitRoaringBitmap() {
     // Based on RoaringBitmap
     Roaring64NavigableMap x = new Roaring64NavigableMap();
-    x.add(8, 16);
+    x.addRange(8, 16);
 
     // Based on MutableRoaringBitmap
     Roaring64NavigableMap y = new Roaring64NavigableMap();
-    y.add(12, 32);
+    y.addRange(12, 32);
 
     {
       x.andNot(y);
@@ -1616,7 +1616,7 @@ public class TestRoaring64NavigableMap {
   public void testNaivelazyor_ImplicitRoaringBitmap() {
     // Based on RoaringBitmap
     Roaring64NavigableMap x = new Roaring64NavigableMap();
-    x.add(123, 124);
+    x.addRange(123, 124);
 
     // Based on MutableRoaringBitmap
     Roaring64NavigableMap y = Roaring64NavigableMap.bitmapOf(4L);


### PR DESCRIPTION
### SUMMARY

In some cases, the 'contains(x,y)' function may return false whereas all elements of the interval '[x,y)' are in the bitmap. This verifies the issue and fixes it.

Fixes https://github.com/RoaringBitmap/RoaringBitmap/issues/623


I have also taken the opportunity to remove some deprecated methods from our tests, which should silence some annoying warnings.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
