### PR TITLE
Optimized creation of bitmap by range

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -562,14 +562,14 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
       return new RoaringBitmap();
     }
     final int hbStart = Util.highbits(min);
-    final int hbLast = Util.highbits(max - 1);
     final int lbStart = Util.lowbits(min);
-    final int lbLast = Util.lowbits(max - 1) + 1;
+    final int hbLast = Util.highbits(max - 1);
+    final int lbLast = Util.lowbits(max - 1);
 
     RoaringArray array = new RoaringArray(hbLast - hbStart + 1);
     RoaringBitmap bitmap = new RoaringBitmap(array);
 
-    int firstEnd = hbStart < hbLast ? 1 << 16 : lbLast;
+    int firstEnd = hbStart < hbLast ? 1 << 16 : lbLast + 1;
     Container firstContainer = RunContainer.rangeOfOnes(lbStart, firstEnd);
     bitmap.append((char) hbStart, firstContainer);
     if (hbStart < hbLast) {
@@ -579,7 +579,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
         bitmap.append((char) i, runContainer);
         i++;
       }
-      Container lastContainer = RunContainer.rangeOfOnes(0, lbLast);
+      Container lastContainer = RunContainer.rangeOfOnes(0, lbLast + 1);
       bitmap.append((char) hbLast, lastContainer);
     }
     return bitmap;

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestUtil.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestUtil.java
@@ -194,4 +194,26 @@ public class TestUtil {
         assertEquals(expectedCardinality, cardinality);
         assertArrayEquals(referenceBitmap, bitmap);
     }
+
+    @Test
+    public void bitmapOfRange() {
+        assertBitmapRange(0, 10);// begin of first container
+        assertBitmapRange(0, 1 << 16 - 1);// early full container
+        assertBitmapRange(0, 1 << 16);// full first container
+        assertBitmapRange(0, 1 << 16 + 1);// full first container + one value the second
+        assertBitmapRange(10, 1 << 16);// without first several integers
+        assertBitmapRange(1 << 16, (1 << 16) * 2);// full second container
+        assertBitmapRange(10, 100);// some integers inside interval
+        assertBitmapRange((1 << 16) - 5, (1 << 16) + 7); // first to second container
+        assertBitmapRange(0, 100_000); // more than one container
+        assertBitmapRange(100_000, 200_000);// second to third container
+        assertBitmapRange(200_000, 400_000);// more containers inside
+    }
+
+    private static void assertBitmapRange(int start, int end) {
+        RoaringBitmap bitmap = RoaringBitmap.bitmapOfRange(start, end);
+        assertEquals(end - start, bitmap.getCardinality());
+        assertEquals(start, bitmap.first());
+        assertEquals(end - 1, bitmap.last());
+    }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestUtil.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestUtil.java
@@ -142,4 +142,26 @@ public class TestUtil {
       assertEquals(bitmap.get(i), referenceBitmap.get(i), "mismatch at " + i);
     }
   }
+
+  @Test
+  public void bitmapOfRange() {
+    assertBitmapRange(0, 10);// begin of first container
+    assertBitmapRange(0, 1 << 16 - 1);// early full container
+    assertBitmapRange(0, 1 << 16);// full first container
+    assertBitmapRange(0, 1 << 16 + 1);// full first container + one value the second
+    assertBitmapRange(10, 1 << 16);// without first several integers
+    assertBitmapRange(1 << 16, (1 << 16) * 2);// full second container
+    assertBitmapRange(10, 100);// some integers inside interval
+    assertBitmapRange((1 << 16) - 5, (1 << 16) + 7); // first to second container
+    assertBitmapRange(0, 100_000); // more than one container
+    assertBitmapRange(100_000, 200_000);// second to third container
+    assertBitmapRange(200_000, 400_000);// more containers inside
+  }
+
+  private static void assertBitmapRange(int start, int end) {
+    MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOfRange(start, end);
+    assertEquals(end - start, bitmap.getCardinality());
+    assertEquals(start, bitmap.first());
+    assertEquals(end - 1, bitmap.last());
+  }
 }

--- a/jmh/src/jmh/java/org/roaringbitmap/BitmapOfRangeBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/BitmapOfRangeBenchmark.java
@@ -1,0 +1,39 @@
+package org.roaringbitmap;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 3, timeUnit = TimeUnit.MILLISECONDS, time = 1000)
+@Measurement(iterations = 5, timeUnit = TimeUnit.MILLISECONDS, time = 1000)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class BitmapOfRangeBenchmark {
+  @Param({"0", // from the beginning
+      "100000" // from some offset
+  })
+  int from;
+
+  @Param({"10",
+      "100000", // ~ 100 kBi
+      "10000000",// ~ 10 MBi
+  })
+  int length;
+
+  @Benchmark
+  public RoaringBitmap original() {
+    return bitmapOfRangeOriginal(from, from + length);
+  }
+
+  @Benchmark
+  public RoaringBitmap optimized() {
+    return RoaringBitmap.bitmapOfRange(from, from + length);
+  }
+
+  public static RoaringBitmap bitmapOfRangeOriginal(long min, long max) {
+    RoaringBitmap bitmap = new RoaringBitmap();
+    bitmap.add(min, max);
+    return bitmap;
+  }
+}


### PR DESCRIPTION
### SUMMARY
Optimized creation of bitmap by range via factory method `Util.bitmapOf()`. There is a trade-off between performance and  code is  duplication, but it can be ignored as piece of duplicated code is already duplicated several times in class `RoaringBitmap`.

| Benchmark | (offset) | (bytes) | Mode | Cnt | Score | Error | Units | 
| --- | --- | --- | --- | --- | --- | --- | --- |
| optimized | 0 | 10 | avgt | 5 | 31.364 | ±0.964 | ns/op |
| optimized | 0 | 100000 | avgt | 5 | 45.240 | ±3.783 | ns/op |
| optimized | 0 | 10000000 | avgt | 5 | 1663.824 | ±22.388 | ns/op |
| optimized | 100000 | 10 | avgt | 5 | 31.179 | ±0.358 | ns/op |
| optimized | 100000 | 100000 | avgt | 5 | 59.337 | ±9.726 | ns/op |
| optimized | 100000 | 10000000 | avgt | 5 | 1764.398 | ±329.763 | ns/op |
| original | 0 | 10 | avgt | 5 | 40.100 | ±1.431 | ns/op |
| original | 0 | 100000 | avgt | 5 | 65.978 | ±9.748 | ns/op |
| original | 0 | 10000000 | avgt | 5 |  3338.978 | ±379.935 | ns/op |
| original | 100000 | 10 | avgt | 5 | 40.919 | ±3.560 | ns/op |
| original | 100000 | 100000 | avgt | 5 | 84.212 | ±1.339 | ns/op |
| original | 100000 | 10000000 | avgt | 5 | 3295.778 | ±68.212 | ns/op |

Some tests added to verify correctness and improve code coverage.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
