### PR TITLE
Unified lowest set bit

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
@@ -28,7 +28,7 @@ public class BitSetUtil {
     for (int i = from, socket = 0; i < to; ++i, socket += Long.SIZE) {
       long word = words[i];
       while (word != 0) {
-        long t = word & -word;
+        long t = word & (word - 1);
         content[index++] = (char) (socket + Long.bitCount(t - 1));
         word ^= t;
       }


### PR DESCRIPTION
Use the same expression for lowest set bit extraction within whole project as there exists two equivalent expressions  - `word & -word` and `word & (word - 1)` - just for correctness only.

Note that, both has the same performance as I do not provide benchmark for this.