### PR TITLE
Avoid getCardinality in RunContainer.toBitmapContainer

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -2646,13 +2646,15 @@ public final class RunContainer extends Container implements Cloneable {
 
   @Override
   public BitmapContainer toBitmapContainer() {
-    int card = this.getCardinality();
+    int card = 0;
     BitmapContainer answer = new BitmapContainer();
     for (int rlepos = 0; rlepos < this.nbrruns; ++rlepos) {
       int start = (this.getValue(rlepos));
       int end = start + (this.getLength(rlepos)) + 1;
+      card += end - start;
       Util.setBitmapRange(answer.bitmap, start, end);
     }
+    assert card == this.getCardinality();
     answer.cardinality = card;
     return answer;
   }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
@@ -3955,6 +3955,18 @@ public class TestRunContainer {
     assertEquals(RunContainer.full(), container);
   }
 
+  @Test
+  public void toBitmapContainer() {
+    Container rc = new RunContainer().add((char)1).add(5, 7).add(10, 21);
+    BitmapContainer bitmapContainer = rc.toBitmapContainer();
+
+    assertTrue(bitmapContainer.contains((char) 1));
+    assertTrue(bitmapContainer.contains(5, 7));
+    assertTrue(bitmapContainer.contains(10, 21));
+
+    assertEquals(rc.getCardinality(), bitmapContainer.getCardinality());
+  }
+
   private static int lower16Bits(int x) {
     return ((char)x) & 0xFFFF;
   }


### PR DESCRIPTION
### SUMMARY

Related to https://github.com/RoaringBitmap/RoaringBitmap/pull/713, `RunContainer.getCardinality()` dominates CPU time in `toBitmapContainer`:

<img width="1711" alt="Screenshot 2024-04-17 at 11 53 17 AM" src="https://github.com/RoaringBitmap/RoaringBitmap/assets/1479220/85b6a660-9c04-4d57-a79a-88e5a008fb86">

We can tally the cardinality as we iterate the runs. 

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
