### PR TITLE
Bitwise operator instead of logical

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RangeBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RangeBitmap.java
@@ -929,7 +929,7 @@ public final class RangeBitmap {
               bits = low.bits;
             } else {
               bits = low.bits;
-              for (int i = 0; i < bits.length & i < high.bits.length; i++) {
+              for (int i = 0; i < Math.min(bits.length, high.bits.length); i++) {
                 bits[i] &= high.bits[i];
               }
             }
@@ -963,7 +963,7 @@ public final class RangeBitmap {
             } else if (high.full) {
               count += cardinalityInBitmapRange(low.bits, 0, remainder);
             } else {
-              for (int i = 0; i < low.bits.length & i < high.bits.length; i++) {
+              for (int i = 0; i < Math.min(low.bits.length, high.bits.length); i++) {
                 high.bits[i] &= low.bits[i];
               }
               count += cardinalityInBitmapRange(high.bits, 0, remainder);
@@ -1001,7 +1001,7 @@ public final class RangeBitmap {
               } else if (high.full) {
                 count += new BitmapContainer(low.bits, -1).andCardinality(container);
               } else {
-                for (int i = 0; i < low.bits.length & i < high.bits.length; i++) {
+                for (int i = 0; i < Math.min(low.bits.length, high.bits.length); i++) {
                   high.bits[i] &= low.bits[i];
                 }
                 count += new BitmapContainer(high.bits, -1).andCardinality(container);
@@ -1337,7 +1337,7 @@ public final class RangeBitmap {
     }
 
     public void and(MappeableContainer container) {
-      if (!empty & !container.isFull()) {
+      if (!empty && !container.isFull()) {
         container.andInto(bits);
         full = false;
       }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringArray.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringArray.java
@@ -275,7 +275,7 @@ public final class ImmutableRoaringArray implements PointableRoaringArray {
 
       @Override
       public boolean hasContainer() {
-        return 0 <= k & k < ImmutableRoaringArray.this.size;
+        return 0 <= k && k < ImmutableRoaringArray.this.size;
       }
 
       @Override

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
@@ -511,7 +511,7 @@ public final class MutableRoaringArray implements Cloneable, Externalizable, Poi
 
       @Override
       public boolean hasContainer() {
-        return 0 <= k & k < MutableRoaringArray.this.size;
+        return 0 <= k && k < MutableRoaringArray.this.size;
       }
 
       @Override


### PR DESCRIPTION
### SUMMARY
Logical operators replaced by bitwise operators, where it should be. No visible performance improvement is reached, so static code analyzer will not complain about that at least.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
