### PR TITLE
ADD Java 21 to CI

### DIFF
--- a/.github/workflows/java-all-versions.yml
+++ b/.github/workflows/java-all-versions.yml
@@ -1,4 +1,4 @@
-name: Java 8, 11, 17 CI
+name: Java 8, 11, 17, 21 CI
 
 on: [push,pull_request]
 
@@ -8,14 +8,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDKs 8, 11, 17
-        uses: actions/setup-java@v3
+      - name: Set up JDKs 8, 11, 17, 21
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |
             8
             11
             17
+            21
       - name: Build with Gradle
         run: ./gradlew assemble
       - name: Style check
@@ -26,3 +27,5 @@ jobs:
         run: ./gradlew test -PtestOnJava=11 --stacktrace
       - name: Test with Java 17
         run: ./gradlew test -PtestOnJava=17 --stacktrace
+      - name: Test with Java 21
+        run: ./gradlew test -PtestOnJava=21 --stacktrace


### PR DESCRIPTION
### SUMMARY
As one of four LTS versions being supported by Eclipse Temurin (see https://adoptium.net/support/), add Java 21 as a tested version.  The next expected version to add is Java 25 on or after September 2025 and the next expected version to drop is Java 8 on or after Nov 2026.

### Automated Checks
- [X] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [X] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
