### PR TITLE
Method fillArray() deduplicated

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -852,7 +852,7 @@ public final class ArrayContainer extends Container implements Cloneable {
 
   void loadData(final BitmapContainer bitmapContainer) {
     this.cardinality = bitmapContainer.cardinality;
-    bitmapContainer.fillArray(content);
+    Util.fillArray(bitmapContainer.bitmap, content);
   }
 
   // for use in inot range known to be nonempty

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -425,24 +425,6 @@ public final class BitmapContainer extends Container implements Cloneable {
   }
 
 
-  /**
-   * Fill the array with set bits
-   *
-   * @param array container (should be sufficiently large)
-   */
-  void fillArray(final char[] array) {
-    int pos = 0;
-    int base = 0;
-    for (int k = 0; k < bitmap.length; ++k) {
-      long bitset = bitmap[k];
-      while (bitset != 0) {
-        array[pos++] = (char) (base + numberOfTrailingZeros(bitset));
-        bitset &= (bitset - 1);
-      }
-      base += 64;
-    }
-  }
-
   @Override
   public void fillLeastSignificant16bits(int[] x, int i, int mask) {
     int pos = i;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/Util.java
@@ -1207,4 +1207,23 @@ public final class Util {
   private Util() {
 
   }
+
+  /**
+   * Fill the array with set bits
+   *
+   * @param bitmap source bitmap
+   * @param array container (should be sufficiently large)
+   */
+  public static void fillArray(long[] bitmap, final char[] array) {
+    int pos = 0;
+    int base = 0;
+    for (int k = 0; k < bitmap.length; ++k) {
+      long bitset = bitmap[k];
+      while (bitset != 0) {
+        array[pos++] = (char) (base + numberOfTrailingZeros(bitset));
+        bitset &= (bitset - 1);
+      }
+      base += 64;
+    }
+  }
 }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -1041,7 +1041,7 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     if (!BufferUtil.isBackedBySimpleArray(this.content)) {
       throw new RuntimeException("Should not happen. Internal bug.");
     }
-    bitmapContainer.fillArray(content.array());
+    Util.fillArray(bitmapContainer.bitmap.array(), content.array());
   }
 
   // for use in inot range known to be nonempty

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -450,39 +450,6 @@ public final class MappeableBitmapContainer extends MappeableContainer implement
     return false;
   }
 
-  /**
-   * Fill the array with set bits
-   * 
-   * @param array container (should be sufficiently large)
-   */
-  void fillArray(final char[] array) {
-    int pos = 0;
-    if (BufferUtil.isBackedBySimpleArray(bitmap)) {
-      long[] b = bitmap.array();
-      int base = 0;
-      for (int k = 0; k < b.length; ++k) {
-        long bitset = b[k];
-        while (bitset != 0) {
-          array[pos++] = (char) (base + numberOfTrailingZeros(bitset));
-          bitset &= (bitset - 1);
-        }
-        base += 64;
-      }
-
-    } else {
-      int len = this.bitmap.limit();
-      int base = 0;
-      for (int k = 0; k < len; ++k) {
-        long bitset = bitmap.get(k);
-        while (bitset != 0) {
-          array[pos++] = (char) (base + numberOfLeadingZeros(bitset));
-          bitset &= (bitset - 1);
-        }
-        base += 64;
-      }
-    }
-  }
-
   @Override
   public void fillLeastSignificant16bits(int[] x, int i, int mask) {
     int pos = i;


### PR DESCRIPTION
### SUMMARY
Methods `fillArray()` deduplicated, part for processing buffered input removed completely as it was dead code. This part also contained the bug - `numberOfLeadingZeros()` was used instead of correct `numberOfTrailingZeros()`.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
