### PR TITLE
More performant integer shift left by bytes

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/IntegerUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/IntegerUtil.java
@@ -50,9 +50,13 @@ public class IntegerUtil {
    * @return a fresh integer value
    */
   public static int shiftLeftFromSpecifiedPosition(int v, int pos, int count) {
-    byte[] initialVal = toBDBytes(v);
-    System.arraycopy(initialVal, pos + 1, initialVal, pos, count);
-    return fromBDBytes(initialVal);
+    if (count != 0) {
+      int shiftToLeft = (4 - count) << 3;
+      int shiftToRight = shiftToLeft - (pos << 3);
+      int maskShifted = 0xFFFFFFFF >>> shiftToLeft << shiftToRight;
+      v = (v & ~maskShifted) | (v << 8 & maskShifted);
+    }
+    return v;
   }
 
   /**

--- a/jmh/src/jmh/java/org/roaringbitmap/longlong/ShiftLeftFromSpecifiedPositionBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/longlong/ShiftLeftFromSpecifiedPositionBenchmark.java
@@ -1,0 +1,38 @@
+package org.roaringbitmap.longlong;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+public class ShiftLeftFromSpecifiedPositionBenchmark {
+
+  public int v = 1234567890; // some value
+
+  @Param({"0", "2"})
+  public int pos;
+
+  @Param({"1", "2"})
+  public int count;
+
+  @Benchmark
+  public void optimized(Blackhole blackhole) {
+    blackhole.consume(IntegerUtil.shiftLeftFromSpecifiedPosition(v, pos, count));
+  }
+
+  @Benchmark
+  public void original(Blackhole blackhole) {
+    blackhole.consume(shiftLeftFromSpecifiedPosition(v, pos, count));
+  }
+
+  public static int shiftLeftFromSpecifiedPosition(int v, int pos, int count) {
+    byte[] initialVal = IntegerUtil.toBDBytes(v);
+    System.arraycopy(initialVal, pos + 1, initialVal, pos, count);
+    return IntegerUtil.fromBDBytes(initialVal);
+  }
+}


### PR DESCRIPTION
Test for changed method `IntegerUtil.shiftLeftFromSpecifiedPosition()` already existed - `IntegerUtilTest.testShiftLeftFromSpecifiedPosition()`.

Simple comparison benchmark `ShiftLeftFromSpecifiedPositionBenchmark` also created, I suppose it should be removed after verification and before merge.