### PR TITLE
Avoid useless computation in oNeilCompare()

### DIFF
--- a/bsi/src/main/java/org/roaringbitmap/bsi/buffer/BitSliceIndexBase.java
+++ b/bsi/src/main/java/org/roaringbitmap/bsi/buffer/BitSliceIndexBase.java
@@ -6,6 +6,7 @@ import org.roaringbitmap.IntConsumer;
 import org.roaringbitmap.IntIterator;
 import org.roaringbitmap.RoaringBitmap;
 import org.roaringbitmap.bsi.BitmapSliceIndex;
+import org.roaringbitmap.bsi.BitmapSliceIndex.Operation;
 import org.roaringbitmap.bsi.Pair;
 import org.roaringbitmap.buffer.BufferFastAggregation;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
@@ -199,15 +200,21 @@ public class BitSliceIndexBase {
     for (int i = this.bitCount() - 1; i >= 0; i--) {
       int bit = (predicate >> i) & 1;
       if (bit == 1) {
-        LT = ImmutableRoaringBitmap.or(LT, ImmutableRoaringBitmap.andNot(EQ, this.bA[i]));
+        if (operation == Operation.LT || operation == Operation.LE) {
+          LT = ImmutableRoaringBitmap.or(LT, ImmutableRoaringBitmap.andNot(EQ, this.bA[i]));
+        }
         EQ = ImmutableRoaringBitmap.and(EQ, this.bA[i]);
       } else {
-        GT = ImmutableRoaringBitmap.or(GT, ImmutableRoaringBitmap.and(EQ, this.bA[i]));
+        if (operation == Operation.GT || operation == Operation.GE) {
+          GT = ImmutableRoaringBitmap.or(GT, ImmutableRoaringBitmap.and(EQ, this.bA[i]));
+        }
         EQ = ImmutableRoaringBitmap.andNot(EQ, this.bA[i]);
       }
 
     }
-    EQ = ImmutableRoaringBitmap.and(fixedFoundSet, EQ);
+    if (operation != Operation.LT && operation != Operation.GT) {
+      EQ = ImmutableRoaringBitmap.and(fixedFoundSet, EQ);
+    }
     switch (operation) {
       case EQ:
         return EQ;

--- a/bsi/src/main/java/org/roaringbitmap/bsi/buffer/BitSliceIndexBase.java
+++ b/bsi/src/main/java/org/roaringbitmap/bsi/buffer/BitSliceIndexBase.java
@@ -192,8 +192,10 @@ public class BitSliceIndexBase {
                         ImmutableRoaringBitmap foundSet) {
     ImmutableRoaringBitmap fixedFoundSet = foundSet == null ? this.ebM : foundSet;
 
-    MutableRoaringBitmap GT = new MutableRoaringBitmap();
-    MutableRoaringBitmap LT = new MutableRoaringBitmap();
+    MutableRoaringBitmap GT = operation == Operation.GT || operation == Operation.GE
+        ? new MutableRoaringBitmap() : null;
+    MutableRoaringBitmap LT = operation == Operation.LT || operation == Operation.LE
+        ? new MutableRoaringBitmap() : null;
     ImmutableRoaringBitmap EQ = this.ebM;
 
 


### PR DESCRIPTION
### SUMMARY
Avoid useless computation in `oNeilCompare()` according to their necessity for processed operation.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
