### PR TITLE
Fix RunContainer#contains(BitmapContainer) (#721)

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -830,7 +830,6 @@ public final class RunContainer extends Container implements Cloneable {
           if (ir == runCount) {
             break;
           }
-          w &= w - 1;
           start = getValue(ir);
           stop = start + getLength(ir);
         } else if (ib * 64 + 64 < stop) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -2739,7 +2739,6 @@ public final class MappeableRunContainer extends MappeableContainer implements C
           if (ir == runCount) {
             break;
           }
-          w &= w - 1;
           start = getValue(ir);
           stop = start + getLength(ir);
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
@@ -1,6 +1,5 @@
 package org.roaringbitmap;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -3337,6 +3336,13 @@ public class TestRunContainer {
   }
 
   @Test
+  public void testContainsBitmapContainer_IncludeProperSubsetMultiWordRun() {
+    Container rc = new RunContainer().add(0,80);
+    Container subset = new BitmapContainer().add(0,79);
+    assertTrue(rc.contains(subset));
+  }
+
+  @Test
   public void testContainsBitmapContainer_ExcludeShiftedSet() {
     Container rc = new RunContainer().add(0,10);
     Container subset = new BitmapContainer().add(2,12);
@@ -3363,6 +3369,20 @@ public class TestRunContainer {
     Container disjoint = new BitmapContainer().add(20, 40);
     assertFalse(rc.contains(disjoint));
     assertFalse(disjoint.contains(rc));
+  }
+
+  @Test
+  public void testContainsBitmapContainer_Issue721Case1() {
+    Container rc = new RunContainer().add(0,60).add(63,64).add(66,67);
+    Container subset = new BitmapContainer().add(63,64);
+    assertTrue(rc.contains(subset));
+  }
+
+  @Test
+  public void testContainsBitmapContainer_Issue721Case2() {
+    Container rc = new RunContainer().add(0,10).add(12,13);
+    Container disjoint = new BitmapContainer().add(11,12);
+    assertFalse(rc.contains(disjoint));
   }
 
   @Test

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRunContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRunContainer.java
@@ -2237,6 +2237,13 @@ public class TestRunContainer {
   }
 
   @Test
+  public void testContainsBitmapContainer_IncludeProperSubsetMultiWordRun() {
+    MappeableContainer rc = new MappeableRunContainer().add(0,80);
+    MappeableContainer subset = new MappeableBitmapContainer().add(0,79);
+    assertTrue(rc.contains(subset));
+  }
+
+  @Test
   public void testContainsMappeableBitmapContainer_ExcludeShiftedSet() {
     MappeableContainer rc = new MappeableRunContainer().add(0,10);
     MappeableContainer subset = new MappeableBitmapContainer().add(2,12);
@@ -2263,6 +2270,20 @@ public class TestRunContainer {
     MappeableContainer disjoint = new MappeableBitmapContainer().add(20, 40);
     assertFalse(rc.contains(disjoint));
     assertFalse(disjoint.contains(rc));
+  }
+
+  @Test
+  public void testContainsMappeableBitmapContainer_Issue721Case1() {
+    MappeableContainer rc = new MappeableRunContainer().add(0,60).add(63,64).add(66,67);
+    MappeableContainer subset = new MappeableBitmapContainer().add(63,64);
+    assertTrue(rc.contains(subset));
+  }
+
+  @Test
+  public void testContainsMappeableBitmapContainer_Issue721Case2() {
+    MappeableContainer rc = new MappeableRunContainer().add(0,10).add(12,13);
+    MappeableContainer disjoint = new MappeableBitmapContainer().add(11,12);
+    assertFalse(rc.contains(disjoint));
   }
 
   @Test


### PR DESCRIPTION
### SUMMARY
Fixes #721: Advancing to the next run, because the current bit is beyond the end of the current run, should not also advance to the next bit.
Add new unit-tests to cover the cases mentioned and another to add coverage of a missed branch.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
