### PR TITLE
Factory method for array container deduplication

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
@@ -5,6 +5,8 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.BitSet;
 
+import static java.lang.Long.numberOfTrailingZeros;
+
 
 /***
  *
@@ -20,8 +22,18 @@ public class BitSetUtil {
   // 64-bit
   // word
 
-  private static ArrayContainer arrayContainerOf(final int from, final int to,
-      final int cardinality, final long[] words) {
+  /**
+   * Creates array container's content char buffer.
+   *
+   * @param from        first value of the range
+   * @param to          last value of the range
+   * @param cardinality new buffer cardinality, expected to be less than 4096 and more than present
+   *                    values in given bitmap
+   * @param words       bitmap
+   * @return array container's content char buffer
+   */
+  public static char[] arrayContainerBufferOf(final int from, final int to, final int cardinality,
+                                              final long[] words) {
     // precondition: cardinality is max 4096
     final char[] content = new char[cardinality];
     int index = 0;
@@ -29,12 +41,16 @@ public class BitSetUtil {
     for (int i = from, socket = 0; i < to; ++i, socket += Long.SIZE) {
       long word = words[i];
       while (word != 0) {
-        long t = word & -word;
-        content[index++] = (char) (socket + Long.bitCount(t - 1));
-        word ^= t;
+        content[index++] = (char) (socket + numberOfTrailingZeros(word));
+        word &= (word - 1);
       }
     }
-    return new ArrayContainer(content);
+    return content;
+  }
+
+  private static ArrayContainer arrayContainerOf(final int from, final int to,
+                                                 final int cardinality, final long[] words) {
+    return new ArrayContainer(arrayContainerBufferOf(from, to, cardinality, words));
   }
 
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferBitSetUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferBitSetUtil.java
@@ -10,8 +10,6 @@ import java.nio.CharBuffer;
 import java.nio.LongBuffer;
 import java.util.BitSet;
 
-import static java.lang.Long.numberOfTrailingZeros;
-
 
 /***
  *
@@ -29,17 +27,7 @@ public class BufferBitSetUtil {
 
   private static MappeableArrayContainer arrayContainerOf(final int from, final int to,
       final int cardinality, final long[] words) {
-    // precondition: cardinality is max 4096
-    final char[] content = new char[cardinality];
-    int index = 0;
-
-    for (int i = from, socket = 0; i < to; ++i, socket += Long.SIZE) {
-      long word = words[i];
-      while (word != 0) {
-        content[index++] = (char) (socket + numberOfTrailingZeros(word));
-        word &= (word - 1);
-      }
-    }
+    char[] content = BitSetUtil.arrayContainerBufferOf(from, to, cardinality, words);
     return new MappeableArrayContainer(CharBuffer.wrap(content), cardinality);
   }
 


### PR DESCRIPTION
### SUMMARY
Factory method for array container from given bitmap within given range deduplicated. Chosen variant, which is more similar to expression used in project - preferred `word &= (word - 1)` to `word ^= word & -word`.

What is ugly, that created common method is public, but it is used in both cases from private methods, but as the utility classes are not within the same package, it is the only way to do it. And as it is public, there is a strong assumption, that method parameters are valid, so it is dangerous when no limit checks are done in method not used internally only. May be some refactoring of both affected utility classes `BitSetUtil` and `BufferBitSetUtil` should be done.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
