### PR TITLE
Fix bug when BSI uses min max values for evaluation and some other improvements

### DIFF
--- a/bsi/src/main/java/org/roaringbitmap/bsi/BitmapSliceIndex.java
+++ b/bsi/src/main/java/org/roaringbitmap/bsi/BitmapSliceIndex.java
@@ -75,8 +75,14 @@ public interface BitmapSliceIndex {
    * currentMaxValue/currentMinValue are optional,it's can be compute from input value list.
    * and avoiding bsi expend slice array capacity.
    */
+  @Deprecated
   void setValues(List<Pair<Integer, Integer>> values, Integer currentMaxValue, Integer currentMinValue);
 
+  /**
+   * Set a batch of values.
+   * @param values
+   */
+  void setValues(List<Pair<Integer, Integer>> values);
 
   void serialize(ByteBuffer buffer) throws IOException;
 

--- a/bsi/src/main/java/org/roaringbitmap/bsi/buffer/BitSliceIndexBase.java
+++ b/bsi/src/main/java/org/roaringbitmap/bsi/buffer/BitSliceIndexBase.java
@@ -4,6 +4,7 @@ package org.roaringbitmap.bsi.buffer;
 import org.roaringbitmap.BatchIterator;
 import org.roaringbitmap.IntConsumer;
 import org.roaringbitmap.IntIterator;
+import org.roaringbitmap.RoaringBitmap;
 import org.roaringbitmap.bsi.BitmapSliceIndex;
 import org.roaringbitmap.bsi.Pair;
 import org.roaringbitmap.buffer.BufferFastAggregation;
@@ -412,11 +413,10 @@ public class BitSliceIndexBase {
    * @return columnId set we found in this bsi with giving conditions, using RoaringBitmap to express
    */
   public ImmutableRoaringBitmap compare(BitmapSliceIndex.Operation operation, int startOrValue, int end, ImmutableRoaringBitmap foundSet) {
-    // todo whether we need this or not?
-    if (startOrValue > this.maxValue || (end > 0 && end < this.minValue)) {
-      return new MutableRoaringBitmap();
+    ImmutableRoaringBitmap result = compareUsingMinMax(operation, startOrValue, end, foundSet);
+    if (result != null) {
+      return result;
     }
-    startOrValue = startOrValue == 0 ? 1 : startOrValue;
 
     switch (operation) {
       case EQ:
@@ -443,6 +443,72 @@ public class BitSliceIndexBase {
       default:
         throw new IllegalArgumentException("not support operation!");
     }
+  }
+
+  private ImmutableRoaringBitmap compareUsingMinMax(BitmapSliceIndex.Operation operation, int startOrValue, int end, ImmutableRoaringBitmap foundSet) {
+    ImmutableRoaringBitmap all = foundSet == null ? this.ebM.clone() : ImmutableRoaringBitmap.and(this.ebM, foundSet);
+    ImmutableRoaringBitmap empty = new MutableRoaringBitmap();
+
+    switch (operation) {
+      case LT:
+        if (startOrValue > maxValue) {
+          return all;
+        } else if (startOrValue <= minValue) {
+          return empty;
+        }
+
+        break;
+      case LE:
+        if (startOrValue >= maxValue) {
+          return all;
+        } else if (startOrValue < minValue) {
+          return empty;
+        }
+
+        break;
+      case GT:
+        if (startOrValue < minValue) {
+          return all;
+        } else if (startOrValue >= maxValue) {
+          return empty;
+        }
+
+        break;
+      case GE:
+        if (startOrValue <= minValue) {
+          return all;
+        } else if (startOrValue > maxValue) {
+          return empty;
+        }
+
+        break;
+      case EQ:
+        if (minValue == maxValue && minValue == startOrValue) {
+          return all;
+        } else if (startOrValue < minValue || startOrValue > maxValue) {
+          return empty;
+        }
+
+        break;
+      case NEQ:
+        if (minValue == maxValue) {
+          return minValue == startOrValue ? empty : all;
+        }
+
+        break;
+      case RANGE:
+        if (startOrValue <= minValue && end >= maxValue) {
+          return all;
+        } else if (startOrValue > maxValue || end < minValue) {
+          return empty;
+        }
+
+        break;
+      default:
+        return null;
+    }
+
+    return null;
   }
 
   public Pair<Long, Long> sum(ImmutableRoaringBitmap foundSet) {

--- a/bsi/src/main/java/org/roaringbitmap/bsi/buffer/BitSliceIndexBase.java
+++ b/bsi/src/main/java/org/roaringbitmap/bsi/buffer/BitSliceIndexBase.java
@@ -350,7 +350,7 @@ public class BitSliceIndexBase {
     }
 
     // https://github.com/RoaringBitmap/RoaringBitmap/issues/549
-    if((predicate >> (this.bA.length - 1)) != 0) {
+    if((predicate >> (this.bA.length)) != 0) {
       return new MutableRoaringBitmap();
     }
 

--- a/bsi/src/main/java/org/roaringbitmap/bsi/buffer/BitSliceIndexBase.java
+++ b/bsi/src/main/java/org/roaringbitmap/bsi/buffer/BitSliceIndexBase.java
@@ -351,8 +351,9 @@ public class BitSliceIndexBase {
     }
 
     // https://github.com/RoaringBitmap/RoaringBitmap/issues/549
-    if((predicate >> (this.bA.length)) != 0) {
-      return new MutableRoaringBitmap();
+    ImmutableRoaringBitmap result = compareUsingMinMax(BitmapSliceIndex.Operation.EQ, predicate, 0, foundSet);
+    if (result != null) {
+      return result;
     }
 
     for (int i = this.bA.length - 1; i >= 0; i--) {

--- a/bsi/src/main/java/org/roaringbitmap/bsi/buffer/ImmutableBitSliceIndex.java
+++ b/bsi/src/main/java/org/roaringbitmap/bsi/buffer/ImmutableBitSliceIndex.java
@@ -91,6 +91,11 @@ public class ImmutableBitSliceIndex extends BitSliceIndexBase implements BitmapS
     throw new UnsupportedOperationException("ImmutableBSI don't support setValues");
   }
 
+  @Override
+  public void setValues(List<Pair<Integer, Integer>> values) {
+    throw new UnsupportedOperationException("ImmutableBSI does not support setting values");
+  }
+
 
   public void add(BitmapSliceIndex otherBitmapSliceIndex) {
     throw new UnsupportedOperationException("ImmutableBSI don't support add");

--- a/bsi/src/test/java/org/roaringbitmap/bsi/BufferBSITest.java
+++ b/bsi/src/test/java/org/roaringbitmap/bsi/BufferBSITest.java
@@ -212,6 +212,11 @@ public class BufferBSITest {
         Assertions.assertTrue(bitmap.getLongCardinality() == 50L);
         ImmutableRoaringBitmap bitmap129 = bsi.toImmutableBitSliceIndex().rangeEQ(null, 129);
         Assertions.assertTrue(bitmap129.getLongCardinality() == 0L);
+
+
+        ImmutableRoaringBitmap bitmap99 = bsi.toImmutableBitSliceIndex().rangeEQ(null, 99);
+        Assertions.assertTrue(bitmap99.getLongCardinality() == 1L);
+        Assertions.assertTrue(bitmap99.contains(99));
     }
 
 

--- a/bsi/src/test/java/org/roaringbitmap/bsi/BufferBSITest.java
+++ b/bsi/src/test/java/org/roaringbitmap/bsi/BufferBSITest.java
@@ -80,7 +80,7 @@ public class BufferBSITest {
         List<Pair<Integer, Integer>> collect = testDataSet.entrySet()
                 .stream().map(x -> Pair.newPair(x.getKey(), x.getValue())).collect(Collectors.toList());
 
-        bsi.setValues(collect, 99, 1);
+        bsi.setValues(collect);
 
         Assertions.assertEquals(bsi.getExistenceBitmap().getLongCardinality(), 99);
         final MutableBitSliceIndex clone = bsi.clone();

--- a/bsi/src/test/java/org/roaringbitmap/bsi/RBBsiTest.java
+++ b/bsi/src/test/java/org/roaringbitmap/bsi/RBBsiTest.java
@@ -67,7 +67,7 @@ public class RBBsiTest {
         List<Pair<Integer, Integer>> collect = testDataSet.entrySet()
                 .stream().map(x -> Pair.newPair(x.getKey(), x.getValue())).collect(Collectors.toList());
 
-        bsi.setValues(collect, 99, 1);
+        bsi.setValues(collect);
 
         Assertions.assertEquals(bsi.getExistenceBitmap().getLongCardinality(), 99);
         final RoaringBitmapSliceIndex clone = bsi.clone();

--- a/bsi/src/test/java/org/roaringbitmap/bsi/RBBsiTest.java
+++ b/bsi/src/test/java/org/roaringbitmap/bsi/RBBsiTest.java
@@ -101,6 +101,24 @@ public class RBBsiTest {
         });
     }
 
+    @Test
+    public void testAddAndEvaluate() {
+        RoaringBitmapSliceIndex bsiA = new RoaringBitmapSliceIndex();
+        IntStream.range(1, 100).forEach(x -> bsiA.setValue(x, x));
+        RoaringBitmapSliceIndex bsiB = new RoaringBitmapSliceIndex();
+        IntStream.range(1, 120).forEach(x -> bsiB.setValue(120 - x, x));
+
+        bsiA.add(bsiB);
+
+        RoaringBitmap result = bsiA.compare(BitmapSliceIndex.Operation.EQ, 120, 0, null);
+        Assertions.assertTrue(result.getLongCardinality() == 99);
+        Assertions.assertArrayEquals(result.toArray(), IntStream.range(1, 100).toArray());
+
+        result = bsiA.compare(BitmapSliceIndex.Operation.RANGE, 1, 20, null);
+        Assertions.assertTrue(result.getLongCardinality() == 20);
+        Assertions.assertArrayEquals(result.toArray(), IntStream.range(100, 120).toArray());
+    }
+
 
     @Test
     public void TestIO4Stream() throws IOException {
@@ -176,6 +194,34 @@ public class RBBsiTest {
 
     }
 
+    @Test
+    public void testNotEQ() {
+        bsi = new RoaringBitmapSliceIndex();
+        bsi.setValue(1, 99);
+        bsi.setValue(2, 1);
+        bsi.setValue(3, 50);
+
+        RoaringBitmap result = bsi.compare(BitmapSliceIndex.Operation.NEQ, 99, 0, null);
+        Assertions.assertTrue(result.getLongCardinality() == 2);
+        Assertions.assertArrayEquals(new int[]{2, 3}, result.toArray());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.NEQ, 100, 0, null);
+        Assertions.assertTrue(result.getLongCardinality() == 3);
+        Assertions.assertArrayEquals(new int[]{1, 2, 3}, result.toArray());
+
+        bsi = new RoaringBitmapSliceIndex();
+        bsi.setValue(1, 99);
+        bsi.setValue(2, 99);
+        bsi.setValue(3, 99);
+
+        result = bsi.compare(BitmapSliceIndex.Operation.NEQ, 99, 0, null);
+        Assertions.assertTrue(result.isEmpty());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.NEQ, 1, 0, null);
+        Assertions.assertTrue(result.getLongCardinality() == 3);
+        Assertions.assertArrayEquals(new int[]{1, 2, 3}, result.toArray());
+    }
+
 
     // parallel operation test
 
@@ -184,6 +230,13 @@ public class RBBsiTest {
         RoaringBitmap result = bsi.compare(BitmapSliceIndex.Operation.GT, 50, 0, null);
         Assertions.assertTrue(result.getLongCardinality() == 49);
         Assertions.assertArrayEquals(IntStream.range(51, 100).toArray(), result.toArray());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.GT, 0, 0, null);
+        Assertions.assertTrue(result.getLongCardinality() == 99);
+        Assertions.assertArrayEquals(IntStream.range(1, 100).toArray(), result.toArray());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.GT, 99, 0, null);
+        Assertions.assertTrue(result.isEmpty());
     }
 
 
@@ -192,6 +245,13 @@ public class RBBsiTest {
         RoaringBitmap result = bsi.compare(BitmapSliceIndex.Operation.GE, 50, 0, null);
         Assertions.assertTrue(result.getLongCardinality() == 50);
         Assertions.assertArrayEquals(IntStream.range(50, 100).toArray(), result.toArray());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.GE, 1, 0, null);
+        Assertions.assertTrue(result.getLongCardinality() == 99);
+        Assertions.assertArrayEquals(IntStream.range(1, 100).toArray(), result.toArray());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.GE, 100, 0, null);
+        Assertions.assertTrue(result.isEmpty());
     }
 
     @Test
@@ -199,6 +259,13 @@ public class RBBsiTest {
         RoaringBitmap result = bsi.compare(BitmapSliceIndex.Operation.LT, 50, 0, null);
         Assertions.assertTrue(result.getLongCardinality() == 49);
         Assertions.assertArrayEquals(IntStream.range(1, 50).toArray(), result.toArray());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.LT, Integer.MAX_VALUE, 0, null);
+        Assertions.assertTrue(result.getLongCardinality() == 99);
+        Assertions.assertArrayEquals(IntStream.range(1, 100).toArray(), result.toArray());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.LT, 1, 0, null);
+        Assertions.assertTrue(result.isEmpty());
     }
 
 
@@ -207,6 +274,13 @@ public class RBBsiTest {
         RoaringBitmap result = bsi.compare(BitmapSliceIndex.Operation.LE, 50, 0, null);
         Assertions.assertTrue(result.getLongCardinality() == 50);
         Assertions.assertArrayEquals(IntStream.range(1, 51).toArray(), result.toArray());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.LE, Integer.MAX_VALUE, 0, null);
+        Assertions.assertTrue(result.getLongCardinality() == 99);
+        Assertions.assertArrayEquals(IntStream.range(1, 100).toArray(), result.toArray());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.LE, 0, 0, null);
+        Assertions.assertTrue(result.isEmpty());
     }
 
     @Test
