### PR TITLE
This fixes a logical error in one implementation of 'intersects'

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -1249,9 +1249,14 @@ public class ImmutableRoaringBitmap
     while (pos < length && minKey > (highLowContainer.getKeyAtIndex(pos))) {
       ++pos;
     }
+    // it is possible for pos == length to be true
+    if(pos == length) {
+      return false;
+    }
+    // we have that pos < length.
     int offset = (minKey == highLowContainer.getKeyAtIndex(pos)) ? lowbitsAsInteger(minimum) : 0;
     int limit = lowbitsAsInteger(supremum);
-    if (pos < length && supKey == (highLowContainer.getKeyAtIndex(pos))) {
+    if (supKey == (highLowContainer.getKeyAtIndex(pos))) {
       if (supKey > minKey) {
         offset = 0;
       }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestSerialization.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestSerialization.java
@@ -478,5 +478,34 @@ public class TestSerialization {
     outbb.rewind();
   }
 
+  @Test
+  public void testDeserializeSmallData() throws IOException {
+    RoaringBitmap source = RoaringBitmap.bitmapOf(25286760);
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    source.serialize(new DataOutputStream(outputStream));
+    boolean expected = source.intersects(26244001, 27293761);
+
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+    RoaringBitmap target = new RoaringBitmap();
+    target.deserialize(new DataInputStream(inputStream));
+
+    boolean actual = target.intersects(26244001, 27293761);
+    assertEquals(actual, expected);
+  }
+
+  @Test
+  public void testDeserializeSmallDataMutable() throws IOException {
+    MutableRoaringBitmap source = MutableRoaringBitmap.bitmapOf(25286760);
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    source.serialize(new DataOutputStream(outputStream));
+    boolean expected = source.intersects(26244001, 27293761);
+
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+    MutableRoaringBitmap target = new MutableRoaringBitmap();
+    target.deserialize(new DataInputStream(inputStream));
+
+    boolean actual = target.intersects(26244001, 27293761);
+    assertEquals(actual, expected);
+  }
 }
 


### PR DESCRIPTION
### SUMMARY

Issue https://github.com/RoaringBitmap/RoaringBitmap/issues/652 describes a verifiable problem where the intersects function fails. But it seems to fail only after deserialization (or, at least, that's the reproducible test case we have). In PR https://github.com/RoaringBitmap/RoaringBitmap/pull/653, @shanielh proposes to change the deserialization process, seemingly increasing the initial capacity after deserialization. That's fine, but I don't think that's where the actual bug lies. The actual bug is a logical bug in `intersects` (one of our implementations).

### Automated Checks

- [X] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [X] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
