### PR TITLE
Avoid intermediate byte array creation

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node16.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/Node16.java
@@ -169,10 +169,8 @@ public class Node16 extends Node {
       return currentNode16;
     } else {
       Node48 node48 = new Node48(currentNode16.prefixLength);
-      byte[] firtBytes = LongUtils.toBDBytes(currentNode16.firstV);
       for (int i = 0; i < 8; i++) {
-        byte v = firtBytes[i];
-        int unsignedIdx = Byte.toUnsignedInt(v);
+        int unsignedIdx = Byte.toUnsignedInt((byte) (currentNode16.firstV >>> ((7 - i) << 3)));
         //i won't be beyond 48
         Node48.setOneByte(unsignedIdx, (byte) i, node48.childIndex);
         node48.children[i] = currentNode16.children[i];

--- a/jmh/src/jmh/java/org/roaringbitmap/IntermediateByteArrayBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/IntermediateByteArrayBenchmark.java
@@ -1,0 +1,38 @@
+package org.roaringbitmap;
+
+import org.openjdk.jmh.annotations.*;
+import org.roaringbitmap.longlong.LongUtils;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 3, timeUnit = TimeUnit.MILLISECONDS, time = 1000)
+@Measurement(iterations = 5, timeUnit = TimeUnit.MILLISECONDS, time = 1000)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class IntermediateByteArrayBenchmark {
+
+    public long firstV = 0xaa_b3_41_23_22_25_33_43L; // some random value
+
+    @Benchmark
+    public int original() {
+        byte[] firtBytes = LongUtils.toBDBytes(firstV);
+        int unsignedIdx = 0;
+        for (int i = 0; i < 8; i++) {
+            byte v = firtBytes[i];
+            unsignedIdx += Byte.toUnsignedInt(v);
+            // some other stuff...
+        }
+        return unsignedIdx;
+    }
+
+    @Benchmark
+    public int optimized() {
+        int unsignedIdx = 0;
+        for (int i = 0; i < 8; i++) {
+            unsignedIdx += Byte.toUnsignedInt((byte) (firstV >>> ((7 - i) << 3)));
+            // some other stuff...
+        }
+        return unsignedIdx;
+    }
+}


### PR DESCRIPTION
Tiny performance improvement for `Node16.insert()` operation, see created benchmark.