### PR TITLE
Check instance reference first when comparing two array containers

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -371,6 +371,9 @@ public final class ArrayContainer extends Container implements Cloneable {
   @Override
   public boolean equals(Object o) {
     if (o instanceof ArrayContainer) {
+      if (this == o) {
+        return true;
+      }
       ArrayContainer srb = (ArrayContainer) o;
       return ArraysShim.equals(this.content, 0, cardinality, srb.content, 0, srb.cardinality);
     } else if (o instanceof RunContainer) {


### PR DESCRIPTION
### SUMMARY
Inspired by equivalent [code in C/roaring](https://github.com/RoaringBitmap/roaring/blob/c79926f24cdcf0dc5fa59f688c308f0045e3b182/arraycontainer.go#L196). The question is if it is really worthy as comparing the same object is not common case.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
