### PR TITLE
Avoid integer overflow within tests

### DIFF
--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -1994,7 +1994,7 @@ public class TestRoaringBitmap {
             rb.add(i);
         }
 
-        for (int i = 1 << 31 + 3 * 65536; i < (1 << 31) + 4 * 65536; i += 5) {
+        for (int i = (1 << 31) + 3 * 65536; i < (1 << 31) + 4 * 65536; i += 5) {
             hs.add(i);
             rb2.add(i);
         }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
@@ -1993,14 +1993,14 @@ public class TestRoaringBitmap {
   @Test
   public void flipTestBigInt() {
     final MutableRoaringBitmap rb = new MutableRoaringBitmap();
-    rb.add( Integer.MAX_VALUE + 100000);
-    rb.add( Integer.MAX_VALUE + 100002);
+    rb.add((int) (Integer.MAX_VALUE + 100000L));
+    rb.add((int) (Integer.MAX_VALUE + 100002L));
     final MutableRoaringBitmap rb2 = MutableRoaringBitmap.flip(rb, Integer.MAX_VALUE+100001L , 
                                                      Integer.MAX_VALUE+200000L);
     assertEquals(99999, rb2.getCardinality());
-    assertTrue(rb2.contains(Integer.MAX_VALUE+100000));
-    assertFalse(rb2.contains(Integer.MAX_VALUE+100002));
-    assertTrue(rb2.contains(Integer.MAX_VALUE+199999));
+    assertTrue(rb2.contains((int) (Integer.MAX_VALUE + 100000L)));
+    assertFalse(rb2.contains((int) (Integer.MAX_VALUE + 100002L)));
+    assertTrue(rb2.contains((int) (Integer.MAX_VALUE + 199999L)));
   }
 
 
@@ -3019,10 +3019,10 @@ public class TestRoaringBitmap {
   public void testIteratorMappedBigInts() {
     MutableRoaringBitmap orb = new MutableRoaringBitmap();
     for (int k = 0; k < 4000; ++k) {
-        orb.add((1<<32)+k);
+      orb.add((1 << 31) + k);
     }
     for (int k = 0; k < 1000; ++k) {
-      orb.add((1<<32)+k * 100);
+      orb.add((1 << 31) + k * 100);
     }
     MutableRoaringBitmap ocopy1 = new MutableRoaringBitmap();
     for (int x : orb) {

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
@@ -1516,11 +1516,11 @@ public class TestRoaring64NavigableMap {
 
   @Test
   public void testLazyOr() {
-    Roaring64NavigableMap map1 = Roaring64NavigableMap.bitmapOf(1 << 16, 1 << 18, 1 << 19, 1 << 33);
+    Roaring64NavigableMap map1 = Roaring64NavigableMap.bitmapOf(1 << 16, 1 << 18, 1 << 19, 1L << 33);
     map1.naivelazyor(Roaring64NavigableMap.bitmapOf(4, 7, 8, 9));
     map1.naivelazyor(Roaring64NavigableMap.bitmapOf(1, 2, 3, 4, 5, 1 << 16, 1 << 17, 1 << 20));
     map1.repairAfterLazy();
-    Roaring64NavigableMap map2 = Roaring64NavigableMap.bitmapOf(1, 2, 3, 4, 5, 7, 8, 9, 1 << 16, 1 << 17, 1 << 18, 1 << 19, 1 << 20 , 1 << 33);
+    Roaring64NavigableMap map2 = Roaring64NavigableMap.bitmapOf(1, 2, 3, 4, 5, 7, 8, 9, 1 << 16, 1 << 17, 1 << 18, 1 << 19, 1 << 20 , 1L << 33);
     assertEquals(map2, map1);
   }
 


### PR DESCRIPTION
### SUMMARY
Changed the expression causing integer overflow in some tests, I suppose unintentional in most of cases. This will be not reported by static code analyzers at least.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
