### PR TITLE
RoaringBitmap to BitSet/long[]/byte[]

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
@@ -31,6 +31,22 @@ public class BitSetUtil {
   }
 
   /**
+   * Convert a {@link RoaringBitmap} to a {@link BitSet} without copying to an intermediate array.
+   */
+  public static BitSet bitsetOfWithoutCopy(RoaringBitmap bitmap) {
+    if (bitmap.isEmpty()) {
+      return new BitSet(0);
+    }
+    int last = bitmap.last();
+    if (last < 0) {
+      throw new IllegalArgumentException("bitmap has negative bits set");
+    }
+    BitSet bitSet = new BitSet(last);
+    bitmap.forEach((IntConsumer) bitSet::set);
+    return bitSet;
+  }
+
+  /**
    * Returns an array of long, given a {@link RoaringBitmap}.
    * <p>
    * See {@link BitSet#toByteArray()}.
@@ -53,7 +69,11 @@ public class BitSetUtil {
       return new long[0];
     }
 
-    int lastBit = Math.max(bitmap.last(), Long.SIZE);
+    int last = bitmap.last();
+    if (last < 0) {
+      throw new IllegalArgumentException("bitmap has negative bits set");
+    }
+    int lastBit = Math.max(last, Long.SIZE);
     int remainder = lastBit % Long.SIZE;
     int numBits = remainder > 0 ? lastBit - remainder : lastBit;
     int wordsInUse = numBits / Long.SIZE + 1;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
@@ -47,7 +47,7 @@ public class BitSetUtil {
   }
 
   /**
-   * Returns an array of long, given a {@link RoaringBitmap}.
+   * Returns an array of little-endian ordered bytes, given a {@link RoaringBitmap}.
    * <p>
    * See {@link BitSet#toByteArray()}.
    */
