### PR TITLE
Fix ArrayContainer#contains(RunContainer) (#723)

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -317,7 +317,7 @@ public final class ArrayContainer extends Container implements Cloneable {
     for (int i = 0; i < runContainer.numberOfRuns(); ++i) {
       int start = (runContainer.getValue(i));
       int length = (runContainer.getLength(i));
-      if (!contains(start, start + length)) {
+      if (!contains(start, start + length + 1)) {
         return false;
       }
     }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -1651,7 +1651,7 @@ public final class MappeableArrayContainer extends MappeableContainer implements
     for (int i = 0; i < runContainer.numberOfRuns(); ++i) {
       int start = (runContainer.getValue(i));
       int length = (runContainer.getLength(i));
-      if (!contains(start, start + length)) {
+      if (!contains(start, start + length + 1)) {
         return false;
       }
     }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestArrayContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestArrayContainer.java
@@ -322,6 +322,20 @@ public class TestArrayContainer {
     }
 
     @Test
+    public void testContainsRunContainer_Issue723Case1() {
+        Container ac = new ArrayContainer().add(0,10);
+        Container subset = new RunContainer().add(5,6);
+        assertTrue(ac.contains(subset));
+    }
+
+    @Test
+    public void testContainsRunContainer_Issue723Case2() {
+        Container ac = new ArrayContainer().add(0,10);
+        Container rc = new RunContainer().add(5,11);
+        assertFalse(ac.contains(rc));
+    }
+
+    @Test
     public void testContainsArrayContainer_EmptyContainsEmpty() {
         Container ac = new ArrayContainer();
         Container subset = new ArrayContainer();

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestMappeableArrayContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestMappeableArrayContainer.java
@@ -318,6 +318,20 @@ public class TestMappeableArrayContainer {
     ac1.add((char) -17);
     assertEquals("{5,6,7,8,9,10,11,12,13,14,65519,65533}", ac1.toString());
   }
+
+  @Test
+  public void testContainsRunContainer_Issue723Case1() {
+    MappeableContainer ac = new MappeableArrayContainer().add(0,10);
+    MappeableContainer subset = new MappeableRunContainer().add(5,6);
+    assertTrue(ac.contains(subset));
+  }
+
+  @Test
+  public void testContainsRunContainer_Issue723Case2() {
+    MappeableContainer ac = new MappeableArrayContainer().add(0,10);
+    MappeableContainer rc = new MappeableRunContainer().add(5,11);
+    assertFalse(ac.contains(rc));
+  }
   
   @Test
   public void iorNotIncreaseCapacity() {


### PR DESCRIPTION
### SUMMARY
Fixes #723 off-by-one error in `ArrayContainer#contains(RunContainer)` call to `contains(int,int)`
Added new unit-test.

There's perhaps some potential for a micro-optimization since contains(int,int) immediately subtracts the 1 just added.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
