### PR TITLE
Equals container bugfix

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -375,6 +375,8 @@ public final class ArrayContainer extends Container implements Cloneable {
       return ArraysShim.equals(this.content, 0, cardinality, srb.content, 0, srb.cardinality);
     } else if (o instanceof RunContainer) {
       return o.equals(this);
+    } else if (o instanceof BitmapContainer) {
+      return o.equals(this);
     }
     return false;
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -423,6 +423,19 @@ public final class BitmapContainer extends Container implements Cloneable {
       return Arrays.equals(this.bitmap, srb.bitmap);
     } else if (o instanceof RunContainer) {
       return o.equals(this);
+    } else if (o instanceof ArrayContainer) {
+      ArrayContainer ac = (ArrayContainer) o;
+      if (ac.getCardinality() != this.getCardinality()) {
+        return false;
+      }
+      PeekableCharIterator it = ac.getCharIterator();
+      while (it.hasNext()) {
+        char value = it.next();
+        if (!contains(value)) {
+          return false;
+        }
+      }
+      return true;
     }
     return false;
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -936,15 +936,15 @@ public final class RunContainer extends Container implements Cloneable {
       return equals((RunContainer) o);
     } else if (o instanceof ArrayContainer) {
       return equals((ArrayContainer) o);
-    } else if (o instanceof Container) {
-      if (((Container) o).getCardinality() != this.getCardinality()) {
+    } else if (o instanceof BitmapContainer) {
+      BitmapContainer bc = (BitmapContainer) o;
+      if (bc.getCardinality() != this.getCardinality()) {
         return false; // should be a frequent branch if they differ
       }
-      // next bit could be optimized if needed:
-      CharIterator me = this.getCharIterator();
-      CharIterator you = ((Container) o).getCharIterator();
-      while (me.hasNext()) {
-        if (me.next() != you.next()) {
+      for (char i = 0; i < nbrruns; ++i) {
+        char runStart = getValue(i);
+        int length = (getLength(i));
+        if (!bc.contains(runStart, runStart + length + 1)) {
           return false;
         }
       }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -449,6 +449,8 @@ public final class MappeableArrayContainer extends MappeableContainer implements
       return true;
     } else if (o instanceof MappeableRunContainer) {
       return o.equals(this);
+    } else if (o instanceof MappeableBitmapContainer) {
+      return o.equals(this);
     }
     return false;
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -447,6 +447,19 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
 
     } else if (o instanceof MappeableRunContainer) {
       return o.equals(this);
+    } else if (o instanceof MappeableArrayContainer) {
+      MappeableArrayContainer ac = (MappeableArrayContainer) o;
+      if (ac.getCardinality() != this.getCardinality()) {
+        return false;
+      }
+      PeekableCharIterator it = ac.getCharIterator();
+      while (it.hasNext()) {
+        char value = it.next();
+        if (!contains(value)) {
+          return false;
+        }
+      }
+      return true;
     }
     return false;
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -833,15 +833,15 @@ public final class MappeableRunContainer extends MappeableContainer implements C
       return equals((MappeableRunContainer) o);
     } else if (o instanceof MappeableArrayContainer) {
       return equals((MappeableArrayContainer) o);
-    } else if (o instanceof MappeableContainer) {
-      if (((MappeableContainer) o).getCardinality() != this.getCardinality()) {
+    } else if (o instanceof MappeableBitmapContainer) {
+      MappeableBitmapContainer bc = (MappeableBitmapContainer) o;
+      if (bc.getCardinality() != this.getCardinality()) {
         return false; // should be a frequent branch if they differ
       }
-      // next bit could be optimized if needed:
-      CharIterator me = this.getCharIterator();
-      CharIterator you = ((MappeableContainer) o).getCharIterator();
-      while (me.hasNext()) {
-        if (me.next() != you.next()) {
+      for (char i = 0; i < nbrruns; ++i) {
+        char runStart = getValue(i);
+        int length = getLength(i);
+        if (!bc.contains(runStart, runStart + length + 1)) {
           return false;
         }
       }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitmapContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitmapContainer.java
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.roaringbitmap.buffer.MappeableArrayContainer;
+import org.roaringbitmap.buffer.MappeableBitmapContainer;
+import org.roaringbitmap.buffer.MappeableRunContainer;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -1341,6 +1344,104 @@ public class TestBitmapContainer {
     ValidationRangeConsumer consumer10 = ValidationRangeConsumer.ofSize(middle);
     container.forAllInRange((char) quarter, (char) (middle + quarter), consumer10);
     consumer10.assertAllPresent();
+  }
+
+  @SuppressWarnings({"AssertBetweenInconvertibleTypes"})
+  @Test
+  void testEquals() {
+    BitmapContainer bc = new BitmapContainer();
+    bc.add((char) 1);
+    bc.add((char) 10_000);
+    ArrayContainer ac = new ArrayContainer();
+    ac.add((char) 1);
+    ac.add((char) 10_000);
+    RunContainer rc = new RunContainer();
+    rc.add((char) 1);
+    rc.add((char) 10_000);
+
+    assertEquals(bc, ac);
+    assertEquals(ac, bc);
+    assertEquals(bc, rc);
+    assertEquals(rc, bc);
+    assertEquals(ac, rc);
+    assertEquals(rc, ac);
+
+    // different cardinalities
+    ac.add((char) 500);
+    bc.add((char) 600);
+    bc.add((char) 700);
+    assertNotEquals(bc, ac);
+    assertNotEquals(ac, bc);
+    assertNotEquals(bc, rc);
+    assertNotEquals(rc, bc);
+    assertNotEquals(ac, rc);
+    assertNotEquals(rc, ac);
+
+    // equal cardinalities
+    ac.add((char) 600);
+    ac.add((char) 700);
+    bc.add((char) 500);
+    rc.add((char) 500);
+    rc.add((char) 600);
+    rc.add((char) 700);
+    ac.add((char) 5000);
+    bc.add((char) 6000);
+    rc.add((char) 7000);
+    assertNotEquals(bc, ac);
+    assertNotEquals(ac, bc);
+    assertNotEquals(bc, rc);
+    assertNotEquals(rc, bc);
+    assertNotEquals(ac, rc);
+    assertNotEquals(rc, ac);
+  }
+
+  @SuppressWarnings({"AssertBetweenInconvertibleTypes"})
+  @Test
+  void testMappeableEquals() {
+    MappeableBitmapContainer bc = new MappeableBitmapContainer();
+    bc.add((char) 1);
+    bc.add((char) 10_000);
+    MappeableArrayContainer ac = new MappeableArrayContainer();
+    ac.add((char) 1);
+    ac.add((char) 10_000);
+    MappeableRunContainer rc = new MappeableRunContainer();
+    rc.add((char) 1);
+    rc.add((char) 10_000);
+
+    assertEquals(ac, bc);
+    assertEquals(bc, ac);
+    assertEquals(bc, rc);
+    assertEquals(rc, bc);
+    assertEquals(ac, rc);
+    assertEquals(rc, ac);
+
+    // different cardinalities
+    ac.add((char) 500);
+    bc.add((char) 600);
+    bc.add((char) 700);
+    assertNotEquals(bc, ac);
+    assertNotEquals(ac, bc);
+    assertNotEquals(bc, rc);
+    assertNotEquals(rc, bc);
+    assertNotEquals(ac, rc);
+    assertNotEquals(rc, ac);
+
+    // equal cardinalities
+    ac.add((char) 600);
+    ac.add((char) 700);
+    bc.add((char) 500);
+    rc.add((char) 500);
+    rc.add((char) 600);
+    rc.add((char) 700);
+    ac.add((char) 5000);
+    bc.add((char) 6000);
+    rc.add((char) 7000);
+    assertNotEquals(bc, ac);
+    assertNotEquals(ac, bc);
+    assertNotEquals(bc, rc);
+    assertNotEquals(rc, bc);
+    assertNotEquals(ac, rc);
+    assertNotEquals(rc, ac);
   }
 
   private static long[] evenBits() {


### PR DESCRIPTION
### SUMMARY
There was missing code for equality test between array and bitmap containers. Above that, equality between run and bitmap containers optimized. Changes affects also mappable variants of containers.

### Automated Checks

- [ ] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [ ] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
