### PR TITLE
Move instance field to static

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -24,6 +24,9 @@ import static java.lang.Long.numberOfTrailingZeros;
 public final class BitmapContainer extends Container implements Cloneable {
   public static final int MAX_CAPACITY = 1 << 16;
 
+  private static final int MAX_CAPACITY_BYTE = MAX_CAPACITY / Byte.SIZE;
+
+  private static final int MAX_CAPACITY_LONG = MAX_CAPACITY / Long.SIZE;
 
   private static final long serialVersionUID = 2L;
 
@@ -69,7 +72,7 @@ public final class BitmapContainer extends Container implements Cloneable {
 
   // nruns value for which RunContainer.serializedSizeInBytes ==
   // BitmapContainer.getArraySizeInBytes()
-  private final int MAXRUNS = (getArraySizeInBytes() - 2) / 4;
+  private static final int MAXRUNS = (MAX_CAPACITY_BYTE - 2) / 4;
 
 
   /**
@@ -77,7 +80,7 @@ public final class BitmapContainer extends Container implements Cloneable {
    */
   public BitmapContainer() {
     this.cardinality = 0;
-    this.bitmap = new long[MAX_CAPACITY / 64];
+    this.bitmap = new long[MAX_CAPACITY_LONG];
   }
 
 
@@ -463,7 +466,7 @@ public final class BitmapContainer extends Container implements Cloneable {
 
   @Override
   public int getArraySizeInBytes() {
-    return MAX_CAPACITY / 8;
+    return MAX_CAPACITY_BYTE;
   }
 
   @Override


### PR DESCRIPTION
### SUMMARY

This adds an additional unnecessary reference to every `BitmapContainer`.

### Automated Checks

- [ x ] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [ x ] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
