### PR TITLE
MutableRoaringArray: Set the right capacity for arrays when deserializing

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
@@ -270,8 +270,9 @@ public final class MutableRoaringArray implements Cloneable, Externalizable, Poi
       throw new InvalidRoaringFormat("Size too large");
     }
     if ((this.keys == null) || (this.keys.length < this.size)) {
-      this.keys = new char[this.size];
-      this.values = new MappeableContainer[this.size];
+      int capacity = getNewCapacity(0, 0);
+      this.keys = new char[capacity];
+      this.values = new MappeableContainer[capacity];
     }
 
     byte[] bitmapOfRunContainers = null;
@@ -359,8 +360,9 @@ public final class MutableRoaringArray implements Cloneable, Externalizable, Poi
       throw new InvalidRoaringFormat("Size too large");
     }
     if ((this.keys == null) || (this.keys.length < this.size)) {
-      this.keys = new char[this.size];
-      this.values = new MappeableContainer[this.size];
+      int capacity = getNewCapacity(0, 0);
+      this.keys = new char[capacity];
+      this.values = new MappeableContainer[capacity];
     }
 
 
@@ -421,14 +423,17 @@ public final class MutableRoaringArray implements Cloneable, Externalizable, Poi
   protected void extendArray(int k) {
     // size + 1 could overflow
     if (this.size + k > this.keys.length) {
-      int newCapacity;
-      if (this.keys.length < 1024) {
-        newCapacity = 2 * (this.size + k);
-      } else {
-        newCapacity = 5 * (this.size + k) / 4;
-      }
+      int newCapacity = getNewCapacity(k, this.keys.length);
       this.keys = Arrays.copyOf(this.keys, newCapacity);
       this.values = Arrays.copyOf(this.values, newCapacity);
+    }
+  }
+
+  private int getNewCapacity(int additionalSize, int keysLength) {
+    if (keysLength < 1024) {
+      return 2 * (this.size + additionalSize);
+    } else {
+      return 5 * (this.size + additionalSize) / 4;
     }
   }
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestSerialization.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestSerialization.java
@@ -478,5 +478,20 @@ public class TestSerialization {
     outbb.rewind();
   }
 
+  @Test
+  public void testDeserializeSmallData() throws IOException {
+    MutableRoaringBitmap source = MutableRoaringBitmap.bitmapOf(25286760);
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    source.serialize(new DataOutputStream(outputStream));
+    boolean expected = source.intersects(26244001, 27293761);
+
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+    MutableRoaringBitmap target = new MutableRoaringBitmap();
+    target.deserialize(new DataInputStream(inputStream));
+
+    boolean actual = target.intersects(26244001, 27293761);
+    assertEquals(actual, expected);
+  }
+
 }
 


### PR DESCRIPTION
Fixes #652

### SUMMARY

I've modified the deserialize method in `RoaringBitmapArray` to use the same mechanism
that sets the array sizes (`keys` and `values`), in order to remove code duplication,
I've extracted a new method `getNewCapacity`. This fixes a bug in deserialization
where deserializing small data would cause `ArrayIndexOutOfBoundsException`.

I've added a test to cover the new code.

### Automated Checks

- [X] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [X] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
