### PR TITLE
Binary search on part of array only

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -112,7 +112,7 @@ public final class ArrayContainer extends Container implements Cloneable {
     if (indexstart < 0) {
       indexstart = -indexstart - 1;
     }
-    int indexend = Util.unsignedBinarySearch(content, 0, cardinality, (char) (end - 1));
+    int indexend = Util.unsignedBinarySearch(content, indexstart, cardinality, (char) (end - 1));
     if (indexend < 0) {
       indexend = -indexend - 1;
     } else {
@@ -473,7 +473,7 @@ public final class ArrayContainer extends Container implements Cloneable {
     if (indexstart < 0) {
       indexstart = -indexstart - 1;
     }
-    int indexend = Util.unsignedBinarySearch(content, 0, cardinality, (char) (end - 1));
+    int indexend = Util.unsignedBinarySearch(content, indexstart, cardinality, (char) (end - 1));
     if (indexend < 0) {
       indexend = -indexend - 1;
     } else {
@@ -639,7 +639,8 @@ public final class ArrayContainer extends Container implements Cloneable {
     if (startIndex < 0) {
       startIndex = -startIndex - 1;
     }
-    int lastIndex = Util.unsignedBinarySearch(content, 0, cardinality, (char) (lastOfRange - 1));
+    int lastIndex = Util.unsignedBinarySearch(content, startIndex, cardinality,
+        (char) (lastOfRange - 1));
     if (lastIndex < 0) {
       lastIndex = -lastIndex - 1 - 1;
     }
@@ -769,7 +770,7 @@ public final class ArrayContainer extends Container implements Cloneable {
     if (indexstart < 0) {
       indexstart = -indexstart - 1;
     }
-    int indexend = Util.unsignedBinarySearch(content, 0, cardinality, (char) (end - 1));
+    int indexend = Util.unsignedBinarySearch(content, indexstart, cardinality, (char) (end - 1));
     if (indexend < 0) {
       indexend = -indexend - 1;
     } else {
@@ -886,7 +887,8 @@ public final class ArrayContainer extends Container implements Cloneable {
     if (startIndex < 0) {
       startIndex = -startIndex - 1;
     }
-    int lastIndex = Util.unsignedBinarySearch(content, 0, cardinality, (char) (lastOfRange - 1));
+    int lastIndex = Util.unsignedBinarySearch(content, startIndex, cardinality,
+        (char) (lastOfRange - 1));
     if (lastIndex < 0) {
       lastIndex = -lastIndex - 2;
     }
@@ -1068,7 +1070,7 @@ public final class ArrayContainer extends Container implements Cloneable {
     if (indexstart < 0) {
       indexstart = -indexstart - 1;
     }
-    int indexend = Util.unsignedBinarySearch(content, 0, cardinality, (char) (end - 1));
+    int indexend = Util.unsignedBinarySearch(content, indexstart, cardinality, (char) (end - 1));
     if (indexend < 0) {
       indexend = -indexend - 1;
     } else {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -1086,8 +1086,8 @@ public final class RunContainer extends Container implements Cloneable {
     }
 
     int bIndex = unsignedInterleavedBinarySearch(this.valueslength, 0, this.nbrruns, (char) begin);
-    int eIndex = unsignedInterleavedBinarySearch(this.valueslength, Math.abs(bIndex) - 1,
-        this.nbrruns, (char) (end - 1));
+    int eIndex = unsignedInterleavedBinarySearch(this.valueslength,
+        bIndex >= 0 ? bIndex : -bIndex - 1, this.nbrruns, (char) (end - 1));
 
     if (bIndex >= 0 && eIndex >= 0) {
       mergeValuesLength(bIndex, eIndex);
@@ -1574,8 +1574,8 @@ public final class RunContainer extends Container implements Cloneable {
     }
 
     int bIndex = unsignedInterleavedBinarySearch(this.valueslength, 0, this.nbrruns, (char) begin);
-    int eIndex = unsignedInterleavedBinarySearch(this.valueslength, Math.abs(bIndex) - 1,
-        this.nbrruns, (char) (end - 1));
+    int eIndex = unsignedInterleavedBinarySearch(this.valueslength,
+        bIndex >= 0 ? bIndex : -bIndex - 1, this.nbrruns, (char) (end - 1));
 
     // note, eIndex is looking for (end-1)
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -1086,8 +1086,8 @@ public final class RunContainer extends Container implements Cloneable {
     }
 
     int bIndex = unsignedInterleavedBinarySearch(this.valueslength, 0, this.nbrruns, (char) begin);
-    int eIndex =
-        unsignedInterleavedBinarySearch(this.valueslength, 0, this.nbrruns, (char) (end - 1));
+    int eIndex = unsignedInterleavedBinarySearch(this.valueslength, Math.abs(bIndex) - 1,
+        this.nbrruns, (char) (end - 1));
 
     if (bIndex >= 0 && eIndex >= 0) {
       mergeValuesLength(bIndex, eIndex);
@@ -1574,8 +1574,8 @@ public final class RunContainer extends Container implements Cloneable {
     }
 
     int bIndex = unsignedInterleavedBinarySearch(this.valueslength, 0, this.nbrruns, (char) begin);
-    int eIndex =
-        unsignedInterleavedBinarySearch(this.valueslength, 0, this.nbrruns, (char) (end - 1));
+    int eIndex = unsignedInterleavedBinarySearch(this.valueslength, Math.abs(bIndex) - 1,
+        this.nbrruns, (char) (end - 1));
 
     // note, eIndex is looking for (end-1)
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -131,7 +131,8 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     if (indexstart < 0) {
       indexstart = -indexstart - 1;
     }
-    int indexend = BufferUtil.unsignedBinarySearch(content, 0, cardinality, (char) (end - 1));
+    int indexend = BufferUtil.unsignedBinarySearch(content, indexstart, cardinality,
+        (char) (end - 1));
     if (indexend < 0) {
       indexend = -indexend - 1;
     } else {
@@ -589,7 +590,8 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     if (indexstart < 0) {
       indexstart = -indexstart - 1;
     }
-    int indexend = BufferUtil.unsignedBinarySearch(content, 0, cardinality, (char) (end - 1));
+    int indexend = BufferUtil.unsignedBinarySearch(content, indexstart, cardinality,
+        (char) (end - 1));
     if (indexend < 0) {
       indexend = -indexend - 1;
     } else {
@@ -780,7 +782,7 @@ public final class MappeableArrayContainer extends MappeableContainer implements
       startIndex = -startIndex - 1;
     }
     int lastIndex =
-        BufferUtil.unsignedBinarySearch(content, 0, cardinality, (char) (lastOfRange - 1));
+        BufferUtil.unsignedBinarySearch(content, startIndex, cardinality, (char) (lastOfRange - 1));
     if (lastIndex < 0) {
       lastIndex = -lastIndex - 1 - 1;
     }
@@ -941,7 +943,8 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     if (indexstart < 0) {
       indexstart = -indexstart - 1;
     }
-    int indexend = BufferUtil.unsignedBinarySearch(content, 0, cardinality, (char) (end - 1));
+    int indexend = BufferUtil.unsignedBinarySearch(content, indexstart, cardinality,
+        (char) (end - 1));
     if (indexend < 0) {
       indexend = -indexend - 1;
     } else {
@@ -1071,7 +1074,7 @@ public final class MappeableArrayContainer extends MappeableContainer implements
       startIndex = -startIndex - 1;
     }
     int lastIndex =
-        BufferUtil.unsignedBinarySearch(content, 0, cardinality, (char) (lastOfRange - 1));
+        BufferUtil.unsignedBinarySearch(content, startIndex, cardinality, (char) (lastOfRange - 1));
     if (lastIndex < 0) {
       lastIndex = -lastIndex - 2;
     }
@@ -1377,7 +1380,8 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     if (indexstart < 0) {
       indexstart = -indexstart - 1;
     }
-    int indexend = BufferUtil.unsignedBinarySearch(content, 0, cardinality, (char) (end - 1));
+    int indexend = BufferUtil.unsignedBinarySearch(content, indexstart, cardinality,
+        (char) (end - 1));
     if (indexend < 0) {
       indexend = -indexend - 1;
     } else {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -1003,8 +1003,8 @@ public final class MappeableRunContainer extends MappeableContainer implements C
 
     int bIndex =
         bufferedUnsignedInterleavedBinarySearch(this.valueslength, 0, this.nbrruns, (char) begin);
-    int eIndex = bufferedUnsignedInterleavedBinarySearch(this.valueslength, 0, this.nbrruns,
-        (char) (end - 1));
+    int eIndex = bufferedUnsignedInterleavedBinarySearch(this.valueslength,
+          bIndex >= 0 ? bIndex : -bIndex - 1, this.nbrruns, (char) (end - 1));
 
     if (bIndex >= 0 && eIndex >= 0) {
       mergeValuesLength(bIndex, eIndex);
@@ -1476,8 +1476,8 @@ public final class MappeableRunContainer extends MappeableContainer implements C
 
     int bIndex =
         bufferedUnsignedInterleavedBinarySearch(this.valueslength, 0, this.nbrruns, (char) begin);
-    int eIndex = bufferedUnsignedInterleavedBinarySearch(this.valueslength, 0, this.nbrruns,
-        (char) (end - 1));
+    int eIndex = bufferedUnsignedInterleavedBinarySearch(this.valueslength,
+          bIndex >= 0 ? bIndex : -bIndex - 1, this.nbrruns, (char) (end - 1));
 
     if (bIndex >= 0) {
       if (eIndex < 0) {


### PR DESCRIPTION
### SUMMARY
Binary search limited to search from known minimal possible start index. This reduces its number of steps.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
