### PR TITLE
AddOffset optimization

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -224,11 +224,14 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
       for(int pos = 0; pos < x.highLowContainer.size(); pos++) {
         int key = (x.highLowContainer.getKeyAtIndex(pos));
         key += container_offset;
+        if (key + 1 < 0 || key > 0xFFFF) {
+          continue;
+        }
         Container c = x.highLowContainer.getContainerAtIndex(pos);
         Container[] offsetted = Util.addOffset(c,
                 (char)in_container_offset);
-        boolean keyok = (key >= 0) && (key <= 0xFFFF);
-        boolean keypok = (key + 1 >= 0) && (key + 1 <= 0xFFFF);
+        boolean keyok = key >= 0;
+        boolean keypok = key + 1 <= 0xFFFF;
         if( !offsetted[0].isEmpty() && keyok) {
           int current_size = answer.highLowContainer.size();
           int lastkey = 0;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
@@ -107,11 +107,14 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
       for(int pos = 0; pos < x.highLowContainer.size(); pos++) {
         int key = (x.highLowContainer.getKeyAtIndex(pos));
         key += container_offset;
+        if (key + 1 < 0 || key > 0xFFFF) {
+          continue;
+        }
         MappeableContainer c = x.highLowContainer.getContainerAtIndex(pos);
         MappeableContainer[] offsetted = BufferUtil.addOffset(c,
                 (char)in_container_offset);
-        boolean keyok = (key >= 0) && (key <= 0xFFFF);
-        boolean keypok = (key + 1 >= 0) && (key + 1 <= 0xFFFF);
+        boolean keyok = key >= 0;
+        boolean keypok = key + 1 <= 0xFFFF;
         if( !offsetted[0].isEmpty() && keyok) {
           int current_size = answer.highLowContainer.size();
           int lastkey = 0;


### PR DESCRIPTION
### SUMMARY
Computation skips of shifted containers that would be discarded due to out of bounds keys in the case of container unaligned offsets. This solves #544.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