@@ -214,6 +288,13 @@ public class RBBsiTest {
         RoaringBitmap result = bsi.compare(BitmapSliceIndex.Operation.RANGE, 10, 20, null);
         Assertions.assertTrue(result.getLongCardinality() == 11);
         Assertions.assertArrayEquals(IntStream.range(10, 21).toArray(), result.toArray());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.RANGE, 1, 200, null);
+        Assertions.assertTrue(result.getLongCardinality() == 99);
+        Assertions.assertArrayEquals(IntStream.range(1, 100).toArray(), result.toArray());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.RANGE, 1000, 2000, null);
+        Assertions.assertTrue(result.isEmpty());
     }
 
     @Test
@@ -233,6 +314,20 @@ public class RBBsiTest {
         Assertions.assertTrue(sumPair.getLeft().intValue() == sum && sumPair.getRight() == count);
     }
 
+    @Test
+    public void testValueZero() {
+        bsi = new RoaringBitmapSliceIndex();
+        bsi.setValue(0, 0);
+        bsi.setValue(1, 0);
+        bsi.setValue(2, 1);
 
+        RoaringBitmap result = bsi.compare(BitmapSliceIndex.Operation.EQ, 0, 0, null);
+        Assertions.assertTrue(result.getLongCardinality() == 2);
+        Assertions.assertArrayEquals(new int[]{0, 1}, result.toArray());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.EQ, 1, 0, null);
+        Assertions.assertTrue(result.getLongCardinality() == 1);
+        Assertions.assertArrayEquals(new int[]{2}, result.toArray());
+    }
 }
 


### PR DESCRIPTION
### SUMMARY
- Describe your changes, including rationale and design decisions

This PR fixes the bug when BSI using the max value for evaluation, currently BSI uses below logic  in comparing: https://github.com/RoaringBitmap/RoaringBitmap/blob/d9d0914ea78d0b25fb5813159a0a1230d701b5ee/bsi/src/main/java/org/roaringbitmap/bsi/RoaringBitmapSliceIndex.java#L410-L415

which is not correct. For example, when the operation is `NEQ` or `LE`,  if the `startOrValue` is greater than the `maxValue`, the return should not be an empty set, but the full set of all values.
To fix this, this add a `compareUsingMinMax` method to deal with different operations. This also fixes the bug that the min value and the max value are not updated after the `add` operation,  this recalculate and update min and max values after each `add` call.  This PR adds more tests to cover evaluation of boundary values.
   
- If your pull request includes new functionality, then you must have corresponding new tests.
This PR does not introduce new functionalities.
- We require all Java files to be ASCII-only to avoid compatibility problems.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
