### PR TITLE
Trying to verify issue with flips.

### DIFF
--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -5460,6 +5460,7 @@ public class TestRoaringBitmap {
         System.out.println("[issue566] RoaringBitmap bits per entry: " + roaringbits * 1.0 / roaringBitMap.getCardinality());
         assertTrue(roaringbits < bitsetbits);
     }
+
     @Test
     public void issue623() {
         RoaringBitmap r = new RoaringBitmap();
@@ -5475,4 +5476,19 @@ public class TestRoaringBitmap {
             assertTrue(r.contains(i, i + 1));
         }
     }
+
+    @Test
+    public void test1235() {
+        RoaringBitmap r = RoaringBitmap.bitmapOf(1, 2, 3, 5);
+        r.flip(4);
+        assertEquals(r,  RoaringBitmap.bitmapOf(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void test2345() {
+        RoaringBitmap r = RoaringBitmap.bitmapOf(1, 2, 3, 4, 5);
+        r.flip(1);
+        assertEquals(r,  RoaringBitmap.bitmapOf(2, 3, 4, 5));
+    }
+
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
@@ -3965,4 +3965,19 @@ public class TestRoaringBitmap {
     }
   }
 
+
+
+    @Test
+    public void test1235() {
+        MutableRoaringBitmap r = MutableRoaringBitmap.bitmapOf(1, 2, 3, 5);
+        r.flip(4);
+        assertEquals(r,  MutableRoaringBitmap.bitmapOf(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void test2345() {
+        MutableRoaringBitmap r = MutableRoaringBitmap.bitmapOf(1, 2, 3, 4, 5);
+        r.flip(1);
+        assertEquals(r,  MutableRoaringBitmap.bitmapOf(2, 3, 4, 5));
+    }
 }


### PR DESCRIPTION
### SUMMARY

In issue https://github.com/RoaringBitmap/RoaringBitmap/pull/666, @xtonik reported an issue where flipping a value in an array container would lead to the wrong result. However, they did not provide an actual test using our public API.

To try to determine whether the issue is real, I added tests based on their unit tests.