### PR TITLE
AdvanceIfNeeded on bitmap container optimized

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -1770,14 +1770,6 @@ class BitmapContainerCharIterator implements PeekableCharIterator {
 
   @Override
   public void advanceIfNeeded(char minval) {
-    if (minval == 59 + 15 * 64) {
-      advanceIfNeededOld(minval);
-    } else {
-      advanceIfNeededNew(minval);
-    }
-  }
-
-  public void advanceIfNeededNew(char minval) {
     if (!hasNext()) {
       return;
     }
@@ -1801,25 +1793,6 @@ class BitmapContainerCharIterator implements PeekableCharIterator {
   public char peekNext() {
     return (char) (x * 64 + numberOfTrailingZeros(w));
   }
-
-  // TODO remove this before merge
-  public void advanceIfNeededOld(char minval) {
-    if ((minval) >= (x + 1) * 64) {
-      x = (minval) / 64;
-      w = bitmap[x];
-      while (w == 0) {
-        ++x;
-        if (x == bitmap.length) {
-          return;
-        }
-        w = bitmap[x];
-      }
-    }
-    while (hasNext() && ((peekNext()) < (minval))) {
-      next(); // could be optimized
-    }
-  }
-
 }
 
 final class BitmapContainerCharRankIterator extends BitmapContainerCharIterator

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -1770,6 +1770,40 @@ class BitmapContainerCharIterator implements PeekableCharIterator {
 
   @Override
   public void advanceIfNeeded(char minval) {
+    if (minval == 59 + 15 * 64) {
+      advanceIfNeededOld(minval);
+    } else {
+      advanceIfNeededNew(minval);
+    }
+  }
+
+  public void advanceIfNeededNew(char minval) {
+    if (!hasNext()) {
+      return;
+    }
+    if (minval >= x * 64) {
+      if (minval >= (x + 1) * 64) {
+        x = minval / 64;
+        w = bitmap[x];
+      }
+      w &= ~0L << (minval & 63);
+      while (w == 0) {
+        x++;
+        if (!hasNext()) {
+          return;
+        }
+        w = bitmap[x];
+      }
+    }
+  }
+
+  @Override
+  public char peekNext() {
+    return (char) (x * 64 + numberOfTrailingZeros(w));
+  }
+
+  // TODO remove this before merge
+  public void advanceIfNeededOld(char minval) {
     if ((minval) >= (x + 1) * 64) {
       x = (minval) / 64;
       w = bitmap[x];
@@ -1786,10 +1820,6 @@ class BitmapContainerCharIterator implements PeekableCharIterator {
     }
   }
 
-  @Override
-  public char peekNext() {
-    return (char) (x * 64 + numberOfTrailingZeros(w));
-  }
 }
 
 final class BitmapContainerCharRankIterator extends BitmapContainerCharIterator
@@ -1813,28 +1843,29 @@ final class BitmapContainerCharRankIterator extends BitmapContainerCharIterator
 
   @Override
   public void advanceIfNeeded(char minval) {
-    if ((minval) >= (x + 1) * 64) {
-
-      int nextX = (minval) / 64;
-      nextRank += bitCount(w);
-      for(x = x + 1; x < nextX; ++x) {
-        w = bitmap[x];
+    if (!hasNext()) {
+      return;
+    }
+    if (minval >= x * 64) {
+      if (minval >= (x + 1) * 64) {
+        int nextX = minval / 64;
         nextRank += bitCount(w);
+        for(x = x + 1; x < nextX; x++) {
+          w = bitmap[x];
+          nextRank += bitCount(w);
+        }
+        w = bitmap[nextX];
       }
-
-      x = nextX;
-      w = bitmap[x];
-
+      nextRank += bitCount(w);
+      w &= ~0L << (minval & 63);
+      nextRank -= bitCount(w);
       while (w == 0) {
         ++x;
-        if (x == bitmap.length) {
+        if (!hasNext()) {
           return;
         }
         w = bitmap[x];
       }
-    }
-    while (hasNext() && ((peekNext()) < (minval))) {
-      next(); // could be optimized
     }
   }
 
@@ -1895,19 +1926,22 @@ final class ReverseBitmapContainerCharIterator implements PeekableCharIterator {
   
   @Override
   public void advanceIfNeeded(char maxval) {
-    if ((maxval) <= (position - 1) * 64) {
-      position = (maxval) / 64;
-      word = bitmap[position];
-      while (word == 0) {
-        --position;
-        if (position == 0) {
-          break;
-        }
-        word = bitmap[position];
+    if (maxval < (position + 1) * 64) {
+      if (maxval < position * 64) {
+        position = maxval / 64;
       }
-    }
-    while (hasNext() && ((peekNext()) > (maxval))) {
-      next(); // could be optimized
+      long currentWord = bitmap[position];
+      currentWord &= ~0L >>> (63 - (maxval & 63));
+      if (position > 0) {
+        while (currentWord == 0) {
+          position--;
+          if (position == 0) {
+            break;
+          }
+          currentWord = bitmap[position];
+        }
+      }
+      word = currentWord;
     }
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -2191,21 +2191,23 @@ final class MappeableBitmapContainerCharIterator implements PeekableCharIterator
 
   @Override
   public void advanceIfNeeded(char minval) {
-    if (minval >= (x + 1) * 64) {
-      x = minval >>> 6;
-      w = parent.bitmap.get(x);
+    if (!hasNext()) {
+      return;
+    }
+    if (minval >= x * 64) {
+      if (minval >= (x + 1) * 64) {
+        x = minval / 64;
+        w = parent.bitmap.get(x);
+      }
+      w &= ~0L << (minval & 63);
       while (w == 0) {
-        ++x;
+        x++;
         if (x == len) {
           return;
         }
         w = parent.bitmap.get(x);
       }
     }
-    while (hasNext() && (peekNext() < minval)) {
-      next(); // could be optimized
-    }
-
   }
 
   @Override

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestReverseIteratorsOfContainers.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestReverseIteratorsOfContainers.java
@@ -134,8 +134,8 @@ public class TestReverseIteratorsOfContainers {
       PeekableCharIterator pii = container.getReverseCharIterator();
       char c = (char) (2 * i);
       pii.advanceIfNeeded(c);
-      assertEquals(pii.peekNext(), 2 * i);
-      assertEquals(pii.next(), 2 * i);
+      assertEquals(2 * i, pii.peekNext());
+      assertEquals(2 * i, pii.next());
     }
   }
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestIntIteratorFlyweight.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestIntIteratorFlyweight.java
@@ -34,7 +34,7 @@ public class TestIntIteratorFlyweight {
   }
 
   private static int[] takeSortedAndDistinct(Random source, int count) {
-    LinkedHashSet<Integer> ints = new LinkedHashSet<Integer>(count);
+    LinkedHashSet<Integer> ints = new LinkedHashSet<>(count);
     for (int size = 0; size < count; size++) {
       int next;
       do {
@@ -43,8 +43,7 @@ public class TestIntIteratorFlyweight {
     }
     // we add a range of continuous values
     for(int k = 1000; k < 10000; ++k) {
-      if(!ints.contains(k))
-        ints.add(k);
+      ints.add(k);
     }
     int[] unboxed = Ints.toArray(ints);
     Arrays.sort(unboxed);
@@ -69,7 +68,7 @@ public class TestIntIteratorFlyweight {
 
   @Test
   public void testIteration() {
-    final Random source = new Random(0xcb000a2b9b5bdfb6l);
+    final Random source = new Random(0xcb000a2b9b5bdfb6L);
     final int[] data = takeSortedAndDistinct(source, 450000);
     MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(data);
 
@@ -105,8 +104,8 @@ public class TestIntIteratorFlyweight {
 
 
   @Test
-  public void testIterationFromBitmap() {//
-    final Random source = new Random(0xcb000a2b9b5bdfb6l);
+  public void testIterationFromBitmap() {
+    final Random source = new Random(0xcb000a2b9b5bdfb6L);
     final int[] data = takeSortedAndDistinct(source, 450000);
     MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(data);
 
@@ -117,7 +116,6 @@ public class TestIntIteratorFlyweight {
     BufferIntIteratorFlyweight iter2 = new BufferIntIteratorFlyweight(bitmap);
     PeekableIntIterator j = bitmap.getIntIterator();
     for(int k = 0; k < data.length; k+=3) {
-      //System.out.println(k);
       iter2.advanceIfNeeded(data[k]);
       iter2.advanceIfNeeded(data[k]);
       j.advanceIfNeeded(data[k]);
@@ -143,7 +141,7 @@ public class TestIntIteratorFlyweight {
 
   @Test
   public void testIterationFromBitmapClone() {
-    final Random source = new Random(0xcb000a2b9b5bdfb6l);
+    final Random source = new Random(0xcb000a2b9b5bdfb6L);
     final int[] data = takeSortedAndDistinct(source, 450000);
     MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(data);
 
@@ -163,11 +161,11 @@ public class TestIntIteratorFlyweight {
 
   @Test
   public void testIteration1() {
-    final Random source = new Random(0xcb000a2b9b5bdfb6l);
+    final Random source = new Random(0xcb000a2b9b5bdfb6L);
     final int[] data1 = takeSortedAndDistinct(source, 450000);
     final int[] data = Arrays.copyOf(data1, data1.length + 50000);
 
-    LinkedHashSet<Integer> data1Members = new LinkedHashSet<Integer>();
+    LinkedHashSet<Integer> data1Members = new LinkedHashSet<>();
     for (int i : data1) {
       data1Members.add(i);
     }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestIntIteratorFlyweight.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestIntIteratorFlyweight.java
@@ -105,7 +105,7 @@ public class TestIntIteratorFlyweight {
 
 
   @Test
-  public void testIterationFromBitmap() {
+  public void testIterationFromBitmap() {//
     final Random source = new Random(0xcb000a2b9b5bdfb6l);
     final int[] data = takeSortedAndDistinct(source, 450000);
     MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(data);
@@ -117,12 +117,13 @@ public class TestIntIteratorFlyweight {
     BufferIntIteratorFlyweight iter2 = new BufferIntIteratorFlyweight(bitmap);
     PeekableIntIterator j = bitmap.getIntIterator();
     for(int k = 0; k < data.length; k+=3) {
+      //System.out.println(k);
       iter2.advanceIfNeeded(data[k]);
       iter2.advanceIfNeeded(data[k]);
       j.advanceIfNeeded(data[k]);
       j.advanceIfNeeded(data[k]);
-      assertEquals(j.peekNext(),data[k]);
-      assertEquals(iter2.peekNext(),data[k]);
+      assertEquals(data[k], j.peekNext());
+      assertEquals(data[k], iter2.peekNext());
     }
 
 

--- a/jmh/src/jmh/java/org/roaringbitmap/AdvanceIfNeededBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/AdvanceIfNeededBenchmark.java
@@ -1,0 +1,60 @@
+package org.roaringbitmap;
+
+import com.google.common.primitives.Ints;
+import org.openjdk.jmh.annotations.*;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, timeUnit = TimeUnit.MILLISECONDS, time = 2000)
+@Measurement(iterations = 10, timeUnit = TimeUnit.MILLISECONDS, time = 2000)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class AdvanceIfNeededBenchmark {
+    public static MutableRoaringBitmap c2;
+    public static PeekableIntIterator it;
+
+    private static int[] takeSortedAndDistinct(Random source, int count) {
+        LinkedHashSet<Integer> ints = new LinkedHashSet<>(count);
+        for (int size = 0; size < count; size++) {
+            int next;
+            do {
+                next = Math.abs(source.nextInt());
+            } while (!ints.add(next));
+        }
+        // we add a range of continuous values
+        for(int k = 1000; k < 10000; ++k) {
+            ints.add(k);
+        }
+        int[] unboxed = Ints.toArray(ints);
+        Arrays.sort(unboxed);
+        return unboxed;
+    }
+    static {
+        final Random source = new Random(0xcb000a2b9b5bdfb6L);
+        final int[] data = takeSortedAndDistinct(source, 450000);
+        c2 = MutableRoaringBitmap.bitmapOf(data);
+
+    }
+    @Setup(Level.Iteration)
+    public void setup() {
+        it = c2.getIntIterator();
+        c2.first();
+    }
+
+    @Benchmark
+    public MutableRoaringBitmap original() {
+        it.advanceIfNeeded((char) (59 + 15 * 64));
+        return c2;
+    }
+
+    @Benchmark
+    public MutableRoaringBitmap optimized() {
+        it.advanceIfNeeded((char) (60 + 15 * 64));
+        return c2;
+    }
+}

--- a/jmh/src/jmh/java/org/roaringbitmap/AdvanceIfNeededBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/AdvanceIfNeededBenchmark.java
@@ -47,14 +47,8 @@ public class AdvanceIfNeededBenchmark {
     }
 
     @Benchmark
-    public MutableRoaringBitmap original() {
+    public MutableRoaringBitmap advanceIfNeeded() {
         it.advanceIfNeeded((char) (59 + 15 * 64));
-        return c2;
-    }
-
-    @Benchmark
-    public MutableRoaringBitmap optimized() {
-        it.advanceIfNeeded((char) (60 + 15 * 64));
         return c2;
     }
 }

--- a/jmh/src/jmh/java/org/roaringbitmap/AdvanceIfNeededBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/AdvanceIfNeededBenchmark.java
@@ -23,7 +23,7 @@ public class AdvanceIfNeededBenchmark {
         for (int size = 0; size < count; size++) {
             int next;
             do {
-                next = Math.abs(source.nextInt());
+                next = source.nextInt(1000000);
             } while (!ints.add(next));
         }
         // we add a range of continuous values


### PR DESCRIPTION
### SUMMARY
Action `advanceIfNeeded()` on bitmap container was not optimal as noted in source code - too complicated bit-wise iterating within one long value, where given limit value belongs to. Above that, when this long value (64-bit bitmap) is not zero and no value under / above limit was found, iterating is done by bits, not by bitmap longs as probably supposed by author of code.

Temporary performance comparison can be seen by running `AdvanceIfNeededBenchmark` when 48ac7f9 is checked out. According to my tests, 10% performance improvement reached.

Tiny related code cleanup done also.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
