### PR TITLE
More performant toString() methods

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -1278,14 +1278,14 @@ public final class ArrayContainer extends Container implements Cloneable {
     if (this.cardinality == 0) {
       return "{}";
     }
-    StringBuilder sb = new StringBuilder();
-    sb.append("{");
+    StringBuilder sb = new StringBuilder("{}".length() + "-123456789,".length() * cardinality);
+    sb.append('{');
     for (int i = 0; i < this.cardinality - 1; i++) {
       sb.append((int)(this.content[i]));
-      sb.append(",");
+      sb.append(',');
     }
     sb.append((int)(this.content[this.cardinality - 1]));
-    sb.append("}");
+    sb.append('}');
     return sb.toString();
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -1320,16 +1320,16 @@ public final class BitmapContainer extends Container implements Cloneable {
 
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder();
+    StringBuilder sb = new StringBuilder("{}".length() + "-123456789,".length() * 256);
     final CharIterator i = this.getCharIterator();
-    sb.append("{");
+    sb.append('{');
     while (i.hasNext()) {
       sb.append((int)(i.next()));
       if (i.hasNext()) {
-        sb.append(",");
+        sb.append(',');
       }
     }
-    sb.append("}");
+    sb.append('}');
     return sb.toString();
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -3103,23 +3103,22 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
    */
   @Override
   public String toString() {
-    final StringBuilder answer = new StringBuilder();
+    final StringBuilder answer = new StringBuilder("{}".length() + "-123456789,".length() * 256);
     final IntIterator i = this.getIntIterator();
-    answer.append("{");
+    answer.append('{');
     if (i.hasNext()) {
       answer.append(i.next() & 0xFFFFFFFFL);
     }
     while (i.hasNext()) {
-      answer.append(",");
+      answer.append(',');
       // to avoid using too much memory, we limit the size
       if(answer.length() > 0x80000) {
-        answer.append("...");
+        answer.append('.').append('.').append('.');
         break;
       }
       answer.append(i.next() & 0xFFFFFFFFL);
-
     }
-    answer.append("}");
+    answer.append('}');
     return answer.toString();
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -2369,13 +2369,13 @@ public final class RunContainer extends Container implements Cloneable {
 
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder();
+    StringBuilder sb = new StringBuilder("[]".length() + "-123456789,".length() * nbrruns);
     for (int k = 0; k < this.nbrruns; ++k) {
-      sb.append("[");
+      sb.append('[');
       sb.append((int)(this.getValue(k)));
-      sb.append(",");
+      sb.append(',');
       sb.append((this.getValue(k)) + (this.getLength(k)));
-      sb.append("]");
+      sb.append(']');
     }
     return sb.toString();
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -1903,22 +1903,22 @@ public class ImmutableRoaringBitmap
    */
   @Override
   public String toString() {
-    final StringBuilder answer = new StringBuilder();
+    final StringBuilder answer = new StringBuilder("{}".length() + "-123456789,".length() * 256);
     final IntIterator i = this.getIntIterator();
-    answer.append("{");
+    answer.append('{');
     if (i.hasNext()) {
       answer.append(i.next() & 0xFFFFFFFFL);
     }
     while (i.hasNext()) {
-      answer.append(",");
+      answer.append(',');
       // to avoid using too much memory, we limit the size
       if(answer.length() > 0x80000) {
-        answer.append("...");
+        answer.append('.').append('.').append('.');
         break;
       }
       answer.append(i.next() & 0xFFFFFFFFL);
     }
-    answer.append("}");
+    answer.append('}');
     return answer.toString();
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -1590,14 +1590,14 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     if (this.cardinality == 0) {
       return "{}";
     }
-    final StringBuilder sb = new StringBuilder();
-    sb.append("{");
+    final StringBuilder sb = new StringBuilder("{}".length() + "-123456789,".length() * cardinality);
+    sb.append('{');
     for (int i = 0; i < this.cardinality - 1; i++) {
       sb.append((int)(this.content.get(i)));
-      sb.append(",");
+      sb.append(',');
     }
     sb.append((int)(this.content.get(this.cardinality - 1)));
-    sb.append("}");
+    sb.append('}');
     return sb.toString();
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -1590,7 +1590,8 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     if (this.cardinality == 0) {
       return "{}";
     }
-    final StringBuilder sb = new StringBuilder("{}".length() + "-123456789,".length() * cardinality);
+    final StringBuilder sb = new StringBuilder("{}".length() + "-123456789,".length()
+        * cardinality);
     sb.append('{');
     for (int i = 0; i < this.cardinality - 1; i++) {
       sb.append((int)(this.content.get(i)));

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -1761,16 +1761,16 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
 
   @Override
   public String toString() {
-    final StringBuilder sb = new StringBuilder();
+    final StringBuilder sb = new StringBuilder("{}".length() + "-123456789,".length() * 256);
     final CharIterator i = this.getCharIterator();
-    sb.append("{");
+    sb.append('{');
     while (i.hasNext()) {
       sb.append((int)(i.next()));
       if (i.hasNext()) {
-        sb.append(",");
+        sb.append(',');
       }
     }
-    sb.append("}");
+    sb.append('}');
     return sb.toString();
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -2326,14 +2326,14 @@ public final class MappeableRunContainer extends MappeableContainer implements C
 
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder();
+    StringBuilder sb = new StringBuilder("[]".length() + "-123456789,".length() * nbrruns);
     for (int k = 0; k < this.nbrruns; ++k) {
-      sb.append("[");
+      sb.append('[');
       sb.append((int)(this.getValue(k)));
-      sb.append(",");
+      sb.append(',');
       sb.append((this.getValue(k))
           + (this.getLength(k)));
-      sb.append("]");
+      sb.append(']');
     }
     return sb.toString();
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/insights/NaiveWriterRecommender.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/insights/NaiveWriterRecommender.java
@@ -15,7 +15,7 @@ public class NaiveWriterRecommender {
     if (s.containerCount() == 0) {
       return "Empty statistics, cannot recommend.";
     }
-    StringBuilder sb = new StringBuilder();
+    StringBuilder sb = new StringBuilder(600);
     containerCountRecommendations(s, sb);
     double acFraction = s.containerFraction(s.getArrayContainersStats().getContainersCount());
     if (acFraction > ArrayContainersDomination) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -491,17 +491,17 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
    */
   @Override
   public String toString() {
-    final StringBuilder answer = new StringBuilder();
+    final StringBuilder answer = new StringBuilder("{}".length() + "-1234567890123456789,".length() * 256);
     final LongIterator i = this.getLongIterator();
-    answer.append("{");
+    answer.append('{');
     if (i.hasNext()) {
       answer.append(i.next());
     }
     while (i.hasNext()) {
-      answer.append(",");
+      answer.append(',');
       // to avoid using too much memory, we limit the size
       if (answer.length() > 0x80000) {
-        answer.append("...");
+        answer.append('.').append('.').append('.');
         break;
       }
       answer.append(i.next());

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -491,7 +491,8 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
    */
   @Override
   public String toString() {
-    final StringBuilder answer = new StringBuilder("{}".length() + "-1234567890123456789,".length() * 256);
+    final StringBuilder answer = new StringBuilder("{}".length() + "-1234567890123456789,".length()
+        * 256);
     final LongIterator i = this.getLongIterator();
     answer.append('{');
     if (i.hasNext()) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
@@ -996,7 +996,8 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
    */
   @Override
   public String toString() {
-    final StringBuilder answer = new StringBuilder("{}".length() + "-1234567890123456789,".length() * 256);
+    final StringBuilder answer = new StringBuilder("{}".length() + "-1234567890123456789,".length()
+        * 256);
     final LongIterator i = this.getLongIterator();
     answer.append('{');
     if (i.hasNext()) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
@@ -996,9 +996,9 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
    */
   @Override
   public String toString() {
-    final StringBuilder answer = new StringBuilder();
+    final StringBuilder answer = new StringBuilder("{}".length() + "-1234567890123456789,".length() * 256);
     final LongIterator i = this.getLongIterator();
-    answer.append("{");
+    answer.append('{');
     if (i.hasNext()) {
       if (signedLongs) {
         answer.append(i.next());
@@ -1007,10 +1007,10 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
       }
     }
     while (i.hasNext()) {
-      answer.append(",");
+      answer.append(',');
       // to avoid using too much memory, we limit the size
       if (answer.length() > 0x80000) {
-        answer.append("...");
+        answer.append('.').append('.').append('.');
         break;
       }
       if (signedLongs) {


### PR DESCRIPTION
There are used two ways to increase the performance of String creation:
1. Use `StringBuilder.append(char)` instead of `StringBuilder.append(String)`. The first one is more performant even for several chars, not only for one.
2. Allocation sufficient space for `StringBuilder` instance as this avoids backed char array repeated initialization (and copy).