### PR TITLE
Optimisation: Add zero-garbage deserialiser for ByteBuffer to RoaringBitmap

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
@@ -16,7 +16,7 @@ public class BitSetUtil {
 
   // a block consists has a maximum of 1024 words, each representing 64 bits,
   // thus representing at maximum 65536 bits
-  static final private int BLOCK_LENGTH = BitmapContainer.MAX_CAPACITY / Long.SIZE; //
+  public static final int BLOCK_LENGTH = BitmapContainer.MAX_CAPACITY / Long.SIZE; //
   // 64-bit
   // word
 
@@ -72,10 +72,6 @@ public class BitSetUtil {
     return ans;
   }
 
-  // To avoid memory allocation, reuse ThreadLocal buffers
-  private static final ThreadLocal<long[]> WORD_BLOCK = ThreadLocal.withInitial(() ->
-      new long[BLOCK_LENGTH]);
-
   /**
    * Efficiently generate a RoaringBitmap from an uncompressed byte array or ByteBuffer
    * This method tries to minimise all kinds of memory allocation
@@ -86,12 +82,32 @@ public class BitSetUtil {
    * @return roaring bitmap
    */
   public static RoaringBitmap bitmapOf(ByteBuffer bb, boolean fastRank) {
+    return bitmapOf(bb, fastRank, new long[BLOCK_LENGTH]);
+  }
+
+  /**
+   * Efficiently generate a RoaringBitmap from an uncompressed byte array or ByteBuffer
+   * This method tries to minimise all kinds of memory allocation
+   * <br>
+   * You can provide a cached wordsBuffer for avoiding 8 KB of extra allocation on every call
+   *   No reference is kept to the wordsBuffer, so it can be cached as a ThreadLocal
+   *
+   * @param bb the uncompressed bitmap
+   * @param fastRank if set, returned bitmap is of type
+   *                 {@link org.roaringbitmap.FastRankRoaringBitmap}
+   * @param wordsBuffer buffer of length {@link BitSetUtil#BLOCK_LENGTH}
+   * @return roaring bitmap
+   */
+  public static RoaringBitmap bitmapOf(ByteBuffer bb, boolean fastRank, long[] wordsBuffer) {
+
+    if (wordsBuffer.length != BLOCK_LENGTH) {
+      throw new IllegalArgumentException("wordsBuffer length should be " + BLOCK_LENGTH);
+    }
 
     bb = bb.slice().order(ByteOrder.LITTLE_ENDIAN);
     final RoaringBitmap ans = fastRank ? new FastRankRoaringBitmap() : new RoaringBitmap();
 
-    // split buffer into blocks of long[], reuse a ThreadLocal array for blocks
-    final long[] words = WORD_BLOCK.get();
+    // split buffer into blocks of long[]
     int containerIndex = 0;
     int blockLength = 0, blockCardinality = 0, offset = 0;
     long word;
@@ -99,7 +115,7 @@ public class BitSetUtil {
       word = bb.getLong();
 
       // Add read long to block
-      words[blockLength++] = word;
+      wordsBuffer[blockLength++] = word;
       blockCardinality += Long.bitCount(word);
 
       // When block is full, add block to bitmap
@@ -107,8 +123,12 @@ public class BitSetUtil {
         // Each block becomes a single container, if any bit is set
         if (blockCardinality > 0) {
           ans.highLowContainer.insertNewKeyValueAt(containerIndex++, Util.highbits(offset),
-              BitSetUtil.containerOf(0, blockLength, blockCardinality, words));
+              BitSetUtil.containerOf(0, blockLength, blockCardinality, wordsBuffer));
         }
+        /*
+            Offset can overflow when bitsets size is more than Integer.MAX_VALUE - 64
+            It's harmless though, as it will happen after the last block is added
+         */
         offset += (BLOCK_LENGTH * Long.SIZE);
         blockLength = blockCardinality = 0;
       }
@@ -124,7 +144,7 @@ public class BitSetUtil {
 
       // Add last word to block, only if any bit is set
       if (word != 0) {
-        words[blockLength++] = word;
+        wordsBuffer[blockLength++] = word;
         blockCardinality += Long.bitCount(word);
       }
     }
@@ -132,7 +152,7 @@ public class BitSetUtil {
     // Add block to map, if any bit is set
     if (blockCardinality > 0) {
       ans.highLowContainer.insertNewKeyValueAt(containerIndex, Util.highbits(offset),
-          BitSetUtil.containerOf(0, blockLength, blockCardinality, words));
+          BitSetUtil.containerOf(0, blockLength, blockCardinality, wordsBuffer));
     }
     return ans;
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
@@ -3,7 +3,6 @@ package org.roaringbitmap;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Arrays;
 import java.util.BitSet;
 
 
@@ -137,7 +136,6 @@ public class BitSetUtil {
     if (blockCardinality > 0) {
       ans.highLowContainer.insertNewKeyValueAt(containerIndex++, Util.highbits(offset),
           BitSetUtil.containerOf(0, blockLength, blockCardinality, words));
-      Arrays.fill(words, 0); // Zero-out thread local buffer after use
     }
     return containerIndex;
   }
@@ -160,8 +158,9 @@ public class BitSetUtil {
       return arrayContainerOf(from, to, blockCardinality, words);
     } else {
       // otherwise use bitmap container
-      return new BitmapContainer(Arrays.copyOfRange(words, from, from + BLOCK_LENGTH),
-          blockCardinality);
+      long[] container = new long[BLOCK_LENGTH];
+      System.arraycopy(words, from, container, 0, to - from);
+      return new BitmapContainer(container, blockCardinality);
     }
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferBitSetUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferBitSetUtil.java
@@ -1,11 +1,13 @@
 package org.roaringbitmap.buffer;
 
 
+import org.roaringbitmap.BitSetUtil;
 import org.roaringbitmap.IntIterator;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.CharBuffer;
 import java.nio.LongBuffer;
-import java.util.Arrays;
 import java.util.BitSet;
 
 import static java.lang.Long.numberOfTrailingZeros;
@@ -77,6 +79,87 @@ public class BufferBitSetUtil {
     return ans;
   }
 
+  /**
+   * Efficiently generate a RoaringBitmap from an uncompressed byte array or ByteBuffer
+   * This method tries to minimise all kinds of memory allocation
+   *
+   * @param bb the uncompressed bitmap
+   * @return roaring bitmap
+   */
+  public static MutableRoaringBitmap bitmapOf(ByteBuffer bb) {
+    return bitmapOf(bb, new long[BLOCK_LENGTH]);
+  }
+
+  /**
+   * Efficiently generate a RoaringBitmap from an uncompressed byte array or ByteBuffer
+   * This method tries to minimise all kinds of memory allocation
+   * <br>
+   * You can provide a cached wordsBuffer for avoiding 8 KB of extra allocation on every call
+   *   No reference is kept to the wordsBuffer, so it can be cached as a ThreadLocal
+   *
+   * @param bb the uncompressed bitmap
+   * @param wordsBuffer buffer of length {@link BitSetUtil#BLOCK_LENGTH}
+   * @return roaring bitmap
+   */
+  public static MutableRoaringBitmap bitmapOf(ByteBuffer bb, long[] wordsBuffer) {
+
+    if (wordsBuffer.length != BLOCK_LENGTH) {
+      throw new IllegalArgumentException("wordsBuffer length should be " + BLOCK_LENGTH);
+    }
+
+    bb = bb.slice().order(ByteOrder.LITTLE_ENDIAN);
+    final MutableRoaringBitmap ans = new MutableRoaringBitmap();
+
+    // split buffer into blocks of long[]
+    int containerIndex = 0;
+    int blockLength = 0, blockCardinality = 0, offset = 0;
+    long word;
+    while (bb.remaining() >= 8) {
+      word = bb.getLong();
+
+      // Add read long to block
+      wordsBuffer[blockLength++] = word;
+      blockCardinality += Long.bitCount(word);
+
+      // When block is full, add block to bitmap
+      if (blockLength == BLOCK_LENGTH) {
+        // Each block becomes a single container, if any bit is set
+        if (blockCardinality > 0) {
+          ((MutableRoaringArray) ans.highLowContainer).insertNewKeyValueAt(containerIndex++, BufferUtil.highbits(offset),
+              BufferBitSetUtil.containerOf(0, blockLength, blockCardinality, wordsBuffer));
+        }
+        /*
+            Offset can overflow when bitsets size is more than Integer.MAX_VALUE - 64
+            It's harmless though, as it will happen after the last block is added
+         */
+        offset += (BLOCK_LENGTH * Long.SIZE);
+        blockLength = blockCardinality = 0;
+      }
+    }
+
+    if (bb.remaining() > 0) {
+      // Read remaining (less than 8) bytes
+      // We can do this in while loop also, it will probably slow things down a bit though
+      word = 0;
+      for (int remaining = bb.remaining(), j = 0; j < remaining; j++) {
+        word |= (bb.get() & 0xffL) << (8 * j);
+      }
+
+      // Add last word to block, only if any bit is set
+      if (word != 0) {
+        wordsBuffer[blockLength++] = word;
+        blockCardinality += Long.bitCount(word);
+      }
+    }
+
+    // Add block to map, if any bit is set
+    if (blockCardinality > 0) {
+      ((MutableRoaringArray) ans.highLowContainer).insertNewKeyValueAt(containerIndex, BufferUtil.highbits(offset),
+          BufferBitSetUtil.containerOf(0, blockLength, blockCardinality, wordsBuffer));
+    }
+    return ans;
+  }
+
   private static int cardinality(final int from, final int to, final long[] words) {
     int sum = 0;
     for (int i = from; i < to; i++) {
@@ -95,8 +178,9 @@ public class BufferBitSetUtil {
       return arrayContainerOf(from, to, blockCardinality, words);
     } else {
       // otherwise use bitmap container
-      return new MappeableBitmapContainer(
-          LongBuffer.wrap(Arrays.copyOfRange(words, from, from + BLOCK_LENGTH)), blockCardinality);
+      long[] container = new long[BLOCK_LENGTH];
+      System.arraycopy(words, from, container, 0, to - from);
+      return new MappeableBitmapContainer(LongBuffer.wrap(container), blockCardinality);
     }
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferBitSetUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferBitSetUtil.java
@@ -125,8 +125,9 @@ public class BufferBitSetUtil {
       if (blockLength == BLOCK_LENGTH) {
         // Each block becomes a single container, if any bit is set
         if (blockCardinality > 0) {
-          ((MutableRoaringArray) ans.highLowContainer).insertNewKeyValueAt(containerIndex++, BufferUtil.highbits(offset),
-              BufferBitSetUtil.containerOf(0, blockLength, blockCardinality, wordsBuffer));
+          ((MutableRoaringArray) ans.highLowContainer).insertNewKeyValueAt(containerIndex++,
+              BufferUtil.highbits(offset), BufferBitSetUtil.containerOf(0, blockLength,
+                  blockCardinality, wordsBuffer));
         }
         /*
             Offset can overflow when bitsets size is more than Integer.MAX_VALUE - 64
@@ -154,7 +155,8 @@ public class BufferBitSetUtil {
 
     // Add block to map, if any bit is set
     if (blockCardinality > 0) {
-      ((MutableRoaringArray) ans.highLowContainer).insertNewKeyValueAt(containerIndex, BufferUtil.highbits(offset),
+      ((MutableRoaringArray) ans.highLowContainer).insertNewKeyValueAt(containerIndex,
+          BufferUtil.highbits(offset),
           BufferBitSetUtil.containerOf(0, blockLength, blockCardinality, wordsBuffer));
     }
     return ans;

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitSetUtil.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitSetUtil.java
@@ -1,7 +1,9 @@
 package org.roaringbitmap;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
 import java.util.BitSet;
 import java.util.Random;
 
@@ -135,4 +137,106 @@ public class TestBitSetUtil {
     assertEqualBitsets(bitset, bitmap);
   }
 
+  /*
+    The ByteBuffer->RoaringBitmap just replicate similar tests written for BitSet/long[]->RoaringBitmap
+   */
+
+  @Test
+  public void testEmptyByteBuffer() {
+    final BitSet bitset = new BitSet();
+    final RoaringBitmap bitmap = BitSetUtil.bitmapOf(toByteBuffer(bitset), false);
+    assertEqualBitsets(bitset, bitmap);
+  }
+
+  @Test
+  public void testFlipFlapBetweenRandomFullAndEmptyByteBuffer() {
+    final Random random = new Random(1234);
+    final int nbitsPerBlock = 1024 * Long.SIZE;
+    final int blocks = 50;
+    final BitSet bitset = new BitSet(nbitsPerBlock * blocks);
+
+    // i want a mix of empty blocks, randomly filled blocks and full blocks
+    for (int block = 0; block < blocks * nbitsPerBlock; block += nbitsPerBlock) {
+      int type = random.nextInt(3);
+      switch (type) {
+        case 0:
+          // a block with random set bits
+          appendRandomBitset(random, block, bitset, nbitsPerBlock);
+          break;
+        case 1:
+          // a full block
+          bitset.set(block, block + nbitsPerBlock);
+          break;
+        default:
+          // and an empty block;
+          break;
+      }
+    }
+    final RoaringBitmap bitmap = BitSetUtil.bitmapOf(toByteBuffer(bitset), false);
+    assertEqualBitsets(bitset, bitmap);
+  }
+
+  @Test
+  public void testFullByteBuffer() {
+    final BitSet bitset = new BitSet();
+    final int nbits = 1024 * Long.SIZE * 50;
+    bitset.set(0, nbits);
+    final RoaringBitmap bitmap = BitSetUtil.bitmapOf(toByteBuffer(bitset), false);
+    assertEqualBitsets(bitset, bitmap);
+  }
+
+  @Test
+  public void testGapByteBuffer() {
+    for (int gap = 1; gap <= 4096; gap *= 2) {
+      for (int offset = 300; offset < 3000; offset += 10) {
+        BitSet bitset = new BitSet();
+        for (int k = 0; k < 100000; k += gap) {
+          bitset.set(k + offset);
+        }
+        final RoaringBitmap bitmap = BitSetUtil.bitmapOf(toByteBuffer(bitset), false);
+        assertEqualBitsets(bitset, bitmap);
+      }
+    }
+  }
+
+  @Test
+  public void testRandomByteBuffer() {
+    final Random random = new Random(8934);
+    final int runs = 100;
+    final int maxNbits = 500000;
+    for (int i = 0;i < runs; ++i) {
+      final int offset = random.nextInt(maxNbits) & Integer.MAX_VALUE;
+      final BitSet bitset = randomBitset(random, offset, random.nextInt(maxNbits));
+      final RoaringBitmap bitmap = BitSetUtil.bitmapOf(toByteBuffer(bitset), false);
+      assertEqualBitsets(bitset, bitmap);
+    }
+  }
+
+  @Test
+  public void testByteArrayWithOnly10000000thBitSet() {
+    final BitSet bitset = new BitSet();
+    bitset.set(10000000);
+    final RoaringBitmap bitmap = BitSetUtil.bitmapOf(toByteBuffer(bitset), false);
+    assertEqualBitsets(bitset, bitmap);
+  }
+
+  @Test
+  public void testByteArrayWithOnly1And10000000thBitSet() {
+    final BitSet bitset = new BitSet();
+    bitset.set(1);
+    bitset.set(10000000);
+    final RoaringBitmap bitmap = BitSetUtil.bitmapOf(toByteBuffer(bitset), false);
+    assertEqualBitsets(bitset, bitmap);
+  }
+
+  @Test
+  public void testByteArrayWithFastRank() {
+    final BitSet bitset = randomBitset(new Random(238), 0, 50);
+    final RoaringBitmap bitmap = BitSetUtil.bitmapOf(toByteBuffer(bitset), true);
+    Assertions.assertTrue(bitmap instanceof FastRankRoaringBitmap);
+  }
+
+  private static ByteBuffer toByteBuffer(BitSet bitset) {
+    return ByteBuffer.wrap(bitset.toByteArray());
+  }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestBitSetUtil.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestBitSetUtil.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
+import java.nio.ByteBuffer;
 import java.util.BitSet;
 import java.util.Random;
 
@@ -135,6 +136,102 @@ public class TestBitSetUtil {
     bitset.set(10000000);
     final MutableRoaringBitmap bitmap = BufferBitSetUtil.bitmapOf(bitset);
     assertEqualBitsets(bitset, bitmap);
+  }
+
+    /*
+    The ByteBuffer->RoaringBitmap just replicate similar tests written for BitSet/long[]->RoaringBitmap
+   */
+
+  @Test
+  public void testEmptyByteBuffer() {
+    final BitSet bitset = new BitSet();
+    final MutableRoaringBitmap bitmap = BufferBitSetUtil.bitmapOf(toByteBuffer(bitset));
+    assertEqualBitsets(bitset, bitmap);
+  }
+
+  @Test
+  public void testFlipFlapBetweenRandomFullAndEmptyByteBuffer() {
+    final Random random = new Random(1234);
+    final int nbitsPerBlock = 1024 * Long.SIZE;
+    final int blocks = 50;
+    final BitSet bitset = new BitSet(nbitsPerBlock * blocks);
+
+    // i want a mix of empty blocks, randomly filled blocks and full blocks
+    for (int block = 0; block < blocks * nbitsPerBlock; block += nbitsPerBlock) {
+      int type = random.nextInt(3);
+      switch (type) {
+        case 0:
+          // a block with random set bits
+          appendRandomBitset(random, block, bitset, nbitsPerBlock);
+          break;
+        case 1:
+          // a full block
+          bitset.set(block, block + nbitsPerBlock);
+          break;
+        default:
+          // and an empty block;
+          break;
+      }
+    }
+    final MutableRoaringBitmap bitmap = BufferBitSetUtil.bitmapOf(toByteBuffer(bitset));
+    assertEqualBitsets(bitset, bitmap);
+  }
+
+  @Test
+  public void testFullByteBuffer() {
+    final BitSet bitset = new BitSet();
+    final int nbits = 1024 * Long.SIZE * 50;
+    bitset.set(0, nbits);
+    final MutableRoaringBitmap bitmap = BufferBitSetUtil.bitmapOf(toByteBuffer(bitset));
+    assertEqualBitsets(bitset, bitmap);
+  }
+
+  @Test
+  public void testGapByteBuffer() {
+    for (int gap = 1; gap <= 4096; gap *= 2) {
+      for (int offset = 300; offset < 3000; offset += 10) {
+        BitSet bitset = new BitSet();
+        for (int k = 0; k < 100000; k += gap) {
+          bitset.set(k + offset);
+        }
+        final MutableRoaringBitmap bitmap = BufferBitSetUtil.bitmapOf(toByteBuffer(bitset));
+        assertEqualBitsets(bitset, bitmap);
+      }
+    }
+  }
+
+  @Test
+  public void testRandomByteBuffer() {
+    final Random random = new Random(8934);
+    final int runs = 100;
+    final int maxNbits = 500000;
+    for (int i = 0;i < runs; ++i) {
+      final int offset = random.nextInt(maxNbits) & Integer.MAX_VALUE;
+      final BitSet bitset = randomBitset(random, offset, random.nextInt(maxNbits));
+      final MutableRoaringBitmap bitmap = BufferBitSetUtil.bitmapOf(toByteBuffer(bitset));
+      assertEqualBitsets(bitset, bitmap);
+    }
+  }
+
+  @Test
+  public void testByteArrayWithOnly10000000thBitSet() {
+    final BitSet bitset = new BitSet();
+    bitset.set(10000000);
+    final MutableRoaringBitmap bitmap = BufferBitSetUtil.bitmapOf(toByteBuffer(bitset));
+    assertEqualBitsets(bitset, bitmap);
+  }
+
+  @Test
+  public void testByteArrayWithOnly1And10000000thBitSet() {
+    final BitSet bitset = new BitSet();
+    bitset.set(1);
+    bitset.set(10000000);
+    final MutableRoaringBitmap bitmap = BufferBitSetUtil.bitmapOf(toByteBuffer(bitset));
+    assertEqualBitsets(bitset, bitmap);
+  }
+
+  private static ByteBuffer toByteBuffer(BitSet bitset) {
+    return ByteBuffer.wrap(bitset.toByteArray());
   }
 
 }

--- a/jmh/src/jmh/java/org/roaringbitmap/BitSetUtilBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/BitSetUtilBenchmark.java
@@ -13,24 +13,24 @@ import java.util.zip.GZIPInputStream;
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class BitSetUtilBenchmark {
 
-//  @Benchmark
-//  public long BitSetToRoaringByAddingBitByBit(Data d) {
-//    long bogus = 0;
-//    for (int i = 0; i < d.bitsets.length; i++) {
-//      bogus += bitmapTheNaiveWay(d.bitsets[i]).getCardinality();
-//    }
-//    return bogus;
-//  }
-//
-//
-//  @Benchmark
-//  public long BitSetToRoaringUsingBitSetUtil(Data d) {
-//    long bogus = 0;
-//    for (int i = 0; i < d.bitsets.length; i++) {
-//      bogus += BitSetUtil.bitmapOf(d.bitsets[i]).getCardinality();
-//    }
-//    return bogus;
-//  }
+  @Benchmark
+  public long BitSetToRoaringByAddingBitByBit(Data d) {
+    long bogus = 0;
+    for (int i = 0; i < d.bitsets.length; i++) {
+      bogus += bitmapTheNaiveWay(d.bitsets[i]).getCardinality();
+    }
+    return bogus;
+  }
+
+
+  @Benchmark
+  public long BitSetToRoaringUsingBitSetUtil(Data d) {
+    long bogus = 0;
+    for (int i = 0; i < d.bitsets.length; i++) {
+      bogus += BitSetUtil.bitmapOf(d.bitsets[i]).getCardinality();
+    }
+    return bogus;
+  }
 
   private static final ThreadLocal<long[]> WORD_BLOCK = ThreadLocal.withInitial(() ->
       new long[BitSetUtil.BLOCK_LENGTH]);

--- a/jmh/src/jmh/java/org/roaringbitmap/BitSetUtilBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/BitSetUtilBenchmark.java
@@ -1,17 +1,13 @@
 package org.roaringbitmap;
 
+import org.openjdk.jmh.annotations.*;
+
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.BitSet;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
-
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
@@ -36,6 +32,33 @@ public class BitSetUtilBenchmark {
     return bogus;
   }
 
+  /*
+    Given an uncompressed bitset represented as a byte array (basically, as read on wire)
+    Below benchmarks the perf difference you will get when:
+    1. ByteArrayToRoaring - Directly convert the byte array to a roaring bitmap by wrapping it in a ByteBuffer
+    2. ByteArrayToBitsetToRoaring - Convert the byte array to a BitSet and then create the bitmap using it
+   */
+
+  @Benchmark
+  public long ByteArrayToRoaring(Data d) {
+    long bogus = 0;
+    for (int i = 0; i < d.bitsetsAsBytes.length; i++) {
+      ByteBuffer bb = ByteBuffer.wrap(d.bitsetsAsBytes[i]);
+      bogus += BitSetUtil.bitmapOf(bb, false).getCardinality();
+    }
+    return bogus;
+  }
+
+
+  @Benchmark
+  public long ByteArrayToBitsetToRoaring(Data d) {
+    long bogus = 0;
+    for (int i = 0; i < d.bitsetsAsBytes.length; i++) {
+      BitSet bitset = BitSet.valueOf(d.bitsetsAsBytes[i]);
+      bogus += BitSetUtil.bitmapOf(bitset).getCardinality();
+    }
+    return bogus;
+  }
 
   private static RoaringBitmap bitmapTheNaiveWay(final long[] words) {
     int cardinality = 0;
@@ -68,30 +91,54 @@ public class BitSetUtilBenchmark {
   @State(Scope.Benchmark)
   public static class Data {
     long[][] bitsets;
+    byte[][] bitsetsAsBytes;
 
     @Setup
     public void setup() throws IOException {
       final String bitset = "/real-roaring-dataset/bitsets_1925630_96.gz";
       this.getClass().getResourceAsStream(bitset);
       this.bitsets = deserialize(bitset);
+      this.bitsetsAsBytes = bitsetsAsBytes(bitsets);
+    }
+
+    private byte[][] bitsetsAsBytes(long[][] bitsets) {
+      byte[][] bitsetsAsBytes = new byte[bitsets.length][];
+      for (int i = 0; i < bitsets.length; i++) {
+        long[] bitset = bitsets[i];
+        bitsetsAsBytes[i] = BitSet.valueOf(bitset).toByteArray();
+      }
+      return bitsetsAsBytes;
     }
 
     private long[][] deserialize(final String bitsetResource) throws IOException {
       final DataInputStream dos = new DataInputStream(
           new GZIPInputStream(this.getClass().getResourceAsStream(bitsetResource)));
       try {
-        final long[][] bitset = new long[dos.readInt()][];
-        for (int i = 0; i < bitset.length; i++) {
+        /* Change this value to see number for small vs large bitsets
+           wordSize = 64 represents 4096 bits (512 bytes)
+           wordSize = 512 represents 32768 bits (~4kb)
+           wordSize = 8192 represents 524288 bits (~64kb)
+           wordSize = 131072 represents 8388608 bits (~8.3 million, ~1mb)
+         */
+        final int minTotalWordSize = 64;
+        // Try to keep size of bitsets created below 1 gb
+        final int bitsetCnt = Math.min((1024 * 1024 * 1024) / (minTotalWordSize * 8), dos.readInt());
+
+        final long[][] bitset = new long[bitsetCnt][];
+        for (int i = 0; i < bitsetCnt; i++) {
           final int wordSize = dos.readInt();
 
           // for duplication, to make bitsets wider
-          final int clone = 0;
-          final long words[] = new long[wordSize * (clone + 1)];
+          final int clone = (minTotalWordSize + wordSize) / wordSize;
+          final long[] words = new long[wordSize * (clone + 1)];
           for (int j = 0; j < wordSize; j++) {
             words[j] = dos.readLong();
           }
 
           // duplicate long[] n times to the right
+          for(int j = 0; j < clone; j++) {
+            System.arraycopy(words, 0, words, (j+1)*wordSize, wordSize);
+          }
           bitset[i] = words;
         }
         return bitset;
@@ -100,6 +147,5 @@ public class BitSetUtilBenchmark {
       }
     }
   }
-
 
 }


### PR DESCRIPTION
### SUMMARY
- There is no direct way to convert a byte array or a ByteBuffer (representing an uncompressed bitmap) to a RoaringBitmap 
- The best way is to create a BitSet first and then use: BitSetUtil.bitmapOf(bitset)
- This creates unnecessary heap garbage as, essentially, a full copy of the byte array is created for BitSet
- This PR introduces a method in BitSetUtil that can be used to directly convert a ByteBuffer to RoaringBitmap
- The implementation tries to do it with constant and minimum possible memory allocation
- This is very useful for performance sensitive code doing this very frequently. Now a RoaringBitmap can be created directly from bytes read on wire with almost no unnecessary memory allocs
- For testing, BitSetUtil tests are replicated and benchmarks are added

### RESULTS
- Benchmark Results are [posted here](https://github.com/RoaringBitmap/RoaringBitmap/pull/650#issuecomment-1667252580)
- **TL;DR** 
- Average time is upto 10-20% faster when we go from small to larger bitsets (compared to existing way)
- GC pressure is about 4-5x lower for all size types

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
