### PR TITLE
Fix for or:ing two RunContainers that produce an undersized BitmapContainer

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -2295,16 +2295,6 @@ public final class RunContainer extends Container implements Cloneable {
     }
   }
 
-  // convert to bitmap *if needed* (useful if you know it can't be an array)
-  private Container toBitmapIfNeeded() {
-    int sizeAsRunContainer = RunContainer.serializedSizeInBytes(this.nbrruns);
-    int sizeAsBitmapContainer = BitmapContainer.serializedSizeInBytes(0);
-    if (sizeAsBitmapContainer > sizeAsRunContainer) {
-      return this;
-    }
-    return toBitmapContainer();
-  }
-
   /**
    * Convert the container to either a Bitmap or an Array Container, depending on the cardinality.
    *

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -1550,7 +1550,7 @@ public final class RunContainer extends Container implements Cloneable {
       this.smartAppend(x.getValue(xrlepos), x.getLength(xrlepos));
       ++xrlepos;
     }
-    return this.toBitmapIfNeeded();
+    return this.toEfficientContainer();
   }
 
   @Override
@@ -1986,7 +1986,7 @@ public final class RunContainer extends Container implements Cloneable {
     if (answer.isFull()) {
       return full();
     }
-    return answer.toBitmapIfNeeded();
+    return answer.toEfficientContainer();
   }
 
   // Prepend a value length with all values starting from a given value

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -1456,7 +1456,7 @@ public final class MappeableRunContainer extends MappeableContainer implements C
       this.smartAppend(vl, x.getValue(xrlepos), x.getLength(xrlepos));
       ++xrlepos;
     }
-    return this.toBitmapIfNeeded();
+    return this.toEfficientContainer();
   }
 
   @Override
@@ -1940,7 +1940,7 @@ public final class MappeableRunContainer extends MappeableContainer implements C
     if (answer.isFull()) {
       return full();
     }
-    return answer.toBitmapIfNeeded();
+    return answer.toEfficientContainer();
   }
 
   // Prepend a value length with all values starting from a given value
@@ -2228,17 +2228,6 @@ public final class MappeableRunContainer extends MappeableContainer implements C
       setLength(nbrruns, (char) (newend - oldend - 1));
       nbrruns++;
     }
-  }
-
-
-  // convert to bitmap *if needed* (useful if you know it can't be an array)
-  private MappeableContainer toBitmapIfNeeded() {
-    int sizeAsRunContainer = MappeableRunContainer.serializedSizeInBytes(this.nbrruns);
-    int sizeAsBitmapContainer = MappeableBitmapContainer.serializedSizeInBytes(0);
-    if (sizeAsBitmapContainer > sizeAsRunContainer) {
-      return this;
-    }
-    return toBitmapContainer();
   }
 
   /**

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestContainer.java
@@ -802,6 +802,25 @@ public class TestContainer {
   }
 
   @Test
+  public void or6() {
+    System.out.println("or6");
+    RunContainer rc1 = new RunContainer();
+    for (int i = 0; i < 6144; i += 6) {
+      rc1.iadd(i, i+1);
+    }
+
+    RunContainer rc2 = new RunContainer();
+
+    for (int i = 3; i < 6144; i += 6) {
+      rc2.iadd(i, i+1);
+    }
+
+    Container result = rc1.or(rc2);
+    assertTrue(result.getCardinality() < ArrayContainer.DEFAULT_MAX_SIZE);
+    assertTrue(result instanceof ArrayContainer);
+  }
+
+  @Test
   public void testXorContainer() throws Exception {
     Container rc1 = new RunContainer(new char[] {10, 12, 90, 10}, 2);
     Container rc2 = new RunContainer(new char[]{1, 10, 40, 400, 900, 10}, 3);


### PR DESCRIPTION
### SUMMARY
- Add the test mentioned in #717 
- Change `toBitmapIfNeeded` to `toEfficientContainer` at the end of `or` and `ior` for `RunContainer` and `MappeableRunContainer`.
- Remove the now unused `toBitmapIfNeeded` methods.
- This fixes #717 

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
