### PR TITLE
646 - Fix  `.andNotCardinality`

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -910,8 +910,8 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
       } else if (s1 < s2) {
         while (s1 < s2 && pos1 < length1) {
           cardinality += x1.highLowContainer.getContainerAtIndex(pos1).getCardinality();
-          s1 = x1.highLowContainer.getKeyAtIndex(pos1);
           ++pos1;
+          s1 = x1.highLowContainer.getKeyAtIndex(pos1);
         }
       } else {
         pos2 = x2.highLowContainer.advanceUntil(s1, pos2);

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -2073,7 +2073,6 @@ public class TestRoaringBitmap {
         assertEquals(andNot.getCardinality(), RoaringBitmap.andNotCardinality(rb, rb2));
     }
 
-
     @Test
     public void testAndNotCardinalityBigVsSmall() {
         RoaringBitmap small = RoaringBitmap.bitmapOf(1, 2, 3);
@@ -2094,6 +2093,15 @@ public class TestRoaringBitmap {
         }
         RoaringBitmap andNot = RoaringBitmap.andNot(small, big);
         assertEquals(andNot.getCardinality(), RoaringBitmap.andNotCardinality(small, big));
+    }
+
+    @Test
+    public void testAndNotCardinality_646() {
+        RoaringBitmap rb = RoaringBitmap.bitmapOf(-587409880, 605467000);
+        RoaringBitmap rb2 = RoaringBitmap.bitmapOf(-587409880, 347844183);
+
+        RoaringBitmap andNot = RoaringBitmap.andNot(rb, rb2);
+        assertEquals(andNot.getCardinality(), RoaringBitmap.andNotCardinality(rb, rb2));
     }
 
     @Test

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
@@ -1362,6 +1362,15 @@ public class TestImmutableRoaringBitmap {
   }
 
   @Test
+  public void testAndNotCardinality_646() {
+    ImmutableRoaringBitmap rb = ImmutableRoaringBitmap.bitmapOf(-587409880, 605467000);
+    ImmutableRoaringBitmap rb2 = ImmutableRoaringBitmap.bitmapOf(-587409880, 347844183);
+
+    ImmutableRoaringBitmap andNot = ImmutableRoaringBitmap.andNot(rb, rb2);
+    assertEquals(andNot.getCardinality(), ImmutableRoaringBitmap.andNotCardinality(rb, rb2));
+  }
+
+  @Test
   public void testRankOverflow() {
     assertEquals(0, ImmutableRoaringBitmap.bitmapOf(65537).rank(1));
     assertEquals(1, ImmutableRoaringBitmap.bitmapOf(65537).rank(65537));


### PR DESCRIPTION
### SUMMARY
- Fix issue reported in https://github.com/RoaringBitmap/RoaringBitmap/issues/646

### Automated Checks

- [ ] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [ ] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
