### PR TITLE
Bugfix for value removals from read only array container

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -185,8 +185,10 @@ public final class MappeableArrayContainer extends MappeableContainer implements
           if (cardinality >= DEFAULT_MAX_SIZE) {
             return toBitmapContainer().add(x);
           }
-          increaseCapacity();
-          sarray = content.array();
+          if (cardinality >= sarray.length) {
+            increaseCapacity();
+            sarray = content.array();
+          }
           // insertion : shift the elements > x by one
           // position to
           // the right
@@ -202,7 +204,9 @@ public final class MappeableArrayContainer extends MappeableContainer implements
         if (cardinality >= DEFAULT_MAX_SIZE) {
           return toBitmapContainer().add(x);
         }
-        increaseCapacity();
+        if (cardinality >= content.limit()) {
+          increaseCapacity();
+        }
         content.put(cardinality++, x);
       }
 
@@ -215,7 +219,9 @@ public final class MappeableArrayContainer extends MappeableContainer implements
           a.add(x);
           return a;
         }
-        increaseCapacity();
+        if (cardinality >= this.content.limit()) {
+          increaseCapacity();
+        }
         // insertion : shift the elements > x by one
         // position to
         // the right
@@ -503,7 +509,9 @@ public final class MappeableArrayContainer extends MappeableContainer implements
           a.add(x);
           return a;
         }
-        increaseCapacity();
+        if (cardinality >= content.limit()) {
+          increaseCapacity();
+        }
         // insertion : shift the elements > x by one position to
         // the right
         // and put x in it's appropriate place

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -185,10 +185,8 @@ public final class MappeableArrayContainer extends MappeableContainer implements
           if (cardinality >= DEFAULT_MAX_SIZE) {
             return toBitmapContainer().add(x);
           }
-          if (cardinality >= sarray.length) {
-            increaseCapacity();
-            sarray = content.array();
-          }
+          increaseCapacity();
+          sarray = content.array();
           // insertion : shift the elements > x by one
           // position to
           // the right
@@ -204,9 +202,7 @@ public final class MappeableArrayContainer extends MappeableContainer implements
         if (cardinality >= DEFAULT_MAX_SIZE) {
           return toBitmapContainer().add(x);
         }
-        if (cardinality >= content.limit()) {
-          increaseCapacity();
-        }
+        increaseCapacity();
         content.put(cardinality++, x);
       }
 
@@ -219,9 +215,7 @@ public final class MappeableArrayContainer extends MappeableContainer implements
           a.add(x);
           return a;
         }
-        if (cardinality >= this.content.limit()) {
-          increaseCapacity();
-        }
+        increaseCapacity();
         // insertion : shift the elements > x by one
         // position to
         // the right
@@ -509,9 +503,7 @@ public final class MappeableArrayContainer extends MappeableContainer implements
           a.add(x);
           return a;
         }
-        if (cardinality >= content.limit()) {
-          increaseCapacity();
-        }
+         increaseCapacity();
         // insertion : shift the elements > x by one position to
         // the right
         // and put x in it's appropriate place

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -521,9 +521,15 @@ public final class MappeableArrayContainer extends MappeableContainer implements
         content.put(-loc - 1, x);
         ++cardinality;
       } else {
-        for (int k = loc + 1; k < cardinality; --k) {
-          content.put(k - 1, content.get(k));
+        // buffer is read only, we must make mutable copy
+        final CharBuffer newContent = CharBuffer.allocate(content.capacity() - 1);
+        for (int k = 0; k < loc; k++) {
+          newContent.put(k, content.get(k));
         }
+        for (int k = loc + 1; k < cardinality; k++) {
+          newContent.put(k - 1, content.get(k));
+        }
+        content = newContent;
         --cardinality;
       }
       return this;
@@ -1408,14 +1414,18 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     } else {
       final int loc = BufferUtil.unsignedBinarySearch(content, 0, cardinality, x);
       if (loc >= 0) {
-        // insertion
-        for (int k = loc + 1; k < cardinality; --k) {
-          content.put(k - 1, content.get(k));
+        // buffer is read only, we must make mutable copy
+        final CharBuffer newContent = CharBuffer.allocate(content.capacity() - 1);
+        for (int k = 0; k < loc; k++) {
+          newContent.put(k, content.get(k));
         }
+        for (int k = loc + 1; k < cardinality; k++) {
+          newContent.put(k - 1, content.get(k));
+        }
+        content = newContent;
         --cardinality;
       }
       return this;
-
     }
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -503,7 +503,7 @@ public final class MappeableArrayContainer extends MappeableContainer implements
           a.add(x);
           return a;
         }
-         increaseCapacity();
+        increaseCapacity();
         // insertion : shift the elements > x by one position to
         // the right
         // and put x in it's appropriate place

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestMappeableArrayContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestMappeableArrayContainer.java
@@ -69,6 +69,33 @@ public class TestMappeableArrayContainer {
   }
 
   @Test
