### PR TITLE
more effective buffer copying when limiting mappable container

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -1802,15 +1802,18 @@ public final class MappeableRunContainer extends MappeableContainer implements C
         break;
       }
     }
-
-    CharBuffer newBuf = CharBuffer.allocate(2 * (r + 1));
-    for (int i = 0; i < 2 * (r + 1); ++i) {
-      newBuf.put(valueslength.get(i)); // could be optimized
+    CharBuffer newBuf;
+    if (BufferUtil.isBackedBySimpleArray(valueslength)) {
+      char[] newArray = Arrays.copyOf(valueslength.array(), 2 * (r + 1));
+      newBuf = CharBuffer.wrap(newArray);
+    } else {
+      newBuf = CharBuffer.allocate(2 * (r + 1));
+      for (int i = 0; i < 2 * (r + 1); i++) {
+        newBuf.put(valueslength.get(i));
+      }
     }
     MappeableRunContainer rc = new MappeableRunContainer(newBuf, r + 1);
-
-    rc.setLength(r,
-        (char) ((rc.getLength(r)) - cardinality + maxcardinality));
+    rc.setLength(r, (char) (rc.getLength(r) - cardinality + maxcardinality));
     return rc;
   }
 


### PR DESCRIPTION
### SUMMARY
More effective buffer copying when limiting direct array container.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
