### PR TITLE
Better Batch. WIP, do not take out of draft PR.

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ArrayBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ArrayBatchIterator.java
@@ -13,11 +13,11 @@ public final class ArrayBatchIterator implements ContainerBatchIterator {
   }
 
   @Override
-  public int next(int key, int[] buffer) {
+  public int next(int key, int[] buffer, int offset) {
     int consumed = 0;
     char[] data = array.content;
-    while (consumed < buffer.length && index < array.getCardinality()) {
-      buffer[consumed++] = key + (data[index++]);
+    while ((offset + consumed) < buffer.length && index < array.getCardinality()) {
+      buffer[offset + consumed++] = key + (data[index++]);
     }
     return consumed;
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapBatchIterator.java
@@ -13,9 +13,9 @@ public final class BitmapBatchIterator implements ContainerBatchIterator {
   }
 
   @Override
-  public int next(int key, int[] buffer) {
+  public int next(int key, int[] buffer, int offset) {
     int consumed = 0;
-    while (consumed < buffer.length) {
+    while ((consumed + offset) < buffer.length) {
       while (word == 0) {
         ++wordIndex;
         if (wordIndex == 1024) {
@@ -23,7 +23,7 @@ public final class BitmapBatchIterator implements ContainerBatchIterator {
         }
         word = bitmap.bitmap[wordIndex];
       }
-      buffer[consumed++] = key + (64 * wordIndex) + numberOfTrailingZeros(word);
+      buffer[offset + consumed++] = key + (64 * wordIndex) + numberOfTrailingZeros(word);
       word &= (word - 1);
     }
     return consumed;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ContainerBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ContainerBatchIterator.java
@@ -7,9 +7,10 @@ public interface ContainerBatchIterator extends Cloneable {
    * and returns how much of the buffer was used.
    * @param key the prefix of the values
    * @param buffer the buffer to write values onto
+   * @param offset the offset into the buffer to write values onto
    * @return how many values were written.
    */
-  int next(int key, int[] buffer);
+  int next(int key, int[] buffer, int offset);
 
   /**
    * Whether the underlying container is exhausted or not

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBatchIterator.java
@@ -18,9 +18,9 @@ public final class RoaringBatchIterator implements BatchIterator {
   @Override
   public int nextBatch(int[] buffer) {
     int consumed = 0;
-    while (iterator != null && consumed == 0) {
-      consumed = iterator.next(key, buffer);
-      if (consumed == 0 || !iterator.hasNext()) {
+    while (iterator != null && consumed < buffer.length) {
+      consumed += iterator.next(key, buffer, consumed);
+      if (consumed < buffer.length || !iterator.hasNext()) {
         nextContainer();
       }
     }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunBatchIterator.java
@@ -13,16 +13,16 @@ public final class RunBatchIterator implements ContainerBatchIterator {
   }
 
   @Override
-  public int next(int key, int[] buffer) {
+  public int next(int key, int[] buffer, int offset) {
     int consumed = 0;
     do {
       int runStart = (runs.getValue(run));
       int runLength = (runs.getLength(run));
       int chunkStart = runStart + cursor;
-      int chunkEnd = chunkStart + Math.min(runLength - cursor, buffer.length - consumed - 1);
+      int chunkEnd = chunkStart + Math.min(runLength - cursor, buffer.length - offset - consumed - 1);
       int chunk = chunkEnd - chunkStart + 1;
       for (int i = 0; i < chunk; ++i) {
-        buffer[consumed + i] = key + chunkStart + i;
+        buffer[offset + consumed + i] = key + chunkStart + i;
       }
       consumed += chunk;
       if (runStart + runLength == chunkEnd) {
@@ -31,7 +31,7 @@ public final class RunBatchIterator implements ContainerBatchIterator {
       } else {
         cursor += chunk;
       }
-    } while (consumed < buffer.length && run != runs.numberOfRuns());
+    } while ((offset + consumed) < buffer.length && run != runs.numberOfRuns());
     return consumed;
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ArrayBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ArrayBatchIterator.java
@@ -17,11 +17,11 @@ public final class ArrayBatchIterator implements ContainerBatchIterator {
   }
 
   @Override
-  public int next(int key, int[] buffer) {
+  public int next(int key, int[] buffer, int offset) {
     int consumed = 0;
     CharBuffer data = array.content;
-    while (consumed < buffer.length && index < array.getCardinality()) {
-      buffer[consumed++] = key + (data.get(index++));
+    while ((offset + consumed) < buffer.length && index < array.getCardinality()) {
+      buffer[offset + consumed++] = key + (data.get(index++));
     }
     return consumed;
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BitmapBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BitmapBatchIterator.java
@@ -15,9 +15,9 @@ public final class BitmapBatchIterator implements ContainerBatchIterator {
   }
 
   @Override
-  public int next(int key, int[] buffer) {
+  public int next(int key, int[] buffer, int offset) {
     int consumed = 0;
-    while (consumed < buffer.length) {
+    while ((offset + consumed) < buffer.length) {
       while (word == 0) {
         ++wordIndex;
         if (wordIndex == 1024) {
@@ -25,7 +25,7 @@ public final class BitmapBatchIterator implements ContainerBatchIterator {
         }
         word = bitmap.bitmap.get(wordIndex);
       }
-      buffer[consumed++] = key + (64 * wordIndex) + numberOfTrailingZeros(word);
+      buffer[offset + consumed++] = key + (64 * wordIndex) + numberOfTrailingZeros(word);
       word &= (word - 1);
     }
     return consumed;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/RoaringBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/RoaringBatchIterator.java
@@ -20,9 +20,9 @@ public final class RoaringBatchIterator implements BatchIterator {
   @Override
   public int nextBatch(int[] buffer) {
     int consumed = 0;
-    while (iterator != null && consumed == 0) {
-      consumed = iterator.next(key, buffer);
-      if (consumed == 0 || !iterator.hasNext()) {
+    while (iterator != null && consumed < buffer.length) {
+      consumed += iterator.next(key, buffer, consumed);
+      if (consumed < buffer.length || !iterator.hasNext()) {
         nextContainer();
       }
     }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/RunBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/RunBatchIterator.java
@@ -15,16 +15,16 @@ public final class RunBatchIterator implements ContainerBatchIterator {
   }
 
   @Override
-  public int next(int key, int[] buffer) {
+  public int next(int key, int[] buffer, int offset) {
     int consumed = 0;
     do {
       int runStart = (runs.getValue(run));
       int runLength = (runs.getLength(run));
       int chunkStart = runStart + cursor;
-      int chunkEnd = chunkStart + Math.min(runLength - cursor, buffer.length - consumed - 1);
+      int chunkEnd = chunkStart + Math.min(runLength - cursor, buffer.length - offset - consumed - 1);
       int chunk = chunkEnd - chunkStart + 1;
       for (int i = 0; i < chunk; ++i) {
-        buffer[consumed + i] = key + chunkStart + i;
+        buffer[offset + consumed + i] = key + chunkStart + i;
       }
       consumed += chunk;
       if (runStart + runLength == chunkEnd) {
@@ -33,7 +33,7 @@ public final class RunBatchIterator implements ContainerBatchIterator {
       } else {
         cursor += chunk;
       }
-    } while (consumed < buffer.length && run != runs.numberOfRuns());
+    } while ((offset + consumed) < buffer.length && run != runs.numberOfRuns());
     return consumed;
   }
 


### PR DESCRIPTION
### SUMMARY
org.roaringbitmap.BatchIterator.nextBatch promises, in a comment, that its implementations "Aims to fill the buffer", but the two implementations of this will stop at the first consumption, even if there are many more ordinals to consume in later containers. This is muddying the idea of a container (which is essentially a roaring bitmap batch) and the user's batch (which may be smaller or larger than the roaring bitmap container cardinality). 

This PR attempts to make the implementation match the promise. 

Considering how long this implementation has been out of step with the comment, this may not be the best solution to merge upstream, but it's the solution my team would prefer. 

### Automated Checks

- [ ] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [ ] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
