### PR TITLE
Avoid array reallocation

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -941,13 +941,11 @@ public final class BitmapContainer extends Container implements Cloneable {
       }
       return ac;
     }
-    BitmapContainer bc = new BitmapContainer(maxcardinality, this.bitmap);
+    long[] newBitmap = new long[MAX_CAPACITY / 64];
+    BitmapContainer bc = new BitmapContainer(newBitmap, maxcardinality);
     int s = (select(maxcardinality));
     int usedwords = (s + 63) / 64;
-    int todelete = this.bitmap.length - usedwords;
-    for (int k = 0; k < todelete; ++k) {
-      bc.bitmap[bc.bitmap.length - 1 - k] = 0;
-    }
+    System.arraycopy(this.bitmap, 0, newBitmap, 0, usedwords);
     int lastword = s % 64;
     if (lastword != 0) {
       bc.bitmap[s / 64] &= (0xFFFFFFFFFFFFFFFFL >>> (64 - lastword));

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -1249,13 +1249,18 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
       }
       return ac;
     }
-    MappeableBitmapContainer bc = new MappeableBitmapContainer(maxcardinality, this.bitmap);
+    LongBuffer newBitmap = LongBuffer.allocate(MAX_CAPACITY / 64);
+    MappeableBitmapContainer bc = new MappeableBitmapContainer(newBitmap, maxcardinality);
     int s = (select(maxcardinality));
     int usedwords = (s + 63) >>> 6;
-    int len = this.bitmap.limit();
-    int todelete = len - usedwords;
-    for (int k = 0; k < todelete; ++k) {
-      bc.bitmap.put(len - 1 - k, 0);
+    if (this.isArrayBacked()) {
+      long[] source = this.bitmap.array();
+      long[] dest = newBitmap.array();
+      System.arraycopy(source, 0, dest, 0, usedwords);
+    } else {
+      for (int k = 0; k < usedwords; ++k) {
+        bc.bitmap.put(k, this.bitmap.get(k));
+      }
     }
     int lastword = s % 64;
     if (lastword != 0) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
@@ -394,7 +394,7 @@ public final class MutableRoaringArray implements Cloneable, Externalizable, Poi
       if (isBitmap[k]) {
         long[] array = new long[MappeableBitmapContainer.MAX_CAPACITY / 64];
         buffer.asLongBuffer().get(array);
-        container = new MappeableBitmapContainer(cardinalities[k], LongBuffer.wrap(array));
+        container = new MappeableBitmapContainer(LongBuffer.wrap(array), cardinalities[k]);
         buffer.position(buffer.position() + 1024 * 8);
       } else if (bitmapOfRunContainers != null
               && ((bitmapOfRunContainers[k / 8] & (1 << (k & 7))) != 0)) {

--- a/jmh/src/jmh/java/org/roaringbitmap/deserialization/BitmapContainersDeserializationBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/deserialization/BitmapContainersDeserializationBenchmark.java
@@ -1,0 +1,54 @@
+package org.roaringbitmap.deserialization;
+
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, timeUnit = TimeUnit.MILLISECONDS, time = 5000)
+@Measurement(iterations = 10, timeUnit = TimeUnit.MILLISECONDS, time = 5000)
+@BenchmarkMode(Mode.Throughput)
+public class BitmapContainersDeserializationBenchmark {
+
+  private ByteBuffer buffer;
+
+  @Setup
+  public void prepare() throws IOException {
+    MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+    Random r = new Random();
+    for (int containerIndex = 0; containerIndex < 1000; containerIndex++) {
+      for (int j = 0; j < 10_000; j++) {
+        int value = r.nextInt(65536);
+        bitmap.add(value + containerIndex * 65536);
+      }
+    }
+    byte[] x = serialise(bitmap);
+    buffer = ByteBuffer.allocate(x.length);
+    bitmap.serialize(buffer);
+  }
+
+  @Benchmark
+  public void deserialize(Blackhole blackhole) throws IOException {
+    buffer.rewind();
+    MutableRoaringBitmap l = new MutableRoaringBitmap();
+    l.deserialize(buffer);
+    blackhole.consume(buffer);
+  }
+
+  private static byte[] serialise(MutableRoaringBitmap input) throws IOException {
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream(input.serializedSizeInBytes());
+         DataOutputStream dos = new DataOutputStream(bos)) {
+      input.serialize(dos);
+      return bos.toByteArray();
+    }
+  }
+}


### PR DESCRIPTION
### SUMMARY
Avoid to use constructors of `(Mappeable)BitmapContainer(int, LongBuffer)` , whose duplicates buffer of given bitmap first, then allocate new buffer, and copy duplicated buffer to newly created one - except the cases, where are called from method `clone()` of course. After these changes it is possible to copy part of buffer only, not copy whole buffer and then unset the rest.

| Benchmark – higher values are better | Mode  | Cnt | Score | Error   | Units  |
|--------------------------------------|-------|-----|-------|---------|--------|
| newly optimized                      | thrpt | 5   | 0.531 | ± 0.028 | ops/ms |
| original                             | thrpt | 5   | 0.301 | ± 0.048 | ops/ms |


Benchmark measurement for original implementation can be obtained after checkout [commit without the changes with benchmark added only](https://github.com/RoaringBitmap/RoaringBitmap/commit/81bf5267e682cbdbab55754c48cb31d7b3662aa4).

This PR is especially useful, because  part of changes improves performance of deserialization, which is widely used feature of RoaringBitmap, I suposse.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
