### PR TITLE
Fix roaringbitmap - batchiterator's advanceIfNeeded to handle run lengths of zero

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunBatchIterator.java
@@ -60,12 +60,13 @@ public final class RunBatchIterator implements ContainerBatchIterator {
     do {
       int runStart = runs.getValue(run);
       int runLength = runs.getLength(run);
-      if (runStart <= target && runStart + runLength > target) {
-        cursor = target - runStart;
-        break;
-      }
       if (runStart > target) {
         cursor = 0;
+        break;
+      }
+      int offset = target - runStart;
+      if (offset <= runLength) {
+        cursor = offset;
         break;
       }
       ++run;

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitmapBatchIteratorTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitmapBatchIteratorTest.java
@@ -8,7 +8,10 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -207,6 +210,21 @@ public class RoaringBitmapBatchIteratorTest {
         assertEquals(batch[0], 3 << 16);
         assertEquals(batch[1], (3 << 16) + 5);
         assertEquals(batch[2], (3 << 16) + 10);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {10, 11, 12, 13, 14, 15, 18, 20, 21, 23, 24})
+    public void testBatchIteratorWithAdvancedIfNeededWithZeroLengthRun(int number) {
+        RoaringBitmap bitmap = RoaringBitmap.bitmapOf(10, 11, 12, 13, 14, 15, 18, 20, 21, 22, 23, 24);
+        bitmap.runOptimize();
+        BatchIterator it = bitmap.getBatchIterator();
+        it.advanceIfNeeded(number);
+        assertTrue(it.hasNext());
+        int[] batch = new int[10];
+        int n = it.nextBatch(batch);
+        int i = Arrays.binarySearch(batch, 0, n, number);
+        assertTrue(i >= 0, "key " + number + " not found");
+        assertEquals(batch[i], number);
     }
 
 }


### PR DESCRIPTION

### SUMMARY
Added unit test to expose batchiterator.advanceIfNeeded bug (this time in the RoaringBitmap and fix it.


### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
