### PR TITLE
Optimized getCardinality() for (Mappeable)RunContainer

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -1007,8 +1007,8 @@ public final class RunContainer extends Container implements Cloneable {
   @Override
   public int getCardinality() {
     int sum = nbrruns;// lengths are returned -1
-    for (int k = 0; k < nbrruns; ++k) {
-      sum = sum + (getLength(k))/* + 1 */;
+    for (int k = 1; k < nbrruns * 2; k++) {
+      sum += valueslength[k];
     }
     return sum;
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -1007,7 +1007,7 @@ public final class RunContainer extends Container implements Cloneable {
   @Override
   public int getCardinality() {
     int sum = nbrruns;// lengths are returned -1
-    for (int k = 1; k < nbrruns * 2; k++) {
+    for (int k = 1; k < nbrruns * 2; k += 2) {
       sum += valueslength[k];
     }
     return sum;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -914,15 +914,15 @@ public final class MappeableRunContainer extends MappeableContainer implements C
   @Override
   public int getCardinality() {
     int sum = nbrruns; // lengths are stored -1
-    int limit = nbrruns * 2 + 2;
-    if (isArrayBacked()) {
+    int limit = nbrruns * 2;
+    if (isArrayBacked() || !valueslength.isReadOnly()) {
       char[] vl = valueslength.array();
       for (int k = 1; k < limit; k += 2) {
-        sum += vl[k]/* + 1 */;
+        sum += vl[k];
       }
     } else {
       for (int k = 1; k < limit; k += 2) {
-        sum += valueslength.get(k)/* + 1 */;
+        sum += valueslength.get(k);
       }
     }
     return sum;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -915,7 +915,7 @@ public final class MappeableRunContainer extends MappeableContainer implements C
   public int getCardinality() {
     int sum = nbrruns; // lengths are stored -1
     int limit = nbrruns * 2;
-    if (isArrayBacked() || !valueslength.isReadOnly()) {
+    if (isArrayBacked()) {
       char[] vl = valueslength.array();
       for (int k = 1; k < limit; k += 2) {
         sum += vl[k];

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -914,14 +914,15 @@ public final class MappeableRunContainer extends MappeableContainer implements C
   @Override
   public int getCardinality() {
     int sum = nbrruns; // lengths are stored -1
+    int limit = nbrruns * 2 + 2;
     if (isArrayBacked()) {
       char[] vl = valueslength.array();
-      for (int k = 0; k < nbrruns; ++k) {
-        sum = sum + (vl[2 * k + 1])/* + 1 */;
+      for (int k = 1; k < limit; k += 2) {
+        sum += vl[k]/* + 1 */;
       }
     } else {
-      for (int k = 0; k < nbrruns; ++k) {
-        sum = sum + (getLength(k))/* + 1 */;
+      for (int k = 1; k < limit; k += 2) {
+        sum += valueslength.get(k)/* + 1 */;
       }
     }
     return sum;

--- a/jmh/src/jmh/java/org/roaringbitmap/runcontainer/GetCardinalityMappeableContainerBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/runcontainer/GetCardinalityMappeableContainerBenchmark.java
@@ -1,0 +1,63 @@
+package org.roaringbitmap.runcontainer;
+
+import org.openjdk.jmh.annotations.*;
+import org.roaringbitmap.buffer.MappeableContainer;
+import org.roaringbitmap.buffer.MappeableRunContainer;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+public class GetCardinalityMappeableContainerBenchmark {
+
+  @Benchmark
+  public int getCardinality_negatedUniformHash(BenchmarkState state) {
+    return state.mc1.getCardinality();
+  }
+
+  @Benchmark
+  public int getCardinality_uniformHash1(BenchmarkState state) {
+    return state.mc2.getCardinality();
+  }
+
+  @Benchmark
+  public int getCardinality_uniformHash2(BenchmarkState state) {
+    return state.mc3.getCardinality();
+  }
+
+  @Benchmark
+  public int getCardinality_crazyRun(BenchmarkState state) {
+    return state.mc4.getCardinality();
+  }
+
+  @State(Scope.Benchmark)
+  public static class BenchmarkState {
+    private static final int OFF_VALUES = 32;
+    private static final int BIT_SET_PER_WORD2 = 63;
+    private static final int BIT_SET_PER_WORD3 = 1;
+    MappeableContainer mc1, mc2, mc3, mc4;
+
+    public BenchmarkState() {
+      Random rand = new Random();
+      final int max = 1 << 16;
+      final int howManyWords = (1 << 16) / 64;
+      int[] values1 = RandomUtil.negate(RandomUtil.generateUniformHash(rand, OFF_VALUES, max), max);
+      int[] values2 = RandomUtil.generateUniformHash(rand, BIT_SET_PER_WORD2 * howManyWords, max);
+      int[] values3 = RandomUtil.generateUniformHash(rand, BIT_SET_PER_WORD3 * howManyWords, max);
+      int[] values4 = RandomUtil.generateCrazyRun(rand, max);
+
+      mc1 = new MappeableRunContainer();
+      mc2 = new MappeableRunContainer();
+      mc3 = new MappeableRunContainer();
+      mc4 = new MappeableRunContainer();
+
+      for (int i : values1) { mc1.add((char) i); }
+      for (int i : values2) { mc2.add((char) i); }
+      for (int i : values3) { mc3.add((char) i); }
+      for (int i : values4) { mc4.add((char) i); }
+    }
+  }
+}


### PR DESCRIPTION
Only up to 10% more performant `MappeableRunContainer.getCardinality()`, analogously improved `RunContainer.getCardinality()`, but as it is basic functionality, it should be worthy still. Benchmark provided.

Off topic question: Isn't more correct naming "Mappable" instead of used "Mapp**e**able"? I know, this breaks backward API compatibility, but it can be done when new major version will be released (1.0).