### PR TITLE
unit test to expose batchiterator.advanceIfNeeded bug and fix

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/RunBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/RunBatchIterator.java
@@ -62,11 +62,11 @@ public final class RunBatchIterator implements ContainerBatchIterator {
     do {
       int runStart = runs.getValue(run);
       int runLength = runs.getLength(run);
-      int offset = target - runStart;
       if (runStart > target) {
         cursor = 0;
         break;
       }
+      int offset = target - runStart;
       if (offset <= runLength) {
         cursor = offset;
         break;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/RunBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/RunBatchIterator.java
@@ -62,12 +62,13 @@ public final class RunBatchIterator implements ContainerBatchIterator {
     do {
       int runStart = runs.getValue(run);
       int runLength = runs.getLength(run);
-      if (runStart <= target && runStart + runLength > target) {
-        cursor = target - runStart;
-        break;
-      }
+      int offset = target - runStart;
       if (runStart > target) {
         cursor = 0;
+        break;
+      }
+      if (offset <= runLength) {
+        cursor = offset;
         break;
       }
       ++run;

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitmapBatchIteratorTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitmapBatchIteratorTest.java
@@ -208,4 +208,5 @@ public class RoaringBitmapBatchIteratorTest {
         assertEquals(batch[1], (3 << 16) + 5);
         assertEquals(batch[2], (3 << 16) + 10);
     }
+
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/ImmutableRoaringBitmapBatchIteratorTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/ImmutableRoaringBitmapBatchIteratorTest.java
@@ -198,8 +198,8 @@ public class ImmutableRoaringBitmapBatchIteratorTest {
     @ParameterizedTest
     @ValueSource(ints = {10, 11, 12, 13, 14, 15, 18, 20, 21, 23, 24})
     public void testBatchIteratorWithAdvancedIfNeededWithZeroLengthRun(int number) {
-       MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(10, 11, 12, 13, 14, 15, 18, 20, 21, 22, 23, 24);
-       bitmap.runOptimize();
+        MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(10, 11, 12, 13, 14, 15, 18, 20, 21, 22, 23, 24);
+        bitmap.runOptimize();
         BatchIterator it = bitmap.getBatchIterator();
         it.advanceIfNeeded(number);
         assertTrue(it.hasNext());

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/ImmutableRoaringBitmapBatchIteratorTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/ImmutableRoaringBitmapBatchIteratorTest.java
@@ -8,10 +8,12 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.roaringbitmap.BatchIterator;
 import org.roaringbitmap.IntIterator;
 import org.roaringbitmap.RoaringBitmapWriter;
 
+import java.util.Arrays;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -191,5 +193,20 @@ public class ImmutableRoaringBitmapBatchIteratorTest {
         assertEquals(batch[0], 3 << 16);
         assertEquals(batch[1], (3 << 16) + 5);
         assertEquals(batch[2], (3 << 16) + 10);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {10, 11, 12, 13, 14, 15, 18, 20, 21, 23, 24})
+    public void testBatchIteratorWithAdvancedIfNeededWithZeroLengthRun(int number) {
+       MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(10, 11, 12, 13, 14, 15, 18, 20, 21, 22, 23, 24);
+       bitmap.runOptimize();
+        BatchIterator it = bitmap.getBatchIterator();
+        it.advanceIfNeeded(number);
+        assertTrue(it.hasNext());
+        int[] batch = new int[10];
+        int n = it.nextBatch(batch);
+        int i = Arrays.binarySearch(batch, 0, n, number);
+        assertTrue(i >= 0, "key " + number + " not found");
+        assertEquals(batch[i], number);
     }
 }


### PR DESCRIPTION
### SUMMARY
Added unit test to expose batchiterator.advanceIfNeeded bug 
### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
