### PR TITLE
Select from both sides

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -1257,15 +1257,15 @@ public final class BitmapContainer extends Container implements Cloneable {
   public char select(int j) {
     if (//cardinality != -1 && // omitted as (-1>>>1) > j as j < (1<<16)
         cardinality >>> 1 < j && j < cardinality) {
-      int rightover = cardinality - j;
+      int leftover = cardinality - j;
       for (int k = bitmap.length - 1; k >= 0; --k) {
         long w = bitmap[k];
         if (w != 0) {
           int bits = Long.bitCount(w);
-          if (bits >= rightover) {
-            return (char) (k * 64 + Util.select(w, bits - rightover));
+          if (bits >= leftover) {
+            return (char) (k * 64 + Util.select(w, bits - leftover));
           }
-          rightover -= bits;
+          leftover -= bits;
         }
       }
     } else {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -1284,6 +1284,22 @@ public final class BitmapContainer extends Container implements Cloneable {
     throw new IllegalArgumentException("Insufficient cardinality.");
   }
 
+  /** TODO For comparison only, should be removed before merge.
+   *
+   * @param j ...
+   * @return ...
+   */
+  public char selectOneSide(int j) {
+    int leftover = j;
+    for (int k = 0; k < bitmap.length; ++k) {
+      int w = Long.bitCount(bitmap[k]);
+      if (w > leftover) {
+        return (char) (k * 64 + Util.select(bitmap[k], leftover));
+      }
+      leftover -= w;
+    }
+    throw new IllegalArgumentException("Insufficient cardinality.");
+  }
   @Override
   public void serialize(DataOutput out) throws IOException {
     // little endian

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -1259,20 +1259,26 @@ public final class BitmapContainer extends Container implements Cloneable {
         cardinality >>> 1 < j && j < cardinality) {
       int rightover = cardinality - j;
       for (int k = bitmap.length - 1; k >= 0; --k) {
-        int w = Long.bitCount(bitmap[k]);
-        if (w >= rightover) {
-          return (char) (k * 64 + Util.select(bitmap[k], w - rightover));
+        long w = bitmap[k];
+        if (w != 0) {
+          int bits = Long.bitCount(w);
+          if (bits >= rightover) {
+            return (char) (k * 64 + Util.select(w, bits - rightover));
+          }
+          rightover -= bits;
         }
-        rightover -= w;
       }
     } else {
       int leftover = j;
       for (int k = 0; k < bitmap.length; ++k) {
-        int w = Long.bitCount(bitmap[k]);
-        if (w > leftover) {
-          return (char) (k * 64 + Util.select(bitmap[k], leftover));
+        long w = bitmap[k];
+        if (w != 0) {
+          int bits = Long.bitCount(bitmap[k]);
+          if (bits > leftover) {
+            return (char) (k * 64 + Util.select(bitmap[k], leftover));
+          }
+          leftover -= bits;
         }
-        leftover -= w;
       }
     }
     throw new IllegalArgumentException("Insufficient cardinality.");

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -1255,13 +1255,25 @@ public final class BitmapContainer extends Container implements Cloneable {
 
   @Override
   public char select(int j) {
-    int leftover = j;
-    for (int k = 0; k < bitmap.length; ++k) {
-      int w = Long.bitCount(bitmap[k]);
-      if (w > leftover) {
-        return (char) (k * 64 + Util.select(bitmap[k], leftover));
+    if (//cardinality != -1 && // omitted as (-1>>>1) > j as j < (1<<16)
+        cardinality >>> 1 < j && j < cardinality) {
+      int rightover = cardinality - j;
+      for (int k = bitmap.length - 1; k >= 0; --k) {
+        int w = Long.bitCount(bitmap[k]);
+        if (w >= rightover) {
+          return (char) (k * 64 + Util.select(bitmap[k], w - rightover));
+        }
+        rightover -= w;
       }
-      leftover -= w;
+    } else {
+      int leftover = j;
+      for (int k = 0; k < bitmap.length; ++k) {
+        int w = Long.bitCount(bitmap[k]);
+        if (w > leftover) {
+          return (char) (k * 64 + Util.select(bitmap[k], leftover));
+        }
+        leftover -= w;
+      }
     }
     throw new IllegalArgumentException("Insufficient cardinality.");
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -1697,23 +1697,23 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
 
   @Override
   public char select(int j) {
-    int leftover = j;
     if (BufferUtil.isBackedBySimpleArray(this.bitmap)) {
       long[] b = this.bitmap.array();
       if (//cardinality != -1 && // omitted as (-1>>>1) > j as j < (1<<16)
           cardinality >>> 1 < j && j < cardinality) {
-        int rightover = cardinality - j;
+        int leftover = cardinality - j;
         for (int k = b.length - 1; k >= 0; --k) {
           long w = b[k];
           if (w != 0) {
             int bits = Long.bitCount(w);
-            if (bits >= rightover) {
-              return (char) (k * 64 + Util.select(w, bits - rightover));
+            if (bits >= leftover) {
+              return (char) (k * 64 + Util.select(w, bits - leftover));
             }
-            rightover -= bits;
+            leftover -= bits;
           }
         }
       } else {
+        int leftover = j;
         for (int k = 0; k < b.length; ++k) {
           long w = b[k];
           if (w != 0) {
@@ -1729,15 +1729,16 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
       int len = this.bitmap.limit();
       if (//cardinality != -1 && // (-1>>>1) > j as j < (1<<16)
           cardinality >>> 1 < j && j < cardinality) {
-        int rightover = cardinality - j;
+        int leftover = cardinality - j;
         for (int k = len - 1; k >= 0; --k) {
           int w = Long.bitCount(bitmap.get(k));
-          if (w >= rightover) {
-            return (char) (k * 64 + Util.select(bitmap.get(k), w - rightover));
+          if (w >= leftover) {
+            return (char) (k * 64 + Util.select(bitmap.get(k), w - leftover));
           }
-          rightover -= w;
+          leftover -= w;
         }
       } else {
+        int leftover = j;
         for (int k = 0; k < len; ++k) {
           long X = bitmap.get(k);
           int w = Long.bitCount(X);

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -1749,6 +1749,36 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
     throw new IllegalArgumentException("Insufficient cardinality.");
   }
 
+  /** TODO For comparison only, should be removed before merge.
+   *
+   * @param j ...
+   * @return ...
+   */
+  public char selectOneSide(int j) {
+    int leftover = j;
+    if (BufferUtil.isBackedBySimpleArray(this.bitmap)) {
+      long[] b = this.bitmap.array();
+
+      for (int k = 0; k < b.length; ++k) {
+        int w = Long.bitCount(b[k]);
+        if (w > leftover) {
+          return (char) (k * 64 + Util.select(b[k], leftover));
+        }
+        leftover -= w;
+      }
+    } else {
+      int len = this.bitmap.limit();
+      for (int k = 0; k < len; ++k) {
+        long X = bitmap.get(k);
+        int w = Long.bitCount(X);
+        if (w > leftover) {
+          return (char) (k * 64 + Util.select(X, leftover));
+        }
+        leftover -= w;
+      }
+    }
+    throw new IllegalArgumentException("Insufficient cardinality.");
+  }
   @Override
   public int serializedSizeInBytes() {
     return serializedSizeInBytes(0);

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -1713,15 +1713,16 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
             rightover -= bits;
           }
         }
-      }
-      for (int k = 0; k < b.length; ++k) {
-        long w = b[k];
-        if (w != 0) {
-          int bits = Long.bitCount(w);
-          if (bits > leftover) {
-            return (char) (k * 64 + Util.select(w, leftover));
+      } else {
+        for (int k = 0; k < b.length; ++k) {
+          long w = b[k];
+          if (w != 0) {
+            int bits = Long.bitCount(w);
+            if (bits > leftover) {
+              return (char) (k * 64 + Util.select(w, leftover));
+            }
+            leftover -= bits;
           }
-          leftover -= bits;
         }
       }
     } else {
@@ -1736,14 +1737,15 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
           }
           rightover -= w;
         }
-      }
-      for (int k = 0; k < len; ++k) {
-        long X = bitmap.get(k);
-        int w = Long.bitCount(X);
-        if (w > leftover) {
-          return (char) (k * 64 + Util.select(X, leftover));
+      } else {
+        for (int k = 0; k < len; ++k) {
+          long X = bitmap.get(k);
+          int w = Long.bitCount(X);
+          if (w > leftover) {
+            return (char) (k * 64 + Util.select(X, leftover));
+          }
+          leftover -= w;
         }
-        leftover -= w;
       }
     }
     throw new IllegalArgumentException("Insufficient cardinality.");

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -1704,19 +1704,25 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
           cardinality >>> 1 < j && j < cardinality) {
         int rightover = cardinality - j;
         for (int k = b.length - 1; k >= 0; --k) {
-          int w = Long.bitCount(b[k]);
-          if (w >= rightover) {
-            return (char) (k * 64 + Util.select(b[k], w - rightover));
+          long w = b[k];
+          if (w != 0) {
+            int bits = Long.bitCount(w);
+            if (bits >= rightover) {
+              return (char) (k * 64 + Util.select(w, bits - rightover));
+            }
+            rightover -= bits;
           }
-          rightover -= w;
         }
       }
       for (int k = 0; k < b.length; ++k) {
-        int w = Long.bitCount(b[k]);
-        if (w > leftover) {
-          return (char) (k * 64 + Util.select(b[k], leftover));
+        long w = b[k];
+        if (w != 0) {
+          int bits = Long.bitCount(w);
+          if (bits > leftover) {
+            return (char) (k * 64 + Util.select(w, leftover));
+          }
+          leftover -= bits;
         }
-        leftover -= w;
       }
     } else {
       int len = this.bitmap.limit();

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -1700,7 +1700,17 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
     int leftover = j;
     if (BufferUtil.isBackedBySimpleArray(this.bitmap)) {
       long[] b = this.bitmap.array();
-
+      if (//cardinality != -1 && // omitted as (-1>>>1) > j as j < (1<<16)
+          cardinality >>> 1 < j && j < cardinality) {
+        int rightover = cardinality - j;
+        for (int k = b.length - 1; k >= 0; --k) {
+          int w = Long.bitCount(b[k]);
+          if (w >= rightover) {
+            return (char) (k * 64 + Util.select(b[k], w - rightover));
+          }
+          rightover -= w;
+        }
+      }
       for (int k = 0; k < b.length; ++k) {
         int w = Long.bitCount(b[k]);
         if (w > leftover) {
@@ -1710,6 +1720,17 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
       }
     } else {
       int len = this.bitmap.limit();
+      if (//cardinality != -1 && // (-1>>>1) > j as j < (1<<16)
+          cardinality >>> 1 < j && j < cardinality) {
+        int rightover = cardinality - j;
+        for (int k = len - 1; k >= 0; --k) {
+          int w = Long.bitCount(bitmap.get(k));
+          if (w >= rightover) {
+            return (char) (k * 64 + Util.select(bitmap.get(k), w - rightover));
+          }
+          rightover -= w;
+        }
+      }
       for (int k = 0; k < len; ++k) {
         long X = bitmap.get(k);
         int w = Long.bitCount(X);

--- a/jmh/src/jmh/java/org/roaringbitmap/bitmapcontainer/SelectBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/bitmapcontainer/SelectBenchmark.java
@@ -1,0 +1,78 @@
+package org.roaringbitmap.bitmapcontainer;
+
+import org.openjdk.jmh.annotations.*;
+import org.roaringbitmap.BitmapContainer;
+import org.roaringbitmap.buffer.MappeableBitmapContainer;
+
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 10, timeUnit = TimeUnit.MILLISECONDS, time = 1000)
+@Measurement(iterations = 20, timeUnit = TimeUnit.MILLISECONDS, time = 1000)
+public class SelectBenchmark {
+
+  private BitmapContainer bc1;
+  private MappeableBitmapContainer mbc1;
+
+  @Param({"100", "5000", "10000"})
+  public int valuesCount;
+
+  public char[] indexes;
+
+  @Setup
+  public void setup() throws ExecutionException {
+    bc1 = new BitmapContainer();
+    mbc1 = new MappeableBitmapContainer();
+    indexes = new char[valuesCount];
+    Random r = new Random(123);
+    for (int i = 0; i < valuesCount; i++) {
+      char value = (char) r.nextInt(Character.MAX_VALUE);
+      bc1.add(value);
+      mbc1.add(value);
+    }
+    int actualCardinality = bc1.getCardinality(); // some values can be inserted multiple times
+    for (int i = 0; i < actualCardinality; i++) {
+      indexes[i] = (char) r.nextInt(actualCardinality);
+    }
+  }
+
+  @Benchmark
+  public long bitmapContainer_selectOneSide() {
+    long accumulator = 0;
+    for (int i = 0; i < bc1.getCardinality(); i++) {
+      accumulator += bc1.selectOneSide(indexes[i]);
+    }
+    return accumulator;
+  }
+
+  @Benchmark
+  public long bitmapContainer_selectBothSides() {
+    long accumulator = 0;
+    for (int i = 0; i < bc1.getCardinality(); i++) {
+      accumulator += bc1.select(indexes[i]);
+    }
+    return accumulator;
+  }
+
+  @Benchmark
+  public long mappeableBitmapContainer_selectOneSide() {
+    long accumulator = 0;
+    for (int i = 0; i < mbc1.getCardinality(); i++) {
+      accumulator += mbc1.selectOneSide(indexes[i]);
+    }
+    return accumulator;
+  }
+
+  @Benchmark
+  public long mappeableBitmapContainer_selectBothSides() {
+    long accumulator = 0;
+    for (int i = 0; i < mbc1.getCardinality(); i++) {
+      accumulator += mbc1.select(indexes[i]);
+    }
+    return accumulator;
+  }
+}


### PR DESCRIPTION
### SUMMARY
Performance optimization for action` (Mappeable)BitmapContainer.select(int)` - if bitmap container's cardinality is known beforehand, **decision is made if search loop should start from the beginning or from the end of the bitmap.** This should lead to double the performance in average when values within bitmap are uniformly distributed, this fact is verified by presented benchmark.

Above that, **counting bit are avoided for words equal to zero** even this occurs not so often as too sparse bitmaps are probably converted to other kind of container. Shortly it is useful, where huge part of bitmap is empty, but the cardinality is still above the conversion threshold.

| Benchmark                                | (valuesCount) | Mode  | Cnt | Score  | Error    | Units  |
|------------------------------------------|---------------|-------|-----|--------|----------|--------|
| bitmapContainer_selectBothSides          | 100           | thrpt | 5   | 65.992 | ± 10.894 | ops/ms |
| bitmapContainer_selectBothSides          | 5000          | thrpt | 5   | 0.525  | ± 0.053  | ops/ms |
| bitmapContainer_selectBothSides          | 10000         | thrpt | 5   | 0.301  | ± 0.037  | ops/ms |
| bitmapContainer_selectOneSide            | 100           | thrpt | 5   | 15.763 | ± 1.870  | ops/ms |
| bitmapContainer_selectOneSide            | 5000          | thrpt | 5   | 0.291  | ± 0.017  | ops/ms |
| bitmapContainer_selectOneSide            | 10000         | thrpt | 5   | 0.150  | ± 0.012  | ops/ms |
| mappeableBitmapContainer_selectBothSides | 100           | thrpt | 5   | 63.751 | ± 5.458  | ops/ms |
| mappeableBitmapContainer_selectBothSides | 5000          | thrpt | 5   | 0.522  | ± 0.016  | ops/ms |
| mappeableBitmapContainer_selectBothSides | 10000         | thrpt | 5   | 0.290  | ± 0.040  | ops/ms |
| mappeableBitmapContainer_selectOneSide   | 100           | thrpt | 5   | 24.720 | ± 30.168 | ops/ms |
| mappeableBitmapContainer_selectOneSide   | 5000          | thrpt | 5   | 0.297  | ± 0.011  | ops/ms |
| mappeableBitmapContainer_selectOneSide   | 10000         | thrpt | 5   | 0.155  | ± 0.004  | ops/ms |

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