@@ -60,9 +60,9 @@ public class BitSetUtil {
   }
 
   /**
-   * Returns an array of little-endian ordered bytes, given a {@link RoaringBitmap}.
+   * Returns an array of long, given a {@link RoaringBitmap}.
    * <p>
-   * See {@link BitSet#toByteArray()}.
+   * See {@link BitSet#toLongArray()}.
    */
   public static long[] toLongArray(RoaringBitmap bitmap) {
     if (bitmap.isEmpty()) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
@@ -14,13 +14,74 @@ import static java.lang.Long.numberOfTrailingZeros;
  *
  */
 public class BitSetUtil {
-  // todo: add a method to convert a RoaringBitmap to a BitSet using BitSet.valueOf
 
   // a block consists has a maximum of 1024 words, each representing 64 bits,
   // thus representing at maximum 65536 bits
   public static final int BLOCK_LENGTH = BitmapContainer.MAX_CAPACITY / Long.SIZE; //
   // 64-bit
   // word
+
+  /**
+   * Convert a {@link RoaringBitmap} to a {@link BitSet}.
+   * <p>
+   * Equivalent to calling {@code BitSet.valueOf(BitSetUtil.toLongArray(bitmap))}.
+   */
+  public static BitSet bitsetOf(RoaringBitmap bitmap) {
+    return BitSet.valueOf(toLongArray(bitmap));
+  }
+
+  /**
+   * Returns an array of long, given a {@link RoaringBitmap}.
+   * <p>
+   * See {@link BitSet#toByteArray()}.
+   */
+  public static byte[] toByteArray(RoaringBitmap bitmap) {
+    long[] words = toLongArray(bitmap);
+    ByteBuffer buffer = ByteBuffer.allocate(words.length * Long.SIZE)
+            .order(ByteOrder.LITTLE_ENDIAN);
+    buffer.asLongBuffer().put(words);
+    return buffer.array();
+  }
+
+  /**
+   * Returns an array of little-endian ordered bytes, given a {@link RoaringBitmap}.
+   * <p>
+   * See {@link BitSet#toByteArray()}.
+   */
+  public static long[] toLongArray(RoaringBitmap bitmap) {
+    if (bitmap.isEmpty()) {
+      return new long[0];
+    }
+
+    int lastBit = Math.max(bitmap.last(), Long.SIZE);
+    int remainder = lastBit % Long.SIZE;
+    int numBits = remainder > 0 ? lastBit - remainder : lastBit;
+    int wordsInUse = numBits / Long.SIZE + 1;
+    long[] words = new long[wordsInUse];
+
+    ContainerPointer pointer = bitmap.getContainerPointer();
+    int numContainers = Math.max(words.length / BLOCK_LENGTH, 1);
+    int position = 0;
+    for (int i = 0; i <= numContainers; i++) {
+      char key = Util.lowbits(i);
+      if (key == pointer.key()) {
+        BitmapContainer container = pointer.getContainer().toBitmapContainer();
+        int remaining = wordsInUse - position;
+        int length = Math.min(BLOCK_LENGTH, remaining);
+        container.copyBitmapTo(words, position, length);
+        position += length;
+        pointer.advance();
+        if (pointer.getContainer() == null) {
+          break;
+        }
+      } else {
+        position += BLOCK_LENGTH;
+      }
+    }
+    assert pointer.getContainer() == null;
+    assert position == wordsInUse;
+    return words;
+  }
 
   /**
    * Creates array container's content char buffer.

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -1707,6 +1707,9 @@ public final class BitmapContainer extends Container implements Cloneable {
     return (i + 1) * 64 - Long.numberOfLeadingZeros(bitmap[i]) - 1;
   }
 
+  public void copyBitmapTo(long[] words, int position, int length) {
+    System.arraycopy(bitmap, 0, words, position, length);
+  }
 }
 
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitSetUtil.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitSetUtil.java
@@ -7,8 +7,7 @@ import java.nio.ByteBuffer;
 import java.util.BitSet;
 import java.util.Random;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class TestBitSetUtil {
@@ -30,6 +29,7 @@ public class TestBitSetUtil {
   private void assertEqualBitsets(final BitSet bitset, final RoaringBitmap bitmap) {
     assertTrue(BitSetUtil.equals(bitset, bitmap), "bitset and bitmap do not match");
     assertEquals(bitset, BitSetUtil.bitsetOf(bitmap), "bitsetOf doesn't match");
+    assertEquals(bitset, BitSetUtil.bitsetOfWithoutCopy(bitmap), "bitsetOfWithoutCopy doesn't match");
     assertEquals(bitset, BitSet.valueOf(BitSetUtil.toByteArray(bitmap)), "toByteArray doesn't match");
   }
 
@@ -237,6 +237,16 @@ public class TestBitSetUtil {
     final BitSet bitset = randomBitset(new Random(238), 0, 50);
     final RoaringBitmap bitmap = BitSetUtil.bitmapOf(toByteBuffer(bitset), true);
     Assertions.assertTrue(bitmap instanceof FastRankRoaringBitmap);
+  }
+
+  @Test
+  public void testBitmapOfNegative() {
+    final RoaringBitmap bitmap = new RoaringBitmap();
+    bitmap.add(-1);
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      BitSetUtil.bitsetOf(bitmap);
+    });
+    assertEquals("bitmap has negative bits set", exception.getMessage());
   }
 
   private static ByteBuffer toByteBuffer(BitSet bitset) {

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitSetUtil.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitSetUtil.java
@@ -7,6 +7,7 @@ import java.nio.ByteBuffer;
 import java.util.BitSet;
 import java.util.Random;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -27,7 +28,9 @@ public class TestBitSetUtil {
 
 
   private void assertEqualBitsets(final BitSet bitset, final RoaringBitmap bitmap) {
-    assertTrue(BitSetUtil.equals(bitset, bitmap));
+    assertTrue(BitSetUtil.equals(bitset, bitmap), "bitset and bitmap do not match");
+    assertEquals(bitset, BitSetUtil.bitsetOf(bitmap), "bitsetOf doesn't match");
+    assertEquals(bitset, BitSet.valueOf(BitSetUtil.toByteArray(bitmap)), "toByteArray doesn't match");
   }
 
   @Test


### PR DESCRIPTION
### SUMMARY

Add methods to allow direct conversion of a RoaringBitmap to a BitSet. This turned out to not be as simple as it first appeared, and the existing tests were a godsend.

This performs quite well too, I see over 5GB/s on my M1 MacBook Pro for 86,884 ops/s.

### Automated Checks

- [ x ] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [ x ] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
