### PR TITLE
fix: formalize edge behaviour for nextAbsentValue and previousAbsentValue

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ImmutableBitmapDataProvider.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ImmutableBitmapDataProvider.java
@@ -235,7 +235,7 @@ public interface ImmutableBitmapDataProvider {
    *
    * @param  fromValue the lower bound (inclusive)
    * @return the smallest absent value larger than or equal to the specified
-   *       value.
+   *       value or {@code -1} if there is no such value.
    */
   long nextAbsentValue(int fromValue);
 
@@ -246,7 +246,7 @@ public interface ImmutableBitmapDataProvider {
    *
    * @param  fromValue the lower bound (inclusive)
    * @return the smallest absent value larger than or equal to the specified
-   *       value.
+   *       value or {@code -1} if there is no such value.
    */
   long previousAbsentValue(int fromValue);
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -2845,9 +2845,11 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
   @Override
   public long nextAbsentValue(int fromValue) {
     long nextAbsentBit = computeNextAbsentValue(fromValue);
-    assert nextAbsentBit <= 0xFFFFFFFFL;
-    assert nextAbsentBit >= Util.toUnsignedLong(fromValue);
-    assert !contains((int) nextAbsentBit);
+    if(nextAbsentBit == 4294967296L) {
+      if(contains(-1)) {
+        return -1L;
+      }
+    }
     return nextAbsentBit;
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -2845,10 +2845,8 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
   @Override
   public long nextAbsentValue(int fromValue) {
     long nextAbsentBit = computeNextAbsentValue(fromValue);
-    if(nextAbsentBit == 4294967296L) {
-      if(contains(-1)) {
-        return -1L;
-      }
+    if(nextAbsentBit == 0x100000000L) {
+      return -1L;
     }
     return nextAbsentBit;
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -1729,10 +1729,8 @@ public class ImmutableRoaringBitmap
   @Override
   public long nextAbsentValue(int fromValue) {
     long nextAbsentBit = computeNextAbsentValue(fromValue);
-    if(nextAbsentBit == 4294967296L) {
-      if(contains(-1)) {
-        return -1L;
-      }
+    if(nextAbsentBit == 0x100000000L) {
+      return -1L;
     }
     return nextAbsentBit;
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -1729,9 +1729,11 @@ public class ImmutableRoaringBitmap
   @Override
   public long nextAbsentValue(int fromValue) {
     long nextAbsentBit = computeNextAbsentValue(fromValue);
-    assert nextAbsentBit <= 0xFFFFFFFFL;
-    assert nextAbsentBit >= Util.toUnsignedLong(fromValue);
-    assert !contains((int) nextAbsentBit);
+    if(nextAbsentBit == 4294967296L) {
+      if(contains(-1)) {
+        return -1L;
+      }
+    }
     return nextAbsentBit;
   }
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -5301,6 +5301,34 @@ public class TestRoaringBitmap {
     }
 
     @Test
+    public void testPreviousValueLimit() {
+        RoaringBitmap bitmap = new RoaringBitmap();
+        bitmap.add(1);
+        assertEquals(-1l, bitmap.previousValue(0));
+    }
+
+    @Test
+    public void testPreviousAbsentValueLimit() {
+        RoaringBitmap bitmap = new RoaringBitmap();
+        bitmap.add(0);
+        assertEquals(-1L, bitmap.previousAbsentValue(0));
+    }
+
+    @Test
+    public void testNextValueLimit() {
+        RoaringBitmap bitmap = new RoaringBitmap();
+        bitmap.add(0xffffffff-1);
+        assertEquals(-1L, bitmap.nextValue(0xffffffff));
+    }
+
+    @Test
+    public void testNextAbsentValueLimit() {
+        RoaringBitmap bitmap = new RoaringBitmap();
+        bitmap.add(-1);
+        assertEquals(-1L, bitmap.nextAbsentValue(-1));
+    }
+
+    @Test
     public void testPreviousValue() {
         RoaringBitmap bitmap = SeededTestData.TestDataSet.testCase()
                 .withRunAt(0)

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRoaringBitmap.java
@@ -3980,4 +3980,32 @@ public class TestRoaringBitmap {
         r.flip(1);
         assertEquals(r,  MutableRoaringBitmap.bitmapOf(2, 3, 4, 5));
     }
+
+    @Test
+    public void testPreviousValueLimit() {
+        MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+        bitmap.add(1);
+        assertEquals(-1l, bitmap.previousValue(0));
+    }
+
+    @Test
+    public void testPreviousAbsentValueLimit() {
+        MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+        bitmap.add(0);
+        assertEquals(-1L, bitmap.previousAbsentValue(0));
+    }
+
+    @Test
+    public void testNextValueLimit() {
+        MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+        bitmap.add(0xffffffff-1);
+        assertEquals(-1L, bitmap.nextValue(0xffffffff));
+    }
+
+    @Test
+    public void testNextAbsentValueLimit() {
+        MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+        bitmap.add(-1);
+        assertEquals(-1L, bitmap.nextAbsentValue(-1));
+    }
 }


### PR DESCRIPTION
The edge cases for nextAbsentValue and previousAbsentValue were undefined.
