### PR TITLE
AddOffset() optimization for array containers

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
@@ -61,14 +61,19 @@ public final class Util {
         ? new ArrayContainer()
         : new ArrayContainer(source.cardinality - splitIndex);
 
+    int lowCardinality = 0;
     for (int k = 0; k < splitIndex; k++) {
       int val = source.content[k] + offsets;
-      low.content[low.cardinality++] = (char) val;
+      low.content[lowCardinality++] = (char) val;
     }
+    low.cardinality = lowCardinality;
+
+    int highCardinality = 0;
     for (int k = splitIndex; k < source.cardinality; k++) {
       int val = source.content[k] + offsets;
-      high.content[high.cardinality++] = (char) val;
+      high.content[highCardinality++] = (char) val;
     }
+    high.cardinality = highCardinality;
 
     return new Container[]{low, high};
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
@@ -30,67 +30,99 @@ public final class Util {
    * @return return an array made of two containers
    */
   public static  Container[] addOffset(Container source, char offsets) {
-    // could be a whole lot faster, this is a simple implementation
     if(source instanceof ArrayContainer) {
-      ArrayContainer c = (ArrayContainer) source;
-      ArrayContainer low = new ArrayContainer(c.cardinality);
-      ArrayContainer high = new ArrayContainer(c.cardinality);
-      for(int k = 0; k < c.cardinality; k++) {
-        int val =  c.content[k];
-        val += (int) (offsets);
-        if(val <= 0xFFFF) {
-          low.content[low.cardinality++] = (char) val;
-        } else {
-          high.content[high.cardinality++] = (char) val;
-        }
-      }
-      return new Container[] {low, high};
+      return addOffset((ArrayContainer) source, offsets);
     } else if (source instanceof BitmapContainer) {
-      BitmapContainer c = (BitmapContainer) source;
-      BitmapContainer low = new BitmapContainer();
-      BitmapContainer high = new BitmapContainer();
-      low.cardinality = -1;
-      high.cardinality = -1;
-      final int b = (int) (offsets) >>> 6;
-      final int i = (int) (offsets) % 64;
-      if(i == 0) {
-        System.arraycopy(c.bitmap, 0, low.bitmap, b, 1024 - b);
-        System.arraycopy(c.bitmap, 1024 - b, high.bitmap, 0, b );
-      } else {
-        low.bitmap[b + 0] = c.bitmap[0] << i;
-        for(int k = 1; k < 1024 - b; k++) {
-          low.bitmap[b + k] = (c.bitmap[k] << i) | (c.bitmap[k - 1] >>> (64-i));
-        }
-        for(int k = 1024 - b; k < 1024 ; k++) {
-          high.bitmap[k - (1024 - b)] =
-             (c.bitmap[k] << i)
-             | (c.bitmap[k - 1] >>> (64-i));
-        }
-        high.bitmap[b] =  (c.bitmap[1024 - 1] >>> (64-i));
-      }
-      return new Container[] {low.repairAfterLazy(), high.repairAfterLazy()};
+      return addOffset((BitmapContainer) source, offsets);
     } else if (source instanceof RunContainer) {
-      RunContainer input = (RunContainer) source;
-      RunContainer low = new RunContainer();
-      RunContainer high = new RunContainer();
-      for(int k = 0 ; k < input.nbrruns; k++) {
-        int val =  (input.getValue(k));
-        val += (int) (offsets);
-        int finalval =  val + (input.getLength(k));
-        if(val <= 0xFFFF) {
-          if(finalval <= 0xFFFF) {
-            low.smartAppend((char)val,input.getLength(k));
-          } else {
-            low.smartAppend((char)val,(char)(0xFFFF-val));
-            high.smartAppend((char) 0,(char)finalval);
-          }
-        } else {
-          high.smartAppend((char)val,input.getLength(k));
-        }
-      }
-      return new Container[] {low, high};
+      return addOffset((RunContainer) source, offsets);
     }
-    throw new RuntimeException("unknown container type"); // never happens
+    throw new RuntimeException("unknown container type");
+  }
+
+  private static Container[] addOffset(ArrayContainer source, char offsets) {
+    int splitIndex;
+    if (source.first() + offsets > 0xFFFF) {
+      splitIndex = 0;
+    } else if (source.last() + offsets < 0xFFFF) {
+      splitIndex = source.cardinality;
+    } else {
+      splitIndex = Util.unsignedBinarySearch(source.content, 0, source.cardinality,
+          (char) (0x10000 - offsets));
+      if (splitIndex < 0) {
+        splitIndex = -splitIndex - 1;
+      }
+    }
+
+    ArrayContainer low = splitIndex == 0
+        ? new ArrayContainer()
+        : new ArrayContainer(splitIndex);
+    ArrayContainer high = source.cardinality - splitIndex == 0
+        ? new ArrayContainer()
+        : new ArrayContainer(source.cardinality - splitIndex);
+
+    int lowCardinality = 0;
+    for (int k = 0; k < splitIndex; k++) {
+      int val = source.content[k] + offsets;
+      low.content[lowCardinality++] = (char) val;
+    }
+    low.cardinality = lowCardinality;
+
+    int highCardinality = 0;
+    for (int k = splitIndex; k < source.cardinality; k++) {
+      int val = source.content[k] + offsets;
+      high.content[highCardinality++] = (char) val;
+    }
+    high.cardinality = highCardinality;
+
+    return new Container[]{low, high};
+  }
+
+  private static Container[] addOffset(BitmapContainer source, char offsets) {
+    BitmapContainer c = source;
+    BitmapContainer low = new BitmapContainer();
+    BitmapContainer high = new BitmapContainer();
+    low.cardinality = -1;
+    high.cardinality = -1;
+    final int b = (int) offsets >>> 6;
+    final int i = (int) offsets % 64;
+    if(i == 0) {
+      System.arraycopy(c.bitmap, 0, low.bitmap, b, 1024 - b);
+      System.arraycopy(c.bitmap, 1024 - b, high.bitmap, 0, b);
+    } else {
+      low.bitmap[b] = c.bitmap[0] << i;
+      for(int k = 1; k < 1024 - b; k++) {
+        low.bitmap[b + k] = (c.bitmap[k] << i) | (c.bitmap[k - 1] >>> (64 - i));
+      }
+      for(int k = 1024 - b; k < 1024 ; k++) {
+        high.bitmap[k - (1024 - b)] =
+            (c.bitmap[k] << i)
+                | (c.bitmap[k - 1] >>> (64 - i));
+      }
+      high.bitmap[b] = c.bitmap[1024 - 1] >>> (64 - i);
+    }
+    return new Container[] {low.repairAfterLazy(), high.repairAfterLazy()};
+  }
+
+  private static Container[] addOffset(RunContainer source, char offsets) {
+    RunContainer input = source;
+    RunContainer low = new RunContainer();
+    RunContainer high = new RunContainer();
+    for(int k = 0 ; k < input.nbrruns; k++) {
+      int val =  input.getValue(k) + offsets;
+      int finalval = val + input.getLength(k);
+      if(val <= 0xFFFF) {
+        if(finalval <= 0xFFFF) {
+          low.smartAppend((char) val, input.getLength(k));
+        } else {
+          low.smartAppend((char) val, (char) (0xFFFF - val));
+          high.smartAppend((char) 0, (char) finalval);
+        }
+      } else {
+        high.smartAppend((char) val, input.getLength(k));
+      }
+    }
+    return new Container[]{low, high};
   }
 
   /**

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
@@ -61,19 +61,14 @@ public final class Util {
         ? new ArrayContainer()
         : new ArrayContainer(source.cardinality - splitIndex);
 
-    int lowCardinality = 0;
     for (int k = 0; k < splitIndex; k++) {
       int val = source.content[k] + offsets;
-      low.content[lowCardinality++] = (char) val;
+      low.content[low.cardinality++] = (char) val;
     }
-    low.cardinality = lowCardinality;
-
-    int highCardinality = 0;
     for (int k = splitIndex; k < source.cardinality; k++) {
       int val = source.content[k] + offsets;
-      high.content[highCardinality++] = (char) val;
+      high.content[high.cardinality++] = (char) val;
     }
-    high.cardinality = highCardinality;
 
     return new Container[]{low, high};
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
@@ -31,16 +31,16 @@ public final class Util {
    */
   public static  Container[] addOffset(Container source, char offsets) {
     if(source instanceof ArrayContainer) {
-      return addOffset((ArrayContainer) source, offsets);
+      return addOffsetArray((ArrayContainer) source, offsets);
     } else if (source instanceof BitmapContainer) {
-      return addOffset((BitmapContainer) source, offsets);
+      return addOffsetBitmap((BitmapContainer) source, offsets);
     } else if (source instanceof RunContainer) {
-      return addOffset((RunContainer) source, offsets);
+      return addOffsetRun((RunContainer) source, offsets);
     }
     throw new RuntimeException("unknown container type");
   }
 
-  private static Container[] addOffset(ArrayContainer source, char offsets) {
+  private static Container[] addOffsetArray(ArrayContainer source, char offsets) {
     int splitIndex;
     if (source.first() + offsets > 0xFFFF) {
       splitIndex = 0;
@@ -78,7 +78,7 @@ public final class Util {
     return new Container[]{low, high};
   }
 
-  private static Container[] addOffset(BitmapContainer source, char offsets) {
+  private static Container[] addOffsetBitmap(BitmapContainer source, char offsets) {
     BitmapContainer c = source;
     BitmapContainer low = new BitmapContainer();
     BitmapContainer high = new BitmapContainer();
@@ -104,7 +104,7 @@ public final class Util {
     return new Container[] {low.repairAfterLazy(), high.repairAfterLazy()};
   }
 
-  private static Container[] addOffset(RunContainer source, char offsets) {
+  private static Container[] addOffsetRun(RunContainer source, char offsets) {
     RunContainer input = source;
     RunContainer low = new RunContainer();
     RunContainer high = new RunContainer();

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferUtil.java
@@ -31,19 +31,18 @@ public final class BufferUtil {
    * @return return an array made of two containers
    */
   public static  MappeableContainer[] addOffset(MappeableContainer source, char offsets) {
-    // could be a whole lot faster, this is a simple implementation
     if(source instanceof MappeableArrayContainer) {
-      return addOffset((MappeableArrayContainer) source, offsets);
+      return addOffsetArray((MappeableArrayContainer) source, offsets);
     } else if (source instanceof MappeableBitmapContainer) {
-      return addOffset((MappeableBitmapContainer) source, offsets);
+      return addOffsetBitmap((MappeableBitmapContainer) source, offsets);
     } else if (source instanceof MappeableRunContainer) {
-      return addOffset((MappeableRunContainer) source, offsets);
+      return addOffsetRun((MappeableRunContainer) source, offsets);
     }
     throw new RuntimeException("unknown container type"); // never happens
   }
 
-  private static MappeableContainer[] addOffset(MappeableArrayContainer source,
-                                                char offsets) {
+  private static MappeableContainer[] addOffsetArray(MappeableArrayContainer source,
+                                                     char offsets) {
     int splitIndex;
     if (source.first() + offsets > 0xFFFF) {
       splitIndex = 0;
@@ -80,8 +79,8 @@ public final class BufferUtil {
     return new MappeableContainer[]{low, high};
   }
 
-  private static MappeableContainer[] addOffset(MappeableBitmapContainer source,
-                                                char offsets) {
+  private static MappeableContainer[] addOffsetBitmap(MappeableBitmapContainer source,
+                                                      char offsets) {
     MappeableBitmapContainer c = source;
     MappeableBitmapContainer low = new MappeableBitmapContainer();
     MappeableBitmapContainer high = new MappeableBitmapContainer();
@@ -113,8 +112,7 @@ public final class BufferUtil {
     return new MappeableContainer[]{low.repairAfterLazy(), high.repairAfterLazy()};
   }
 
-  private static MappeableContainer[] addOffset(MappeableRunContainer source,
-                                                char offsets) {
+  private static MappeableContainer[] addOffsetRun(MappeableRunContainer source, char offsets) {
     MappeableRunContainer c = source;
     MappeableRunContainer low = new MappeableRunContainer();
     MappeableRunContainer high = new MappeableRunContainer();

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferUtil.java
@@ -62,19 +62,15 @@ public final class BufferUtil {
         ? new MappeableArrayContainer()
         : new MappeableArrayContainer(source.cardinality - splitIndex);
 
-    int lowCardinality = 0;
     for (int k = 0; k < splitIndex; k++) {
       int val = source.content.get(k) + offsets;
-      low.content.put(lowCardinality++, (char) val);
+      low.content.put(low.cardinality++, (char) val);
     }
-    low.cardinality = lowCardinality;
 
-    int highCardinality = 0;
     for (int k = splitIndex; k < source.cardinality; k++) {
       int val = source.content.get(k) + offsets;
-      high.content.put(highCardinality++, (char) val);
+      high.content.put(high.cardinality++, (char) val);
     }
-    high.cardinality = highCardinality;
 
     return new MappeableContainer[]{low, high};
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferUtil.java
@@ -31,74 +31,109 @@ public final class BufferUtil {
    * @return return an array made of two containers
    */
   public static  MappeableContainer[] addOffset(MappeableContainer source, char offsets) {
-    // could be a whole lot faster, this is a simple implementation
     if(source instanceof MappeableArrayContainer) {
-      MappeableArrayContainer c = (MappeableArrayContainer) source;
-      MappeableArrayContainer low = new MappeableArrayContainer(c.cardinality);
-      MappeableArrayContainer high = new MappeableArrayContainer(c.cardinality);
-      for(int k = 0; k < c.cardinality; k++) {
-        int val = (c.content.get(k));
-        val += (int) (offsets);
-        if(val <= 0xFFFF) {
-          low.content.put(low.cardinality++, (char) val);
-        } else {
-          high.content.put(high.cardinality++, (char) val);
-        }
-      }
-      return new MappeableContainer[] {low, high};
+      return addOffset((MappeableArrayContainer) source, offsets);
     } else if (source instanceof MappeableBitmapContainer) {
-      MappeableBitmapContainer c = (MappeableBitmapContainer) source;
-      MappeableBitmapContainer low = new MappeableBitmapContainer();
-      MappeableBitmapContainer high = new MappeableBitmapContainer();
-      low.cardinality = -1;
-      high.cardinality = -1;
-      final int b = (int) (offsets) >>> 6;
-      final int i = (int) (offsets) % 64;
-      if(i == 0) {
-        for(int k = 0; k < 1024 - b; k++) {
-          low.bitmap.put(b + k, c.bitmap.get(k));
-        }
-        for(int k = 1024 - b; k < 1024 ; k++) {
-          high.bitmap.put(k - (1024 - b),c.bitmap.get(k));
-        }
-      } else {
-        low.bitmap.put(b + 0, c.bitmap.get(0) << i);
-        for(int k = 1; k < 1024 - b; k++) {
-          low.bitmap.put(b + k, (c.bitmap.get(k) << i) 
-              | (c.bitmap.get(k - 1) >>> (64-i)));
-        }
-        for(int k = 1024 - b; k < 1024 ; k++) {
-          high.bitmap.put(k - (1024 - b),
-               (c.bitmap.get(k) << i) 
-               | (c.bitmap.get(k - 1) >>> (64-i)));
-        }
-        high.bitmap.put(b,  (c.bitmap.get(1024 - 1) >>> (64-i)));
-      }
-      return new MappeableContainer[] {low.repairAfterLazy(), high.repairAfterLazy()};
+      return addOffset((MappeableBitmapContainer) source, offsets);
     } else if (source instanceof MappeableRunContainer) {
-      MappeableRunContainer c = (MappeableRunContainer) source;
-      MappeableRunContainer low = new MappeableRunContainer();
-      MappeableRunContainer high = new MappeableRunContainer();
-      for(int k = 0 ; k < c.nbrruns; k++) {
-        int val =  (c.getValue(k));
-        val += (int) (offsets);
-        int finalval =  val + (c.getLength(k));
-        if(val <= 0xFFFF) {
-          if(finalval <= 0xFFFF) {
-            low.smartAppend((char)val,c.getLength(k));
-          } else {
-            low.smartAppend((char)val,(char)(0xFFFF-val));
-            high.smartAppend((char) 0,(char)finalval);
-          }
-        } else {
-          high.smartAppend((char)val,c.getLength(k));
-        }
-      }
-      return new MappeableContainer[] {low, high};
+      return addOffset((MappeableRunContainer) source, offsets);
     }
     throw new RuntimeException("unknown container type"); // never happens
   }
 
+  private static MappeableContainer[] addOffset(MappeableArrayContainer source,
+                                                char offsets) {
+    int splitIndex;
+    if (source.first() + offsets > 0xFFFF) {
+      splitIndex = 0;
+    } else if (source.last() + offsets < 0xFFFF) {
+      splitIndex = source.cardinality;
+    } else {
+      splitIndex = BufferUtil.unsignedBinarySearch(source.content, 0, source.cardinality,
+          (char) (0x10000 - offsets));
+      if (splitIndex < 0) {
+        splitIndex = -splitIndex - 1;
+      }
+    }
+    MappeableArrayContainer low = splitIndex == 0
+        ? new MappeableArrayContainer()
+        : new MappeableArrayContainer(splitIndex);
+    MappeableArrayContainer high = source.cardinality - splitIndex == 0
+        ? new MappeableArrayContainer()
+        : new MappeableArrayContainer(source.cardinality - splitIndex);
+
+    int lowCardinality = 0;
+    for (int k = 0; k < splitIndex; k++) {
+      int val = source.content.get(k) + offsets;
+      low.content.put(lowCardinality++, (char) val);
+    }
+    low.cardinality = lowCardinality;
+
+    int highCardinality = 0;
+    for (int k = splitIndex; k < source.cardinality; k++) {
+      int val = source.content.get(k) + offsets;
+      high.content.put(highCardinality++, (char) val);
+    }
+    high.cardinality = highCardinality;
+
+    return new MappeableContainer[]{low, high};
+  }
+
+  private static MappeableContainer[] addOffset(MappeableBitmapContainer source,
+                                                char offsets) {
+    MappeableBitmapContainer c = source;
+    MappeableBitmapContainer low = new MappeableBitmapContainer();
+    MappeableBitmapContainer high = new MappeableBitmapContainer();
+    low.cardinality = -1;
+    high.cardinality = -1;
+    final int b = (int) offsets >>> 6;
+    final int i = (int) offsets % 64;
+    if (i == 0) {
+      for (int k = 0; k < 1024 - b; k++) {
+        low.bitmap.put(b + k, c.bitmap.get(k));
+      }
+      for (int k = 1024 - b; k < 1024; k++) {
+        high.bitmap.put(k - (1024 - b), c.bitmap.get(k));
+      }
+    } else {
+      //noinspection PointlessArithmeticExpression
+      low.bitmap.put(b + 0, c.bitmap.get(0) << i);
+      for (int k = 1; k < 1024 - b; k++) {
+        low.bitmap.put(b + k, (c.bitmap.get(k) << i)
+            | (c.bitmap.get(k - 1) >>> (64 - i)));
+      }
+      for (int k = 1024 - b; k < 1024; k++) {
+        high.bitmap.put(k - (1024 - b),
+            (c.bitmap.get(k) << i)
+                | (c.bitmap.get(k - 1) >>> (64 - i)));
+      }
+      high.bitmap.put(b, (c.bitmap.get(1024 - 1) >>> (64 - i)));
+    }
+    return new MappeableContainer[]{low.repairAfterLazy(), high.repairAfterLazy()};
+  }
+
+  private static MappeableContainer[] addOffset(MappeableRunContainer source,
+                                                char offsets) {
+    MappeableRunContainer c = source;
+    MappeableRunContainer low = new MappeableRunContainer();
+    MappeableRunContainer high = new MappeableRunContainer();
+    for (int k = 0; k < c.nbrruns; k++) {
+      int val = c.getValue(k);
+      val += offsets;
+      int finalval = val + c.getLength(k);
+      if (val <= 0xFFFF) {
+        if (finalval <= 0xFFFF) {
+          low.smartAppend((char) val, c.getLength(k));
+        } else {
+          low.smartAppend((char) val, (char) (0xFFFF - val));
+          high.smartAppend((char) 0, (char) finalval);
+        }
+      } else {
+        high.smartAppend((char) val, c.getLength(k));
+      }
+    }
+    return new MappeableContainer[]{low, high};
+  }
   /**
    * Find the smallest integer larger than pos such that array[pos]&gt;= min. If none can be found,
    * return length. Based on code by O. Kaser.

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BufferUtil.java
@@ -31,6 +31,7 @@ public final class BufferUtil {
    * @return return an array made of two containers
    */
   public static  MappeableContainer[] addOffset(MappeableContainer source, char offsets) {
+    // could be a whole lot faster, this is a simple implementation
     if(source instanceof MappeableArrayContainer) {
       return addOffset((MappeableArrayContainer) source, offsets);
     } else if (source instanceof MappeableBitmapContainer) {
@@ -62,15 +63,19 @@ public final class BufferUtil {
         ? new MappeableArrayContainer()
         : new MappeableArrayContainer(source.cardinality - splitIndex);
 
+    int lowCardinality = 0;
     for (int k = 0; k < splitIndex; k++) {
       int val = source.content.get(k) + offsets;
-      low.content.put(low.cardinality++, (char) val);
+      low.content.put(lowCardinality++, (char) val);
     }
+    low.cardinality = lowCardinality;
 
+    int highCardinality = 0;
     for (int k = splitIndex; k < source.cardinality; k++) {
       int val = source.content.get(k) + offsets;
-      high.content.put(high.cardinality++, (char) val);
+      high.content.put(highCardinality++, (char) val);
     }
+    high.cardinality = highCardinality;
 
     return new MappeableContainer[]{low, high};
   }

--- a/jmh/src/jmh/java/org/roaringbitmap/AddOffsetBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/AddOffsetBenchmark.java
@@ -1,0 +1,239 @@
+package org.roaringbitmap;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, timeUnit = TimeUnit.MILLISECONDS, time = 5000)
+@Measurement(iterations = 10, timeUnit = TimeUnit.MILLISECONDS, time = 5000)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgsPrepend =
+    {
+        "-XX:-TieredCompilation",
+        "-XX:+UseSerialGC", // "-XX:+UseParallelGC",
+        "-mx2G",
+        "-ms2G",
+        "-XX:+AlwaysPreTouch"
+    })
+public class AddOffsetBenchmark {
+  @Param({
+      "ARRAY_ALL_IN_LOW", "ARRAY_HALF_TO_HALF", "ARRAY_ALL_SHIFTED_TO_HIGH",
+      // all variant provided for completeness only, original and current implementation are the same
+      // "RUN_ALL_IN_LOW", "RUN_HALF_TO_HALF", "RUN_ALL_SHIFTED_TO_HIGH",
+      // "BITMAP_ALL_IN_LOW", "BITMAP_HALF_TO_HALF", "BITMAP_ALL_SHIFTED_TO_HIGH",
+      // "BITMAP_HALF_TO_HALF_MULTIPLE_OF_LONG", "BITMAP_ALL_SHIFTED_TO_HIGH_MULTIPLE_OF_LONG",
+  })
+  Scenario scenario;
+
+  @SuppressWarnings("unused")
+  public enum Scenario {
+    RUN_ALL_IN_LOW(ContainerType.RUN, 0),
+    RUN_HALF_TO_HALF(ContainerType.RUN, 35000),
+    RUN_ALL_SHIFTED_TO_HIGH(ContainerType.RUN, 60000),
+
+    ARRAY_ALL_IN_LOW(ContainerType.ARRAY, 0),
+    ARRAY_HALF_TO_HALF(ContainerType.ARRAY, 35000),
+    ARRAY_ALL_SHIFTED_TO_HIGH(ContainerType.ARRAY, 60000),
+
+    BITMAP_ALL_IN_LOW(ContainerType.BITMAP, 0),
+    BITMAP_HALF_TO_HALF(ContainerType.BITMAP, 35000),
+    BITMAP_ALL_SHIFTED_TO_HIGH(ContainerType.BITMAP, 60000),
+
+    BITMAP_HALF_TO_HALF_MULTIPLE_OF_LONG(ContainerType.BITMAP, 32768 + Long.SIZE * 32), // ~ 35000
+    BITMAP_ALL_SHIFTED_TO_HIGH_MULTIPLE_OF_LONG(ContainerType.BITMAP, 65536 - Long.SIZE),
+    ;
+
+    private final ContainerType containerType;
+    private final char offsets;
+
+    Scenario(ContainerType containerType, int offsets) {
+      this.containerType = containerType;
+      this.offsets = (char) offsets;
+    }
+
+    public ContainerType getContainerType() {
+      return containerType;
+    }
+
+    public char getOffsets() {
+      return offsets;
+    }
+
+    public Container createContainer() {
+      return containerType.createContainer();
+    }
+  }
+
+  public enum ContainerType {
+    RUN {
+      @Override
+      public Container createContainer() {
+        RunContainer rc = new RunContainer();
+        for (int i = 0; i < numberOfValues; i++) {
+          rc.add(minValue + i * 2, minValue + i * 2 + 1);
+        }
+        return rc;
+      }
+    },
+    BITMAP {
+      @Override
+      public Container createContainer() {
+        BitmapContainer bc = new BitmapContainer();
+        for (int i = 0; i < numberOfValues; i++) {
+          bc.add((char) (minValue + i * 2));
+        }
+        return bc;
+      }
+    }, ARRAY {
+      @Override
+      public Container createContainer() {
+        ArrayContainer ac = new ArrayContainer();
+        for (int i = 0; i < numberOfValues; i++) {
+          ac.add((char) (minValue + i * 2));
+        }
+        return ac;
+      }
+    };
+    // value = minValue + i * 2 for i < numberOfValues, thus they lies in interval 20000 - 40000
+    private static final int minValue = 20_000;
+    private static final int numberOfValues = 10000;
+
+    public abstract Container createContainer();
+  }
+
+  public Container container;
+  public char offsets;
+
+
+  @Setup(Level.Invocation)
+  public void setUp() {
+    container = scenario.createContainer();
+    offsets = scenario.getOffsets();
+  }
+
+  @Benchmark
+  public Container[] optimized() {
+    return Util.addOffset(container, offsets);
+  }
+
+  @Benchmark
+  public Container[] optimizedFieldIncrement() {
+    if (container instanceof ArrayContainer) {
+      // only for comparison with optimized version
+      return addOffsetIncrementField((ArrayContainer) container, offsets);
+    } else {
+      return new Container[0];
+    }
+  }
+
+  @Benchmark
+  public Container[] original() {
+    return addOffsetOriginal(container, offsets);
+  }
+
+  @SuppressWarnings({"RedundantCast", "PointlessArithmeticExpression", "GrazieInspection"})
+  public static Container[] addOffsetOriginal(Container source, char offsets) {
+    // could be a whole lot faster, this is a simple implementation
+    if (source instanceof ArrayContainer) {
+      ArrayContainer c = (ArrayContainer) source;
+      ArrayContainer low = new ArrayContainer(c.cardinality);
+      ArrayContainer high = new ArrayContainer(c.cardinality);
+      for (int k = 0; k < c.cardinality; k++) {
+        int val = c.content[k];
+        val += (int) (offsets);
+        if (val <= 0xFFFF) {
+          low.content[low.cardinality++] = (char) val;
+        } else {
+          high.content[high.cardinality++] = (char) val;
+        }
+      }
+      return new Container[]{low, high};
+    } else if (source instanceof BitmapContainer) {
+      BitmapContainer c = (BitmapContainer) source;
+      BitmapContainer low = new BitmapContainer();
+      BitmapContainer high = new BitmapContainer();
+      low.cardinality = -1;
+      high.cardinality = -1;
+      final int b = (int) (offsets) >>> 6;
+      final int i = (int) (offsets) % 64;
+      if (i == 0) {
+        System.arraycopy(c.bitmap, 0, low.bitmap, b, 1024 - b);
+        System.arraycopy(c.bitmap, 1024 - b, high.bitmap, 0, b);
+      } else {
+        low.bitmap[b + 0] = c.bitmap[0] << i;
+        for (int k = 1; k < 1024 - b; k++) {
+          low.bitmap[b + k] = (c.bitmap[k] << i) | (c.bitmap[k - 1] >>> (64 - i));
+        }
+        for (int k = 1024 - b; k < 1024; k++) {
+          high.bitmap[k - (1024 - b)] =
+              (c.bitmap[k] << i)
+                  | (c.bitmap[k - 1] >>> (64 - i));
+        }
+        high.bitmap[b] = (c.bitmap[1024 - 1] >>> (64 - i));
+      }
+      return new Container[]{low.repairAfterLazy(), high.repairAfterLazy()};
+    } else if (source instanceof RunContainer) {
+      RunContainer input = (RunContainer) source;
+      RunContainer low = new RunContainer();
+      RunContainer high = new RunContainer();
+      for (int k = 0; k < input.nbrruns; k++) {
+        int val = (input.getValue(k));
+        val += (int) (offsets);
+        int finalval = val + (input.getLength(k));
+        if (val <= 0xFFFF) {
+          if (finalval <= 0xFFFF) {
+            low.smartAppend((char) val, input.getLength(k));
+          } else {
+            low.smartAppend((char) val, (char) (0xFFFF - val));
+            high.smartAppend((char) 0, (char) finalval);
+          }
+        } else {
+          high.smartAppend((char) val, input.getLength(k));
+        }
+      }
+      return new Container[]{low, high};
+    }
+    throw new RuntimeException("unknown container type"); // never happens
+  }
+
+  private static Container[] addOffsetIncrementField(ArrayContainer source, char offsets) {
+    ArrayContainer low;
+    ArrayContainer high;
+    if (source.first() + offsets > 0xFFFF) {
+      low = new ArrayContainer();
+      high = new ArrayContainer(source.cardinality);
+      for (int k = 0; k < source.cardinality; k++) {
+        int val = source.content[k] + offsets;
+        high.content[k] = (char) val;
+      }
+      high.cardinality = source.cardinality;
+    } else if (source.last() + offsets < 0xFFFF) {
+      low = new ArrayContainer(source.cardinality);
+      high = new ArrayContainer();
+      for (int k = 0; k < source.cardinality; k++) {
+        int val = source.content[k] + offsets;
+        low.content[k] = (char) val;
+      }
+      low.cardinality = source.cardinality;
+    } else {
+      int splitIndex = Util.unsignedBinarySearch(source.content, 0, source.cardinality,
+          (char) ~offsets);
+      if (splitIndex < 0) {
+        splitIndex = -splitIndex - 1;
+      }
+      low = new ArrayContainer(splitIndex);
+      high = new ArrayContainer(source.cardinality - splitIndex);
+      for (int k = 0; k < splitIndex; k++) {
+        int val = source.content[k] + offsets;
+        low.content[low.cardinality++] = (char) val;
+      }
+      for (int k = splitIndex; k < source.cardinality; k++) {
+        int val = source.content[k] + offsets;
+        high.content[high.cardinality++] = (char) val;
+      }
+    }
+    return new Container[]{low, high};
+  }
+}

--- a/jmh/src/jmh/java/org/roaringbitmap/AddOffsetBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/AddOffsetBenchmark.java
@@ -119,10 +119,10 @@ public class AddOffsetBenchmark {
   }
 
   @Benchmark
-  public Container[] optimizedFieldIncrement() {
+  public Container[] localVariableForCardinality() {
     if (container instanceof ArrayContainer) {
       // only for comparison with optimized version
-      return addOffsetIncrementField((ArrayContainer) container, offsets);
+      return addOffsetLocalVariableForCardinality((ArrayContainer) container, offsets);
     } else {
       return new Container[0];
     }
@@ -198,7 +198,7 @@ public class AddOffsetBenchmark {
     throw new RuntimeException("unknown container type"); // never happens
   }
 
-  private static Container[] addOffsetIncrementField(ArrayContainer source, char offsets) {
+  private static Container[] addOffsetLocalVariableForCardinality(ArrayContainer source, char offsets) {
     ArrayContainer low;
     ArrayContainer high;
     if (source.first() + offsets > 0xFFFF) {
@@ -225,14 +225,20 @@ public class AddOffsetBenchmark {
       }
       low = new ArrayContainer(splitIndex);
       high = new ArrayContainer(source.cardinality - splitIndex);
+
+      int lowCardinality = 0;
       for (int k = 0; k < splitIndex; k++) {
         int val = source.content[k] + offsets;
-        low.content[low.cardinality++] = (char) val;
+        low.content[lowCardinality++] = (char) val;
       }
+      low.cardinality = lowCardinality;
+
+      int highCardinality = 0;
       for (int k = splitIndex; k < source.cardinality; k++) {
         int val = source.content[k] + offsets;
-        high.content[high.cardinality++] = (char) val;
+        high.content[highCardinality++] = (char) val;
       }
+      high.cardinality = highCardinality;
     }
     return new Container[]{low, high};
   }

--- a/jmh/src/jmh/java/org/roaringbitmap/AddOffsetBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/AddOffsetBenchmark.java
@@ -119,10 +119,10 @@ public class AddOffsetBenchmark {
   }
 
   @Benchmark
-  public Container[] localVariableForCardinality() {
+  public Container[] optimizedFieldIncrement() {
     if (container instanceof ArrayContainer) {
       // only for comparison with optimized version
-      return addOffsetLocalVariableForCardinality((ArrayContainer) container, offsets);
+      return addOffsetIncrementField((ArrayContainer) container, offsets);
     } else {
       return new Container[0];
     }
@@ -198,7 +198,7 @@ public class AddOffsetBenchmark {
     throw new RuntimeException("unknown container type"); // never happens
   }
 
-  private static Container[] addOffsetLocalVariableForCardinality(ArrayContainer source, char offsets) {
+  private static Container[] addOffsetIncrementField(ArrayContainer source, char offsets) {
     ArrayContainer low;
     ArrayContainer high;
     if (source.first() + offsets > 0xFFFF) {
@@ -225,20 +225,14 @@ public class AddOffsetBenchmark {
       }
       low = new ArrayContainer(splitIndex);
       high = new ArrayContainer(source.cardinality - splitIndex);
-
-      int lowCardinality = 0;
       for (int k = 0; k < splitIndex; k++) {
         int val = source.content[k] + offsets;
-        low.content[lowCardinality++] = (char) val;
+        low.content[low.cardinality++] = (char) val;
       }
-      low.cardinality = lowCardinality;
-
-      int highCardinality = 0;
       for (int k = splitIndex; k < source.cardinality; k++) {
         int val = source.content[k] + offsets;
-        high.content[highCardinality++] = (char) val;
+        high.content[high.cardinality++] = (char) val;
       }
-      high.cardinality = highCardinality;
     }
     return new Container[]{low, high};
   }


### PR DESCRIPTION
### SUMMARY
`AddOffset()` optimized for array containers via avoidance of condition in a loop for filling values to containers. The index of split container is determined beforehand and thus the loop for filling values to first and next container is done separately. See benchmark results (less is better):
| Benchmark               | (scenario)                | Mode | Cnt | Score     | Error      | Units |
|-------------------------|---------------------------|------|-----|-----------|------------|-------|
| optimized               | ARRAY_ALL_IN_LOW          | avgt | 5   | **8819.802**  | ± 1726.774 | ns/op |
| optimized               | ARRAY_HALF_TO_HALF        | avgt | 5   | **8632.215**  | ± 1556.700 | ns/op |
| optimized               | ARRAY_ALL_SHIFTED_TO_HIGH | avgt | 5   | **9889.661**  | ± 3594.900 | ns/op |
| optimizedFieldIncrement | ARRAY_ALL_IN_LOW          | avgt | 5   | 8198.729  | ± 1284.328 | ns/op |
| optimizedFieldIncrement | ARRAY_HALF_TO_HALF        | avgt | 5   | 7708.754  | ± 787.017  | ns/op |
| optimizedFieldIncrement | ARRAY_ALL_SHIFTED_TO_HIGH | avgt | 5   | 7146.009  | ± 849.682  | ns/op |
| original                | ARRAY_ALL_IN_LOW          | avgt | 5   | **11633.606** | ± 1460.088 | ns/op |
| original                | ARRAY_HALF_TO_HALF        | avgt | 5   | **11848.305** | ± 845.286  | ns/op |
| original                | ARRAY_ALL_SHIFTED_TO_HIGH | avgt | 5   | **12493.045** | ± 5523.579 | ns/op |

According to benchmark it is more performant to use class field for counting cardinality, but when I switch (code within benchmark and within production) this version with the second using local variable four counting cardinality, optimized version goes much worse performance, this can be verified by running `AddOffsetBenchmark` after checkout [previous commit](https://github.com/RoaringBitmap/RoaringBitmap/commit/a5d1224c86bb029bf6cf8a59366476c3ef5d1aec).

Note that method `AddOffset()` was also split into three methods - each for particular type of container to avoid spaghetti code. If this related change is not welcomed, I can rollback it.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
