### PR TITLE
Update MutableRoaringBitmap.java

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
@@ -15,7 +15,7 @@ import java.util.Iterator;
  * MutableRoaringBitmap, a compressed alternative to the BitSet. It is similar to
  * org.roaringbitmap.RoaringBitmap, but it differs in that it can interact with
  * ImmutableRoaringBitmap objects in the sense that MutableRoaringBitmap is
- * derived from MutableRoaringBitmap.
+ * derived from ImmutableRoaringBitmap.
  *
  * A MutableRoaringBitmap is an instance of an ImmutableRoaringBitmap (where methods like
  * "serialize" are implemented). That is, they both share the same core (immutable) methods, but a


### PR DESCRIPTION
update javadoc

### SUMMARY
- MutableRoaringBitmap.java doc update `MutableRoaringBitmap is
 derived from MutableRoaringBitmap` to  `MutableRoaringBitmap is
 derived from ImmutableRoaringBitmap`

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
