### PR TITLE
Avoid intermediate arrays for other container types

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -1130,6 +1130,14 @@ public final class ArrayContainer extends Container implements Cloneable {
   }
 
   @Override
+  public void copyBitmapTo(long[] dest, int position) {
+    for (int k = 0; k < cardinality; ++k) {
+      final char x = content[k];
+      dest[position + x/64] |= 1L << x;
+    }
+  }
+
+  @Override
   public int nextValue(char fromValue) {
     int index = Util.advanceUntil(content, -1, cardinality, fromValue);
     if (index == cardinality) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitSetUtil.java
@@ -85,10 +85,14 @@ public class BitSetUtil {
     for (int i = 0; i <= numContainers; i++) {
       char key = Util.lowbits(i);
       if (key == pointer.key()) {
-        BitmapContainer container = pointer.getContainer().toBitmapContainer();
+        Container container = pointer.getContainer();
         int remaining = wordsInUse - position;
         int length = Math.min(BLOCK_LENGTH, remaining);
-        container.copyBitmapTo(words, position, length);
+        if (container instanceof BitmapContainer) {
+          ((BitmapContainer)container).copyBitmapTo(words, position, length);
+        } else {
+          container.copyBitmapTo(words, position);
+        }
         position += length;
         pointer.advance();
         if (pointer.getContainer() == null) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -1666,6 +1666,15 @@ public final class BitmapContainer extends Container implements Cloneable {
   }
 
   @Override
+  public void copyBitmapTo(long[] words, int position) {
+    System.arraycopy(bitmap, 0, words, position, bitmap.length);
+  }
+
+  public void copyBitmapTo(long[] words, int position, int length) {
+    System.arraycopy(bitmap, 0, words, position, length);
+  }
+
+  @Override
   public int nextValue(char fromValue) {
     return nextSetBit((fromValue));
   }
@@ -1705,10 +1714,6 @@ public final class BitmapContainer extends Container implements Cloneable {
     }
     // sizeof(long) * #words from start - number of bits after the last bit set
     return (i + 1) * 64 - Long.numberOfLeadingZeros(bitmap[i]) - 1;
-  }
-
-  public void copyBitmapTo(long[] words, int position, int length) {
-    System.arraycopy(bitmap, 0, words, position, length);
   }
 }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/Container.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/Container.java
@@ -987,6 +987,17 @@ public abstract class Container implements Iterable<Character>, Cloneable, Exter
   public abstract BitmapContainer toBitmapContainer();
 
   /**
+   * Copy the current container to a destination {@code long[]}. Equivalent to calling
+   * {@link #toBitmapContainer()} and copying the result to the given position. The destination
+   * array should be sized to accomodate the maximum number of words required to represent
+   * the container bitmap.
+   *
+   * @param dest the destination array
+   * @param position the position to copy to
+   */
+  public abstract void copyBitmapTo(long[] dest, int position);
+
+  /**
    * Gets the first value greater than or equal to the lower bound, or -1 if no such value exists.
    * @param fromValue the lower bound (inclusive)
    * @return the next value

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -2660,6 +2660,16 @@ public final class RunContainer extends Container implements Cloneable {
   }
 
   @Override
+  public void copyBitmapTo(long[] dest, int position) {
+    int offset = position * Long.SIZE;
+    for (int rlepos = 0; rlepos < this.nbrruns; ++rlepos) {
+      int start = offset + this.getValue(rlepos);
+      int end = start + this.getLength(rlepos) + 1;
+      Util.setBitmapRange(dest, start, end);
+    }
+  }
+
+  @Override
   public int nextValue(char fromValue) {
     int index = unsignedInterleavedBinarySearch(valueslength, 0, nbrruns, fromValue);
     int effectiveIndex = index >= 0 ? index : -index - 2;

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitSetUtil.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestBitSetUtil.java
@@ -31,6 +31,10 @@ public class TestBitSetUtil {
     assertEquals(bitset, BitSetUtil.bitsetOf(bitmap), "bitsetOf doesn't match");
     assertEquals(bitset, BitSetUtil.bitsetOfWithoutCopy(bitmap), "bitsetOfWithoutCopy doesn't match");
     assertEquals(bitset, BitSet.valueOf(BitSetUtil.toByteArray(bitmap)), "toByteArray doesn't match");
+
+    RoaringBitmap runBitmap = bitmap.clone();
+    runBitmap.runOptimize();
+    assertEquals(bitset, BitSetUtil.bitsetOf(runBitmap), "bitsetOf doesn't match for run optimized bitmap");
   }
 
   @Test


### PR DESCRIPTION
### SUMMARY

Another quick follow up to #713 to avoid `toBitmapContainer` as this has shown up on hot paths for us too.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