+  public void removePresentValueFromReadOnlyContainer() {
+    MappeableContainer ac = newArrayContainer(1, 4);
+
+    ac.remove((char) 2);
+
+    assertEquals(2, ac.getCardinality());
+    assertFalse(ac.contains((char) 0));
+    assertTrue(ac.contains((char) 1));
+    assertFalse(ac.contains((char) 2));
+    assertTrue(ac.contains((char) 3));
+    assertFalse(ac.contains((char) 4));
+  }
+
+  @Test
+  public void removeNotPresentValueFromReadOnlyContainer() {
+    MappeableContainer ac = newArrayContainer(1, 3);
+
+    ac.remove((char) 3);
+
+    assertEquals(2, ac.getCardinality());
+    assertFalse(ac.contains((char) 0));
+    assertTrue(ac.contains((char) 1));
+    assertTrue(ac.contains((char) 2));
+    assertFalse(ac.contains((char) 3));
+  }
+
+  @Test
   public void removeInvalidRange() {
     assertThrows(IllegalArgumentException.class, () -> {
       MappeableContainer ac = new MappeableArrayContainer();
@@ -122,32 +149,80 @@ public class TestMappeableArrayContainer {
   }
 
   @Test
-  public void flip() {
+  public void flipIncreasedCapacityInReadOnlyContainer() {
     MappeableContainer ac = newArrayContainer(1, 2, 3, 5);
     ac = ac.flip((char) 4);
     assertEquals(5, ac.getCardinality());
     for (int i = 1; i <= 5; i++) {
-      assertTrue(ac.contains((char) i));
+      assertTrue(ac.contains((char) i), i + " should be present");
     }
   }
 
   @Test
-  public void flip2() {
+  public void flipPresentNotLastValueInReadOnlyContainer() {
     MappeableContainer ac = newArrayContainer(1, 2, 3, 4, 5);
-    ac = ac.flip((char) 5);
+    ac = ac.flip((char) 1);
     assertEquals(4, ac.getCardinality());
-    for (int i = 1; i <= 4; i++) {
-      assertTrue(ac.contains((char) i));
+    assertFalse(ac.contains((char) 1));
+    for (int i = 2; i <= 5; i++) {
+      assertTrue(ac.contains((char) i), i + " should be present");
     }
   }
 
   @Test
-  public void flip3() {
+  public void flipMissingValueInReadOnlyContainerConvertedToBitmapContainer() {
     MappeableContainer ac = newArrayContainer(1, 5000);
     ac = ac.flip((char) 7000);
     assertEquals(5000, ac.getCardinality());
     for (int i = 1; i < 5000; i++) {
-      assertTrue(ac.contains((char) i));
+      assertTrue(ac.contains((char) i), i + " should be present");
+    }
+    for (int i = 5000; i < 7000; i++) {
+      assertFalse(ac.contains((char) i), i + " should not be present");
+    }
+    assertTrue(ac.contains((char) 7000));
+  }
+
+  @Test
+  public void flipMissingValueInReadOnlyContainerIncreasedCapacity() {
+    MappeableContainer ac = newArrayContainer(1, 2, 3, 5);
+    ac = ac.clone();// not to have container backed by read only buffer
+
+    ac = ac.flip((char) 4);
+
+    assertEquals(5, ac.getCardinality());
+    for (int i = 1; i <= 5; i++) {
+      assertTrue(ac.contains((char) i), i + " should be present");
+    }
+  }
+
+  @Test
+  public void flipPresentValue() {
+    MappeableContainer ac = newArrayContainer(1, 2, 3, 4, 5);
+    ac = ac.clone();// not to have container backed by read only buffer
+
+    ac = ac.flip((char) 1);
+
+    assertEquals(4, ac.getCardinality());
+    assertFalse(ac.contains((char) 1));
+    for (int i = 2; i <= 5; i++) {
+      assertTrue(ac.contains((char) i), i + " should be present");
+    }
+  }
+
+  @Test
+  public void flipMissingValueAndConvertToBitmapContainer() {
+    MappeableContainer ac = TestMappeableArrayContainer.newArrayContainer(1, 5000);
+    ac = ac.clone();// not to have container backed by read only buffer
+
+    ac = ac.flip((char) 7000);
+
+    assertEquals(5000, ac.getCardinality());
+    for (int i = 1; i < 5000; i++) {
+      assertTrue(ac.contains((char) i), i + " should be present");
+    }
+    for (int i = 5000; i < 7000; i++) {
+      assertFalse(ac.contains((char) i), i + " should not be present");
     }
     assertTrue(ac.contains((char) 7000));
   }


### PR DESCRIPTION
### SUMMARY
There was bad loop iteration, which caused all consecutive values are omitted from results of actions `flip()` of present value and `remove()` on array container backed by read only buffer.

Creation of mutable copy of backing buffer is necessary as otherwise the exception `ReadOnlyBufferException` was thrown, just run `TestMappeableArrayContainer` after checkout 556cfe3.

Condition to increase capacity was omitted as it is always satisfied - I have not found any way to create not read only heap char buffer, am I wrong?

Note, that misconception between direct array and not read only buffer is widely spread across whole project, when recognition between all variants are done by `isBackedBySimpleArray()`, but nowadays I suppose it is better left as it is as this is strongly breakable change. I mean there are three variants at least:
1. mutable direct array buffer - do everything what you need
2. mutable indirect access buffer - you can change the values, but you have to iterate one by one through the values
3. read only buffer whatsoever backed by array or some indirect access buffer - you have to iterate one by one, if you want to do some changes, mutable buffer copy must be done

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
