### PR TITLE
[feature] Add a BitSet implementation based on RoaringBitmap

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitSet.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitSet.java
@@ -184,15 +184,11 @@ public class RoaringBitSet extends BitSet {
     if (obj instanceof RoaringBitSet) {
       return roaringBitmap.equals(((RoaringBitSet) obj).roaringBitmap);
     }
-    if (obj instanceof BitSet) {
-      return roaringBitmap.equals(fromBitSet((BitSet) obj));
-    }
     return false;
   }
 
   @Override
   public Object clone() {
-    super.clone();
     return new RoaringBitSet(roaringBitmap.clone());
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitSet.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitSet.java
@@ -36,18 +36,16 @@ public class RoaringBitSet extends BitSet {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
   public void set(int fromIndex, int toIndex) {
-    roaringBitmap.add(fromIndex, toIndex);
+    roaringBitmap.add((long) fromIndex, (long) toIndex);
   }
 
   @Override
-  @SuppressWarnings("deprecation")
   public void set(int fromIndex, int toIndex, boolean value) {
     if (value) {
-      roaringBitmap.add(fromIndex, toIndex);
+      roaringBitmap.add((long) fromIndex, (long) toIndex);
     } else {
-      roaringBitmap.remove(fromIndex, toIndex);
+      roaringBitmap.remove((long) fromIndex, (long) toIndex);
     }
   }
 
@@ -57,9 +55,8 @@ public class RoaringBitSet extends BitSet {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
   public void clear(int fromIndex, int toIndex) {
-    roaringBitmap.remove(fromIndex, toIndex);
+    roaringBitmap.remove((long) fromIndex, (long) toIndex);
   }
 
   @Override
@@ -204,15 +201,13 @@ public class RoaringBitSet extends BitSet {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
   public void flip(int bitIndex) {
-    roaringBitmap.flip(bitIndex, bitIndex + 1);
+    roaringBitmap.flip((long) bitIndex, (long) bitIndex + 1);
   }
 
   @Override
-  @SuppressWarnings("deprecation")
   public void flip(int fromIndex, int toIndex) {
-    roaringBitmap.flip(fromIndex, toIndex);
+    roaringBitmap.flip((long) fromIndex, (long) toIndex);
   }
 
   @Override

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitSet.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitSet.java
@@ -1,0 +1,235 @@
+package org.roaringbitmap;
+
+import java.util.BitSet;
+import java.util.stream.IntStream;
+
+/**
+ * A {@link BitSet} implementation based on {@link RoaringBitmap}.
+ */
+public class RoaringBitSet extends BitSet {
+    private static final long serialVersionUID = 1L;
+
+    private final RoaringBitmap roaringBitmap;
+
+    public RoaringBitSet() {
+        super(0);
+        roaringBitmap = new RoaringBitmap();
+    }
+
+    private RoaringBitSet(RoaringBitmap roaringBitmap) {
+        super(0);
+        this.roaringBitmap = roaringBitmap;
+    }
+
+    @Override
+    public void set(int bitIndex) {
+        roaringBitmap.add(bitIndex);
+    }
+
+    @Override
+    public void set(int bitIndex, boolean value) {
+        if (value) {
+            roaringBitmap.add(bitIndex);
+        } else {
+            roaringBitmap.remove(bitIndex);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void set(int fromIndex, int toIndex) {
+        roaringBitmap.add(fromIndex, toIndex);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void set(int fromIndex, int toIndex, boolean value) {
+        if (value) {
+            roaringBitmap.add(fromIndex, toIndex);
+        } else {
+            roaringBitmap.remove(fromIndex, toIndex);
+        }
+    }
+
+    @Override
+    public void clear(int bitIndex) {
+        roaringBitmap.remove(bitIndex);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void clear(int fromIndex, int toIndex) {
+        roaringBitmap.remove(fromIndex, toIndex);
+    }
+
+    @Override
+    public void clear() {
+        roaringBitmap.clear();
+    }
+
+    @Override
+    public boolean get(int bitIndex) {
+        return roaringBitmap.contains(bitIndex);
+    }
+
+    @Override
+    public BitSet get(int fromIndex, int toIndex) {
+        BitSet bitSet = BitSetUtil.bitsetOf(roaringBitmap);
+        bitSet = bitSet.get(fromIndex, toIndex);
+        return new RoaringBitSet(fromBitSet(bitSet));
+    }
+
+    @Override
+    public int nextSetBit(int fromIndex) {
+        return (int) roaringBitmap.nextValue(fromIndex);
+    }
+
+    @Override
+    public int nextClearBit(int fromIndex) {
+        return (int) roaringBitmap.nextAbsentValue(fromIndex);
+    }
+
+    @Override
+    public int previousSetBit(int fromIndex) {
+        return (int) roaringBitmap.previousValue(fromIndex);
+    }
+
+    @Override
+    public int previousClearBit(int fromIndex) {
+        return (int) roaringBitmap.previousAbsentValue(fromIndex);
+    }
+
+    @Override
+    public int length() {
+        if (roaringBitmap.isEmpty()) {
+            return 0;
+        }
+        return roaringBitmap.last() + 1;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return roaringBitmap.isEmpty();
+    }
+
+    @Override
+    public boolean intersects(BitSet set) {
+        if (set instanceof RoaringBitSet) {
+            return RoaringBitmap.intersects(roaringBitmap, ((RoaringBitSet) set).roaringBitmap);
+        }
+        return RoaringBitmap.intersects(roaringBitmap, fromBitSet(set));
+    }
+
+    @Override
+    public int cardinality() {
+        return roaringBitmap.getCardinality();
+    }
+
+    @Override
+    public void and(BitSet set) {
+        if (set instanceof RoaringBitSet) {
+            roaringBitmap.and(((RoaringBitSet) set).roaringBitmap);
+        } else {
+            roaringBitmap.and(fromBitSet(set));
+        }
+    }
+
+    @Override
+    public void or(BitSet set) {
+        if (set instanceof RoaringBitSet) {
+            roaringBitmap.or(((RoaringBitSet) set).roaringBitmap);
+        } else {
+            roaringBitmap.or(fromBitSet(set));
+        }
+    }
+
+    @Override
+    public void xor(BitSet set) {
+        if (set instanceof RoaringBitSet) {
+            roaringBitmap.xor(((RoaringBitSet) set).roaringBitmap);
+        } else {
+            roaringBitmap.xor(fromBitSet(set));
+        }
+    }
+
+    @Override
+    public void andNot(BitSet set) {
+        if (set instanceof RoaringBitSet) {
+            roaringBitmap.andNot(((RoaringBitSet) set).roaringBitmap);
+        } else {
+            roaringBitmap.andNot(fromBitSet(set));
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return roaringBitmap.hashCode();
+    }
+
+    @Override
+    public int size() {
+        if (roaringBitmap.isEmpty()) {
+            return 0;
+        }
+        int lastBit = Math.max(length(), 64);
+        int remainder = lastBit % 64;
+        return remainder == 0 ? lastBit : lastBit + 64 - remainder;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof RoaringBitSet) {
+            return roaringBitmap.equals(((RoaringBitSet) obj).roaringBitmap);
+        }
+        if (obj instanceof BitSet) {
+            return roaringBitmap.equals(fromBitSet((BitSet) obj));
+        }
+        return false;
+    }
+
+    @Override
+    public Object clone() {
+        super.clone();
+        return new RoaringBitSet(roaringBitmap.clone());
+    }
+
+
+    @Override
+    public IntStream stream() {
+        return roaringBitmap.stream();
+    }
+
+    @Override
+    public String toString() {
+        return roaringBitmap.toString();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void flip(int bitIndex) {
+        roaringBitmap.flip(bitIndex, bitIndex + 1);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void flip(int fromIndex, int toIndex) {
+        roaringBitmap.flip(fromIndex, toIndex);
+    }
+
+    @Override
+    public long[] toLongArray() {
+        return BitSetUtil.toLongArray(roaringBitmap);
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        return BitSetUtil.toByteArray(roaringBitmap);
+    }
+
+    private static RoaringBitmap fromBitSet(BitSet bitSet) {
+        return BitSetUtil.bitmapOf(bitSet);
+    }
+}

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitSet.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitSet.java
@@ -7,229 +7,229 @@ import java.util.stream.IntStream;
  * A {@link BitSet} implementation based on {@link RoaringBitmap}.
  */
 public class RoaringBitSet extends BitSet {
-    private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-    private final RoaringBitmap roaringBitmap;
+  private final RoaringBitmap roaringBitmap;
 
-    public RoaringBitSet() {
-        super(0);
-        roaringBitmap = new RoaringBitmap();
+  public RoaringBitSet() {
+    super(0);
+    roaringBitmap = new RoaringBitmap();
+  }
+
+  private RoaringBitSet(RoaringBitmap roaringBitmap) {
+    super(0);
+    this.roaringBitmap = roaringBitmap;
+  }
+
+  @Override
+  public void set(int bitIndex) {
+    roaringBitmap.add(bitIndex);
+  }
+
+  @Override
+  public void set(int bitIndex, boolean value) {
+    if (value) {
+      roaringBitmap.add(bitIndex);
+    } else {
+      roaringBitmap.remove(bitIndex);
     }
+  }
 
-    private RoaringBitSet(RoaringBitmap roaringBitmap) {
-        super(0);
-        this.roaringBitmap = roaringBitmap;
+  @Override
+  @SuppressWarnings("deprecation")
+  public void set(int fromIndex, int toIndex) {
+    roaringBitmap.add(fromIndex, toIndex);
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public void set(int fromIndex, int toIndex, boolean value) {
+    if (value) {
+      roaringBitmap.add(fromIndex, toIndex);
+    } else {
+      roaringBitmap.remove(fromIndex, toIndex);
     }
+  }
 
-    @Override
-    public void set(int bitIndex) {
-        roaringBitmap.add(bitIndex);
+  @Override
+  public void clear(int bitIndex) {
+    roaringBitmap.remove(bitIndex);
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public void clear(int fromIndex, int toIndex) {
+    roaringBitmap.remove(fromIndex, toIndex);
+  }
+
+  @Override
+  public void clear() {
+    roaringBitmap.clear();
+  }
+
+  @Override
+  public boolean get(int bitIndex) {
+    return roaringBitmap.contains(bitIndex);
+  }
+
+  @Override
+  public BitSet get(int fromIndex, int toIndex) {
+    BitSet bitSet = BitSetUtil.bitsetOf(roaringBitmap);
+    bitSet = bitSet.get(fromIndex, toIndex);
+    return new RoaringBitSet(fromBitSet(bitSet));
+  }
+
+  @Override
+  public int nextSetBit(int fromIndex) {
+    return (int) roaringBitmap.nextValue(fromIndex);
+  }
+
+  @Override
+  public int nextClearBit(int fromIndex) {
+    return (int) roaringBitmap.nextAbsentValue(fromIndex);
+  }
+
+  @Override
+  public int previousSetBit(int fromIndex) {
+    return (int) roaringBitmap.previousValue(fromIndex);
+  }
+
+  @Override
+  public int previousClearBit(int fromIndex) {
+    return (int) roaringBitmap.previousAbsentValue(fromIndex);
+  }
+
+  @Override
+  public int length() {
+    if (roaringBitmap.isEmpty()) {
+      return 0;
     }
+    return roaringBitmap.last() + 1;
+  }
 
-    @Override
-    public void set(int bitIndex, boolean value) {
-        if (value) {
-            roaringBitmap.add(bitIndex);
-        } else {
-            roaringBitmap.remove(bitIndex);
-        }
+  @Override
+  public boolean isEmpty() {
+    return roaringBitmap.isEmpty();
+  }
+
+  @Override
+  public boolean intersects(BitSet set) {
+    if (set instanceof RoaringBitSet) {
+      return RoaringBitmap.intersects(roaringBitmap, ((RoaringBitSet) set).roaringBitmap);
     }
+    return RoaringBitmap.intersects(roaringBitmap, fromBitSet(set));
+  }
 
-    @Override
-    @SuppressWarnings("deprecation")
-    public void set(int fromIndex, int toIndex) {
-        roaringBitmap.add(fromIndex, toIndex);
+  @Override
+  public int cardinality() {
+    return roaringBitmap.getCardinality();
+  }
+
+  @Override
+  public void and(BitSet set) {
+    if (set instanceof RoaringBitSet) {
+      roaringBitmap.and(((RoaringBitSet) set).roaringBitmap);
+    } else {
+      roaringBitmap.and(fromBitSet(set));
     }
+  }
 
-    @Override
-    @SuppressWarnings("deprecation")
-    public void set(int fromIndex, int toIndex, boolean value) {
-        if (value) {
-            roaringBitmap.add(fromIndex, toIndex);
-        } else {
-            roaringBitmap.remove(fromIndex, toIndex);
-        }
+  @Override
+  public void or(BitSet set) {
+    if (set instanceof RoaringBitSet) {
+      roaringBitmap.or(((RoaringBitSet) set).roaringBitmap);
+    } else {
+      roaringBitmap.or(fromBitSet(set));
     }
+  }
 
-    @Override
-    public void clear(int bitIndex) {
-        roaringBitmap.remove(bitIndex);
+  @Override
+  public void xor(BitSet set) {
+    if (set instanceof RoaringBitSet) {
+      roaringBitmap.xor(((RoaringBitSet) set).roaringBitmap);
+    } else {
+      roaringBitmap.xor(fromBitSet(set));
     }
+  }
 
-    @Override
-    @SuppressWarnings("deprecation")
-    public void clear(int fromIndex, int toIndex) {
-        roaringBitmap.remove(fromIndex, toIndex);
+  @Override
+  public void andNot(BitSet set) {
+    if (set instanceof RoaringBitSet) {
+      roaringBitmap.andNot(((RoaringBitSet) set).roaringBitmap);
+    } else {
+      roaringBitmap.andNot(fromBitSet(set));
     }
+  }
 
-    @Override
-    public void clear() {
-        roaringBitmap.clear();
+  @Override
+  public int hashCode() {
+    return roaringBitmap.hashCode();
+  }
+
+  @Override
+  public int size() {
+    if (roaringBitmap.isEmpty()) {
+      return 0;
     }
+    int lastBit = Math.max(length(), 64);
+    int remainder = lastBit % 64;
+    return remainder == 0 ? lastBit : lastBit + 64 - remainder;
+  }
 
-    @Override
-    public boolean get(int bitIndex) {
-        return roaringBitmap.contains(bitIndex);
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
     }
-
-    @Override
-    public BitSet get(int fromIndex, int toIndex) {
-        BitSet bitSet = BitSetUtil.bitsetOf(roaringBitmap);
-        bitSet = bitSet.get(fromIndex, toIndex);
-        return new RoaringBitSet(fromBitSet(bitSet));
+    if (obj instanceof RoaringBitSet) {
+      return roaringBitmap.equals(((RoaringBitSet) obj).roaringBitmap);
     }
-
-    @Override
-    public int nextSetBit(int fromIndex) {
-        return (int) roaringBitmap.nextValue(fromIndex);
+    if (obj instanceof BitSet) {
+      return roaringBitmap.equals(fromBitSet((BitSet) obj));
     }
+    return false;
+  }
 
-    @Override
-    public int nextClearBit(int fromIndex) {
-        return (int) roaringBitmap.nextAbsentValue(fromIndex);
-    }
-
-    @Override
-    public int previousSetBit(int fromIndex) {
-        return (int) roaringBitmap.previousValue(fromIndex);
-    }
-
-    @Override
-    public int previousClearBit(int fromIndex) {
-        return (int) roaringBitmap.previousAbsentValue(fromIndex);
-    }
-
-    @Override
-    public int length() {
-        if (roaringBitmap.isEmpty()) {
-            return 0;
-        }
-        return roaringBitmap.last() + 1;
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return roaringBitmap.isEmpty();
-    }
-
-    @Override
-    public boolean intersects(BitSet set) {
-        if (set instanceof RoaringBitSet) {
-            return RoaringBitmap.intersects(roaringBitmap, ((RoaringBitSet) set).roaringBitmap);
-        }
-        return RoaringBitmap.intersects(roaringBitmap, fromBitSet(set));
-    }
-
-    @Override
-    public int cardinality() {
-        return roaringBitmap.getCardinality();
-    }
-
-    @Override
-    public void and(BitSet set) {
-        if (set instanceof RoaringBitSet) {
-            roaringBitmap.and(((RoaringBitSet) set).roaringBitmap);
-        } else {
-            roaringBitmap.and(fromBitSet(set));
-        }
-    }
-
-    @Override
-    public void or(BitSet set) {
-        if (set instanceof RoaringBitSet) {
-            roaringBitmap.or(((RoaringBitSet) set).roaringBitmap);
-        } else {
-            roaringBitmap.or(fromBitSet(set));
-        }
-    }
-
-    @Override
-    public void xor(BitSet set) {
-        if (set instanceof RoaringBitSet) {
-            roaringBitmap.xor(((RoaringBitSet) set).roaringBitmap);
-        } else {
-            roaringBitmap.xor(fromBitSet(set));
-        }
-    }
-
-    @Override
-    public void andNot(BitSet set) {
-        if (set instanceof RoaringBitSet) {
-            roaringBitmap.andNot(((RoaringBitSet) set).roaringBitmap);
-        } else {
-            roaringBitmap.andNot(fromBitSet(set));
-        }
-    }
-
-    @Override
-    public int hashCode() {
-        return roaringBitmap.hashCode();
-    }
-
-    @Override
-    public int size() {
-        if (roaringBitmap.isEmpty()) {
-            return 0;
-        }
-        int lastBit = Math.max(length(), 64);
-        int remainder = lastBit % 64;
-        return remainder == 0 ? lastBit : lastBit + 64 - remainder;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == this) {
-            return true;
-        }
-        if (obj instanceof RoaringBitSet) {
-            return roaringBitmap.equals(((RoaringBitSet) obj).roaringBitmap);
-        }
-        if (obj instanceof BitSet) {
-            return roaringBitmap.equals(fromBitSet((BitSet) obj));
-        }
-        return false;
-    }
-
-    @Override
-    public Object clone() {
-        super.clone();
-        return new RoaringBitSet(roaringBitmap.clone());
-    }
+  @Override
+  public Object clone() {
+    super.clone();
+    return new RoaringBitSet(roaringBitmap.clone());
+  }
 
 
-    @Override
-    public IntStream stream() {
-        return roaringBitmap.stream();
-    }
+  @Override
+  public IntStream stream() {
+    return roaringBitmap.stream();
+  }
 
-    @Override
-    public String toString() {
-        return roaringBitmap.toString();
-    }
+  @Override
+  public String toString() {
+    return roaringBitmap.toString();
+  }
 
-    @Override
-    @SuppressWarnings("deprecation")
-    public void flip(int bitIndex) {
-        roaringBitmap.flip(bitIndex, bitIndex + 1);
-    }
+  @Override
+  @SuppressWarnings("deprecation")
+  public void flip(int bitIndex) {
+    roaringBitmap.flip(bitIndex, bitIndex + 1);
+  }
 
-    @Override
-    @SuppressWarnings("deprecation")
-    public void flip(int fromIndex, int toIndex) {
-        roaringBitmap.flip(fromIndex, toIndex);
-    }
+  @Override
+  @SuppressWarnings("deprecation")
+  public void flip(int fromIndex, int toIndex) {
+    roaringBitmap.flip(fromIndex, toIndex);
+  }
 
-    @Override
-    public long[] toLongArray() {
-        return BitSetUtil.toLongArray(roaringBitmap);
-    }
+  @Override
+  public long[] toLongArray() {
+    return BitSetUtil.toLongArray(roaringBitmap);
+  }
 
-    @Override
-    public byte[] toByteArray() {
-        return BitSetUtil.toByteArray(roaringBitmap);
-    }
+  @Override
+  public byte[] toByteArray() {
+    return BitSetUtil.toByteArray(roaringBitmap);
+  }
 
-    private static RoaringBitmap fromBitSet(BitSet bitSet) {
-        return BitSetUtil.bitmapOf(bitSet);
-    }
+  private static RoaringBitmap fromBitSet(BitSet bitSet) {
+    return BitSetUtil.bitmapOf(bitSet);
+  }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitSetTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitSetTest.java
@@ -9,904 +9,904 @@ import org.junit.jupiter.api.Test;
 // From https://github.com/openjdk/jdk/blob/master/test/jdk/java/util/BitSet/BSMethods.java
 @SuppressWarnings("all")
 public class RoaringBitSetTest {
-    private static Random generator = new Random();
+  private static Random generator = new Random();
 
-    @Test
-    public void testSetGetClearFlip() {
-        int failCount = 0;
+  @Test
+  public void testSetGetClearFlip() {
+    int failCount = 0;
 
-        for (int i = 0; i < 100; i++) {
-            RoaringBitSet testSet = new RoaringBitSet();
-            HashSet<Integer> history = new HashSet<>();
+    for (int i = 0; i < 100; i++) {
+      RoaringBitSet testSet = new RoaringBitSet();
+      HashSet<Integer> history = new HashSet<>();
 
-            // Set a random number of bits in random places
-            // up to a random maximum
-            int nextBitToSet = 0;
-            int numberOfSetBits = generator.nextInt(100) + 1;
-            int highestPossibleSetBit = generator.nextInt(1000) + 1;
-            for (int x = 0; x < numberOfSetBits; x++) {
-                nextBitToSet = generator.nextInt(highestPossibleSetBit);
-                history.add(Integer.valueOf(nextBitToSet));
-                testSet.set(nextBitToSet);
-            }
+      // Set a random number of bits in random places
+      // up to a random maximum
+      int nextBitToSet = 0;
+      int numberOfSetBits = generator.nextInt(100) + 1;
+      int highestPossibleSetBit = generator.nextInt(1000) + 1;
+      for (int x = 0; x < numberOfSetBits; x++) {
+        nextBitToSet = generator.nextInt(highestPossibleSetBit);
+        history.add(Integer.valueOf(nextBitToSet));
+        testSet.set(nextBitToSet);
+      }
 
-            // Make sure each bit is set appropriately
-            for (int x = 0; x < highestPossibleSetBit; x++) {
-                if (testSet.get(x) != history.contains(Integer.valueOf(x)))
-                    failCount++;
-            }
+      // Make sure each bit is set appropriately
+      for (int x = 0; x < highestPossibleSetBit; x++) {
+        if (testSet.get(x) != history.contains(Integer.valueOf(x)))
+          failCount++;
+      }
 
-            // Clear the bits
-            Iterator<Integer> setBitIterator = history.iterator();
-            while (setBitIterator.hasNext()) {
-                Integer setBit = setBitIterator.next();
-                testSet.clear(setBit.intValue());
-            }
+      // Clear the bits
+      Iterator<Integer> setBitIterator = history.iterator();
+      while (setBitIterator.hasNext()) {
+        Integer setBit = setBitIterator.next();
+        testSet.clear(setBit.intValue());
+      }
 
-            // Verify they were cleared
-            for (int x = 0; x < highestPossibleSetBit; x++)
-                if (testSet.get(x))
-                    failCount++;
-            if (testSet.length() != 0)
-                failCount++;
+      // Verify they were cleared
+      for (int x = 0; x < highestPossibleSetBit; x++)
+        if (testSet.get(x))
+          failCount++;
+      if (testSet.length() != 0)
+        failCount++;
 
-            // Set them with set(int, boolean)
-            setBitIterator = history.iterator();
-            while (setBitIterator.hasNext()) {
-                Integer setBit = setBitIterator.next();
-                testSet.set(setBit.intValue(), true);
-            }
+      // Set them with set(int, boolean)
+      setBitIterator = history.iterator();
+      while (setBitIterator.hasNext()) {
+        Integer setBit = setBitIterator.next();
+        testSet.set(setBit.intValue(), true);
+      }
 
-            // Make sure each bit is set appropriately
-            for (int x = 0; x < highestPossibleSetBit; x++) {
-                if (testSet.get(x) != history.contains(Integer.valueOf(x)))
-                    failCount++;
-            }
+      // Make sure each bit is set appropriately
+      for (int x = 0; x < highestPossibleSetBit; x++) {
+        if (testSet.get(x) != history.contains(Integer.valueOf(x)))
+          failCount++;
+      }
 
-            // Clear them with set(int, boolean)
-            setBitIterator = history.iterator();
-            while (setBitIterator.hasNext()) {
-                Integer setBit = setBitIterator.next();
-                testSet.set(setBit.intValue(), false);
-            }
+      // Clear them with set(int, boolean)
+      setBitIterator = history.iterator();
+      while (setBitIterator.hasNext()) {
+        Integer setBit = setBitIterator.next();
+        testSet.set(setBit.intValue(), false);
+      }
 
-            // Verify they were cleared
-            for (int x = 0; x < highestPossibleSetBit; x++)
-                if (testSet.get(x))
-                    failCount++;
-            if (testSet.length() != 0)
-                failCount++;
+      // Verify they were cleared
+      for (int x = 0; x < highestPossibleSetBit; x++)
+        if (testSet.get(x))
+          failCount++;
+      if (testSet.length() != 0)
+        failCount++;
 
-            // Flip them on
-            setBitIterator = history.iterator();
-            while (setBitIterator.hasNext()) {
-                Integer setBit = setBitIterator.next();
-                testSet.flip(setBit.intValue());
-            }
+      // Flip them on
+      setBitIterator = history.iterator();
+      while (setBitIterator.hasNext()) {
+        Integer setBit = setBitIterator.next();
+        testSet.flip(setBit.intValue());
+      }
 
-            // Verify they were flipped
-            for (int x = 0; x < highestPossibleSetBit; x++) {
-                if (testSet.get(x) != history.contains(Integer.valueOf(x)))
-                    failCount++;
-            }
+      // Verify they were flipped
+      for (int x = 0; x < highestPossibleSetBit; x++) {
+        if (testSet.get(x) != history.contains(Integer.valueOf(x)))
+          failCount++;
+      }
 
-            // Flip them off
-            setBitIterator = history.iterator();
-            while (setBitIterator.hasNext()) {
-                Integer setBit = setBitIterator.next();
-                testSet.flip(setBit.intValue());
-            }
+      // Flip them off
+      setBitIterator = history.iterator();
+      while (setBitIterator.hasNext()) {
+        Integer setBit = setBitIterator.next();
+        testSet.flip(setBit.intValue());
+      }
 
-            // Verify they were flipped
-            for (int x = 0; x < highestPossibleSetBit; x++)
-                if (testSet.get(x))
-                    failCount++;
-            if (testSet.length() != 0)
-                failCount++;
+      // Verify they were flipped
+      for (int x = 0; x < highestPossibleSetBit; x++)
+        if (testSet.get(x))
+          failCount++;
+      if (testSet.length() != 0)
+        failCount++;
 
-            checkSanity(testSet);
-        }
-
-        Assertions.assertEquals(failCount, 0);
+      checkSanity(testSet);
     }
 
-    @Test
-    public void testClear() {
-        int failCount = 0;
+    Assertions.assertEquals(failCount, 0);
+  }
 
-        for (int i = 0; i < 1000; i++) {
-            RoaringBitSet b1 = new RoaringBitSet();
+  @Test
+  public void testClear() {
+    int failCount = 0;
 
-            // Make a fairly random bitset
-            int numberOfSetBits = generator.nextInt(100) + 1;
-            int highestPossibleSetBit = generator.nextInt(1000) + 1;
+    for (int i = 0; i < 1000; i++) {
+      RoaringBitSet b1 = new RoaringBitSet();
 
-            for (int x = 0; x < numberOfSetBits; x++)
-                b1.set(generator.nextInt(highestPossibleSetBit));
+      // Make a fairly random bitset
+      int numberOfSetBits = generator.nextInt(100) + 1;
+      int highestPossibleSetBit = generator.nextInt(1000) + 1;
 
-            RoaringBitSet b2 = (RoaringBitSet) b1.clone();
+      for (int x = 0; x < numberOfSetBits; x++)
+        b1.set(generator.nextInt(highestPossibleSetBit));
 
-            // Clear out a random range
-            int rangeStart = generator.nextInt(100);
-            int rangeEnd = rangeStart + generator.nextInt(100);
+      RoaringBitSet b2 = (RoaringBitSet) b1.clone();
 
-            // Use the clear(int, int) call on b1
-            b1.clear(rangeStart, rangeEnd);
+      // Clear out a random range
+      int rangeStart = generator.nextInt(100);
+      int rangeEnd = rangeStart + generator.nextInt(100);
 
-            // Use a loop on b2
-            for (int x = rangeStart; x < rangeEnd; x++)
-                b2.clear(x);
+      // Use the clear(int, int) call on b1
+      b1.clear(rangeStart, rangeEnd);
 
-            // Verify their equality
-            if (!b1.equals(b2)) {
-                failCount++;
-            }
-            checkEquality(b1, b2);
-        }
+      // Use a loop on b2
+      for (int x = rangeStart; x < rangeEnd; x++)
+        b2.clear(x);
 
-        Assertions.assertEquals(failCount, 0);
+      // Verify their equality
+      if (!b1.equals(b2)) {
+        failCount++;
+      }
+      checkEquality(b1, b2);
     }
 
-    @Test
-    public void testFlip() {
-        int failCount = 0;
+    Assertions.assertEquals(failCount, 0);
+  }
 
-        for (int i = 0; i < 1000; i++) {
-            RoaringBitSet b1 = new RoaringBitSet();
+  @Test
+  public void testFlip() {
+    int failCount = 0;
 
-            // Make a fairly random bitset
-            int numberOfSetBits = generator.nextInt(100) + 1;
-            int highestPossibleSetBit = generator.nextInt(1000) + 1;
+    for (int i = 0; i < 1000; i++) {
+      RoaringBitSet b1 = new RoaringBitSet();
 
-            for (int x = 0; x < numberOfSetBits; x++)
-                b1.set(generator.nextInt(highestPossibleSetBit));
+      // Make a fairly random bitset
+      int numberOfSetBits = generator.nextInt(100) + 1;
+      int highestPossibleSetBit = generator.nextInt(1000) + 1;
 
-            RoaringBitSet b2 = (RoaringBitSet) b1.clone();
+      for (int x = 0; x < numberOfSetBits; x++)
+        b1.set(generator.nextInt(highestPossibleSetBit));
 
-            // Flip a random range
-            int rangeStart = generator.nextInt(100);
-            int rangeEnd = rangeStart + generator.nextInt(100);
+      RoaringBitSet b2 = (RoaringBitSet) b1.clone();
 
-            // Use the flip(int, int) call on b1
-            b1.flip(rangeStart, rangeEnd);
+      // Flip a random range
+      int rangeStart = generator.nextInt(100);
+      int rangeEnd = rangeStart + generator.nextInt(100);
 
-            // Use a loop on b2
-            for (int x = rangeStart; x < rangeEnd; x++)
-                b2.flip(x);
+      // Use the flip(int, int) call on b1
+      b1.flip(rangeStart, rangeEnd);
 
-            // Verify their equality
-            if (!b1.equals(b2))
-                failCount++;
-            checkEquality(b1, b2);
-        }
+      // Use a loop on b2
+      for (int x = rangeStart; x < rangeEnd; x++)
+        b2.flip(x);
 
-        Assertions.assertEquals(failCount, 0);
+      // Verify their equality
+      if (!b1.equals(b2))
+        failCount++;
+      checkEquality(b1, b2);
     }
 
-    @Test
-    public void testSet() {
-        int failCount = 0;
+    Assertions.assertEquals(failCount, 0);
+  }
 
-        // Test set(int, int)
-        for (int i = 0; i < 1000; i++) {
-            RoaringBitSet b1 = new RoaringBitSet();
+  @Test
+  public void testSet() {
+    int failCount = 0;
 
-            // Make a fairly random bitset
-            int numberOfSetBits = generator.nextInt(100) + 1;
-            int highestPossibleSetBit = generator.nextInt(1000) + 1;
+    // Test set(int, int)
+    for (int i = 0; i < 1000; i++) {
+      RoaringBitSet b1 = new RoaringBitSet();
 
-            for (int x = 0; x < numberOfSetBits; x++)
-                b1.set(generator.nextInt(highestPossibleSetBit));
+      // Make a fairly random bitset
+      int numberOfSetBits = generator.nextInt(100) + 1;
+      int highestPossibleSetBit = generator.nextInt(1000) + 1;
 
-            RoaringBitSet b2 = (RoaringBitSet) b1.clone();
+      for (int x = 0; x < numberOfSetBits; x++)
+        b1.set(generator.nextInt(highestPossibleSetBit));
 
-            // Set a random range
-            int rangeStart = generator.nextInt(100);
-            int rangeEnd = rangeStart + generator.nextInt(100);
+      RoaringBitSet b2 = (RoaringBitSet) b1.clone();
 
-            // Use the set(int, int) call on b1
-            b1.set(rangeStart, rangeEnd);
+      // Set a random range
+      int rangeStart = generator.nextInt(100);
+      int rangeEnd = rangeStart + generator.nextInt(100);
 
-            // Use a loop on b2
-            for (int x = rangeStart; x < rangeEnd; x++)
-                b2.set(x);
+      // Use the set(int, int) call on b1
+      b1.set(rangeStart, rangeEnd);
 
-            // Verify their equality
-            if (!b1.equals(b2)) {
-                failCount++;
-            }
-            checkEquality(b1, b2);
-        }
+      // Use a loop on b2
+      for (int x = rangeStart; x < rangeEnd; x++)
+        b2.set(x);
 
-        // Test set(int, int, boolean)
-        for (int i = 0; i < 100; i++) {
-            RoaringBitSet b1 = new RoaringBitSet();
-
-            // Make a fairly random bitset
-            int numberOfSetBits = generator.nextInt(100) + 1;
-            int highestPossibleSetBit = generator.nextInt(1000) + 1;
-
-            for (int x = 0; x < numberOfSetBits; x++)
-                b1.set(generator.nextInt(highestPossibleSetBit));
-
-            RoaringBitSet b2 = (RoaringBitSet) b1.clone();
-            boolean setOrClear = generator.nextBoolean();
-
-            // Set a random range
-            int rangeStart = generator.nextInt(100);
-            int rangeEnd = rangeStart + generator.nextInt(100);
-
-            // Use the set(int, int, boolean) call on b1
-            b1.set(rangeStart, rangeEnd, setOrClear);
-
-            // Use a loop on b2
-            for (int x = rangeStart; x < rangeEnd; x++)
-                b2.set(x, setOrClear);
-
-            // Verify their equality
-            if (!b1.equals(b2)) {
-                failCount++;
-            }
-            checkEquality(b1, b2);
-        }
-
-        Assertions.assertEquals(failCount, 0);
+      // Verify their equality
+      if (!b1.equals(b2)) {
+        failCount++;
+      }
+      checkEquality(b1, b2);
     }
 
-    @Test
-    public void testGet() {
-        int failCount = 0;
+    // Test set(int, int, boolean)
+    for (int i = 0; i < 100; i++) {
+      RoaringBitSet b1 = new RoaringBitSet();
 
-        for (int i = 0; i < 1000; i++) {
-            RoaringBitSet b1 = new RoaringBitSet();
+      // Make a fairly random bitset
+      int numberOfSetBits = generator.nextInt(100) + 1;
+      int highestPossibleSetBit = generator.nextInt(1000) + 1;
 
-            // Make a fairly random bitset
-            int numberOfSetBits = generator.nextInt(100) + 1;
-            int highestPossibleSetBit = generator.nextInt(1000) + 1;
+      for (int x = 0; x < numberOfSetBits; x++)
+        b1.set(generator.nextInt(highestPossibleSetBit));
 
-            for (int x = 0; x < numberOfSetBits; x++)
-                b1.set(generator.nextInt(highestPossibleSetBit));
+      RoaringBitSet b2 = (RoaringBitSet) b1.clone();
+      boolean setOrClear = generator.nextBoolean();
 
-            // Get a new set from a random range
-            int rangeStart = generator.nextInt(100);
-            int rangeEnd = rangeStart + generator.nextInt(100);
+      // Set a random range
+      int rangeStart = generator.nextInt(100);
+      int rangeEnd = rangeStart + generator.nextInt(100);
 
-            RoaringBitSet b2 = (RoaringBitSet) b1.get(rangeStart, rangeEnd);
+      // Use the set(int, int, boolean) call on b1
+      b1.set(rangeStart, rangeEnd, setOrClear);
 
-            RoaringBitSet b3 = new RoaringBitSet();
-            for (int x = rangeStart; x < rangeEnd; x++)
-                b3.set(x - rangeStart, b1.get(x));
+      // Use a loop on b2
+      for (int x = rangeStart; x < rangeEnd; x++)
+        b2.set(x, setOrClear);
 
-            // Verify their equality
-            if (!b2.equals(b3)) {
-                failCount++;
-            }
-            checkEquality(b2, b3);
-        }
-
-        Assertions.assertEquals(failCount, 0);
+      // Verify their equality
+      if (!b1.equals(b2)) {
+        failCount++;
+      }
+      checkEquality(b1, b2);
     }
 
-    @Test
-    public void testAndNot() {
-        int failCount = 0;
+    Assertions.assertEquals(failCount, 0);
+  }
 
-        for (int i = 0; i < 100; i++) {
-            RoaringBitSet b1 = new RoaringBitSet();
-            RoaringBitSet b2 = new RoaringBitSet();
+  @Test
+  public void testGet() {
+    int failCount = 0;
 
-            // Set some random bits in first set and remember them
-            int nextBitToSet = 0;
-            for (int x = 0; x < 10; x++)
-                b1.set(generator.nextInt(255));
+    for (int i = 0; i < 1000; i++) {
+      RoaringBitSet b1 = new RoaringBitSet();
 
-            // Set some random bits in second set and remember them
-            for (int x = 10; x < 20; x++)
-                b2.set(generator.nextInt(255));
+      // Make a fairly random bitset
+      int numberOfSetBits = generator.nextInt(100) + 1;
+      int highestPossibleSetBit = generator.nextInt(1000) + 1;
 
-            // andNot the sets together
-            RoaringBitSet b3 = (RoaringBitSet) b1.clone();
-            b3.andNot(b2);
+      for (int x = 0; x < numberOfSetBits; x++)
+        b1.set(generator.nextInt(highestPossibleSetBit));
 
-            // Examine each bit of b3 for errors
-            for (int x = 0; x < 256; x++) {
-                boolean bit1 = b1.get(x);
-                boolean bit2 = b2.get(x);
-                boolean bit3 = b3.get(x);
-                if (!(bit3 == (bit1 & (!bit2))))
-                    failCount++;
-            }
-            checkSanity(b1, b2, b3);
-        }
-        Assertions.assertEquals(failCount, 0);
+      // Get a new set from a random range
+      int rangeStart = generator.nextInt(100);
+      int rangeEnd = rangeStart + generator.nextInt(100);
+
+      RoaringBitSet b2 = (RoaringBitSet) b1.get(rangeStart, rangeEnd);
+
+      RoaringBitSet b3 = new RoaringBitSet();
+      for (int x = rangeStart; x < rangeEnd; x++)
+        b3.set(x - rangeStart, b1.get(x));
+
+      // Verify their equality
+      if (!b2.equals(b3)) {
+        failCount++;
+      }
+      checkEquality(b2, b3);
     }
 
-    @Test
-    public void testAnd() {
-        int failCount = 0;
+    Assertions.assertEquals(failCount, 0);
+  }
 
-        for (int i = 0; i < 100; i++) {
-            RoaringBitSet b1 = new RoaringBitSet();
-            RoaringBitSet b2 = new RoaringBitSet();
+  @Test
+  public void testAndNot() {
+    int failCount = 0;
 
-            // Set some random bits in first set and remember them
-            int nextBitToSet = 0;
-            for (int x = 0; x < 10; x++)
-                b1.set(generator.nextInt(255));
+    for (int i = 0; i < 100; i++) {
+      RoaringBitSet b1 = new RoaringBitSet();
+      RoaringBitSet b2 = new RoaringBitSet();
 
-            // Set more random bits in second set and remember them
-            for (int x = 10; x < 20; x++)
-                b2.set(generator.nextInt(255));
+      // Set some random bits in first set and remember them
+      int nextBitToSet = 0;
+      for (int x = 0; x < 10; x++)
+        b1.set(generator.nextInt(255));
 
-            // And the sets together
-            RoaringBitSet b3 = (RoaringBitSet) b1.clone();
-            b3.and(b2);
+      // Set some random bits in second set and remember them
+      for (int x = 10; x < 20; x++)
+        b2.set(generator.nextInt(255));
 
-            // Examine each bit of b3 for errors
-            for (int x = 0; x < 256; x++) {
-                boolean bit1 = b1.get(x);
-                boolean bit2 = b2.get(x);
-                boolean bit3 = b3.get(x);
-                if (!(bit3 == (bit1 & bit2)))
-                    failCount++;
-            }
-            checkSanity(b1, b2, b3);
-        }
+      // andNot the sets together
+      RoaringBitSet b3 = (RoaringBitSet) b1.clone();
+      b3.andNot(b2);
 
-        // `and' that happens to clear the last word
-        RoaringBitSet b4 = makeSet(2, 127);
-        b4.and(makeSet(2, 64));
-        checkSanity(b4);
-        if (!(b4.equals(makeSet(2))))
-            failCount++;
+      // Examine each bit of b3 for errors
+      for (int x = 0; x < 256; x++) {
+        boolean bit1 = b1.get(x);
+        boolean bit2 = b2.get(x);
+        boolean bit3 = b3.get(x);
+        if (!(bit3 == (bit1 & (!bit2))))
+          failCount++;
+      }
+      checkSanity(b1, b2, b3);
+    }
+    Assertions.assertEquals(failCount, 0);
+  }
 
-        Assertions.assertEquals(failCount, 0);
+  @Test
+  public void testAnd() {
+    int failCount = 0;
+
+    for (int i = 0; i < 100; i++) {
+      RoaringBitSet b1 = new RoaringBitSet();
+      RoaringBitSet b2 = new RoaringBitSet();
+
+      // Set some random bits in first set and remember them
+      int nextBitToSet = 0;
+      for (int x = 0; x < 10; x++)
+        b1.set(generator.nextInt(255));
+
+      // Set more random bits in second set and remember them
+      for (int x = 10; x < 20; x++)
+        b2.set(generator.nextInt(255));
+
+      // And the sets together
+      RoaringBitSet b3 = (RoaringBitSet) b1.clone();
+      b3.and(b2);
+
+      // Examine each bit of b3 for errors
+      for (int x = 0; x < 256; x++) {
+        boolean bit1 = b1.get(x);
+        boolean bit2 = b2.get(x);
+        boolean bit3 = b3.get(x);
+        if (!(bit3 == (bit1 & bit2)))
+          failCount++;
+      }
+      checkSanity(b1, b2, b3);
     }
 
-    @Test
-    public void testOr() {
-        int failCount = 0;
+    // `and' that happens to clear the last word
+    RoaringBitSet b4 = makeSet(2, 127);
+    b4.and(makeSet(2, 64));
+    checkSanity(b4);
+    if (!(b4.equals(makeSet(2))))
+      failCount++;
 
-        for (int i = 0; i < 100; i++) {
-            RoaringBitSet b1 = new RoaringBitSet();
-            RoaringBitSet b2 = new RoaringBitSet();
-            int[] history = new int[20];
+    Assertions.assertEquals(failCount, 0);
+  }
 
-            // Set some random bits in first set and remember them
-            int nextBitToSet = 0;
-            for (int x = 0; x < 10; x++) {
-                nextBitToSet = generator.nextInt(255);
-                history[x] = nextBitToSet;
-                b1.set(nextBitToSet);
-            }
+  @Test
+  public void testOr() {
+    int failCount = 0;
 
-            // Set more random bits in second set and remember them
-            for (int x = 10; x < 20; x++) {
-                nextBitToSet = generator.nextInt(255);
-                history[x] = nextBitToSet;
-                b2.set(nextBitToSet);
-            }
+    for (int i = 0; i < 100; i++) {
+      RoaringBitSet b1 = new RoaringBitSet();
+      RoaringBitSet b2 = new RoaringBitSet();
+      int[] history = new int[20];
 
-            // Or the sets together
-            RoaringBitSet b3 = (RoaringBitSet) b1.clone();
-            b3.or(b2);
+      // Set some random bits in first set and remember them
+      int nextBitToSet = 0;
+      for (int x = 0; x < 10; x++) {
+        nextBitToSet = generator.nextInt(255);
+        history[x] = nextBitToSet;
+        b1.set(nextBitToSet);
+      }
 
-            // Verify the set bits of b3 from the history
-            int historyIndex = 0;
-            for (int x = 0; x < 20; x++) {
-                if (!b3.get(history[x]))
-                    failCount++;
-            }
+      // Set more random bits in second set and remember them
+      for (int x = 10; x < 20; x++) {
+        nextBitToSet = generator.nextInt(255);
+        history[x] = nextBitToSet;
+        b2.set(nextBitToSet);
+      }
 
-            // Examine each bit of b3 for errors
-            for (int x = 0; x < 256; x++) {
-                boolean bit1 = b1.get(x);
-                boolean bit2 = b2.get(x);
-                boolean bit3 = b3.get(x);
-                if (!(bit3 == (bit1 | bit2)))
-                    failCount++;
-            }
-            checkSanity(b1, b2, b3);
-        }
-        Assertions.assertEquals(failCount, 0);
+      // Or the sets together
+      RoaringBitSet b3 = (RoaringBitSet) b1.clone();
+      b3.or(b2);
+
+      // Verify the set bits of b3 from the history
+      int historyIndex = 0;
+      for (int x = 0; x < 20; x++) {
+        if (!b3.get(history[x]))
+          failCount++;
+      }
+
+      // Examine each bit of b3 for errors
+      for (int x = 0; x < 256; x++) {
+        boolean bit1 = b1.get(x);
+        boolean bit2 = b2.get(x);
+        boolean bit3 = b3.get(x);
+        if (!(bit3 == (bit1 | bit2)))
+          failCount++;
+      }
+      checkSanity(b1, b2, b3);
+    }
+    Assertions.assertEquals(failCount, 0);
+  }
+
+  @Test
+  public void testXor() {
+    int failCount = 0;
+
+    for (int i = 0; i < 100; i++) {
+      RoaringBitSet b1 = new RoaringBitSet();
+      RoaringBitSet b2 = new RoaringBitSet();
+
+      // Set some random bits in first set and remember them
+      int nextBitToSet = 0;
+      for (int x = 0; x < 10; x++)
+        b1.set(generator.nextInt(255));
+
+      // Set more random bits in second set and remember them
+      for (int x = 10; x < 20; x++)
+        b2.set(generator.nextInt(255));
+
+      // Xor the sets together
+      RoaringBitSet b3 = (RoaringBitSet) b1.clone();
+      b3.xor(b2);
+
+      // Examine each bit of b3 for errors
+      for (int x = 0; x < 256; x++) {
+        boolean bit1 = b1.get(x);
+        boolean bit2 = b2.get(x);
+        boolean bit3 = b3.get(x);
+        if (!(bit3 == (bit1 ^ bit2)))
+          failCount++;
+      }
+      checkSanity(b1, b2, b3);
+      b3.xor(b3);
+      checkEmpty(b3);
     }
 
-    @Test
-    public void testXor() {
-        int failCount = 0;
+    // xor that happens to clear the last word
+    RoaringBitSet b4 = makeSet(2, 64, 127);
+    b4.xor(makeSet(64, 127));
+    checkSanity(b4);
+    if (!(b4.equals(makeSet(2))))
+      failCount++;
 
-        for (int i = 0; i < 100; i++) {
-            RoaringBitSet b1 = new RoaringBitSet();
-            RoaringBitSet b2 = new RoaringBitSet();
+    Assertions.assertEquals(failCount, 0);
+  }
 
-            // Set some random bits in first set and remember them
-            int nextBitToSet = 0;
-            for (int x = 0; x < 10; x++)
-                b1.set(generator.nextInt(255));
+  @Test
+  public void testLength() {
+    int failCount = 0;
 
-            // Set more random bits in second set and remember them
-            for (int x = 10; x < 20; x++)
-                b2.set(generator.nextInt(255));
+    // Test length after set
+    for (int i = 0; i < 100; i++) {
+      RoaringBitSet b1 = new RoaringBitSet();
+      int highestSetBit = 0;
 
-            // Xor the sets together
-            RoaringBitSet b3 = (RoaringBitSet) b1.clone();
-            b3.xor(b2);
-
-            // Examine each bit of b3 for errors
-            for (int x = 0; x < 256; x++) {
-                boolean bit1 = b1.get(x);
-                boolean bit2 = b2.get(x);
-                boolean bit3 = b3.get(x);
-                if (!(bit3 == (bit1 ^ bit2)))
-                    failCount++;
-            }
-            checkSanity(b1, b2, b3);
-            b3.xor(b3);
-            checkEmpty(b3);
-        }
-
-        // xor that happens to clear the last word
-        RoaringBitSet b4 = makeSet(2, 64, 127);
-        b4.xor(makeSet(64, 127));
-        checkSanity(b4);
-        if (!(b4.equals(makeSet(2))))
-            failCount++;
-
-        Assertions.assertEquals(failCount, 0);
+      for (int x = 0; x < 100; x++) {
+        int nextBitToSet = generator.nextInt(255);
+        if (nextBitToSet > highestSetBit)
+          highestSetBit = nextBitToSet;
+        b1.set(nextBitToSet);
+        if (b1.length() != highestSetBit + 1)
+          failCount++;
+      }
+      checkSanity(b1);
     }
 
-    @Test
-    public void testLength() {
-        int failCount = 0;
-
-        // Test length after set
-        for (int i = 0; i < 100; i++) {
-            RoaringBitSet b1 = new RoaringBitSet();
-            int highestSetBit = 0;
-
-            for (int x = 0; x < 100; x++) {
-                int nextBitToSet = generator.nextInt(255);
-                if (nextBitToSet > highestSetBit)
-                    highestSetBit = nextBitToSet;
-                b1.set(nextBitToSet);
-                if (b1.length() != highestSetBit + 1)
-                    failCount++;
-            }
-            checkSanity(b1);
-        }
-
-        // Test length after flip
-        for (int i = 0; i < 100; i++) {
-            RoaringBitSet b1 = new RoaringBitSet();
-            for (int x = 0; x < 100; x++) {
-                // Flip a random range twice
-                int rangeStart = generator.nextInt(100);
-                int rangeEnd = rangeStart + generator.nextInt(100);
-                b1.flip(rangeStart);
-                b1.flip(rangeStart);
-                if (b1.length() != 0)
-                    failCount++;
-                b1.flip(rangeStart, rangeEnd);
-                b1.flip(rangeStart, rangeEnd);
-                if (b1.length() != 0)
-                    failCount++;
-            }
-            checkSanity(b1);
-        }
-
-        // Test length after or
-        for (int i = 0; i < 100; i++) {
-            RoaringBitSet b1 = new RoaringBitSet();
-            RoaringBitSet b2 = new RoaringBitSet();
-            int bit1 = generator.nextInt(100);
-            int bit2 = generator.nextInt(100);
-            int highestSetBit = (bit1 > bit2) ? bit1 : bit2;
-            b1.set(bit1);
-            b2.set(bit2);
-            b1.or(b2);
-            if (b1.length() != highestSetBit + 1)
-                failCount++;
-            checkSanity(b1, b2);
-        }
-        Assertions.assertEquals(failCount, 0);
+    // Test length after flip
+    for (int i = 0; i < 100; i++) {
+      RoaringBitSet b1 = new RoaringBitSet();
+      for (int x = 0; x < 100; x++) {
+        // Flip a random range twice
+        int rangeStart = generator.nextInt(100);
+        int rangeEnd = rangeStart + generator.nextInt(100);
+        b1.flip(rangeStart);
+        b1.flip(rangeStart);
+        if (b1.length() != 0)
+          failCount++;
+        b1.flip(rangeStart, rangeEnd);
+        b1.flip(rangeStart, rangeEnd);
+        if (b1.length() != 0)
+          failCount++;
+      }
+      checkSanity(b1);
     }
 
-    @Test
-    public void testEquals() {
-        int failCount = 0;
+    // Test length after or
+    for (int i = 0; i < 100; i++) {
+      RoaringBitSet b1 = new RoaringBitSet();
+      RoaringBitSet b2 = new RoaringBitSet();
+      int bit1 = generator.nextInt(100);
+      int bit2 = generator.nextInt(100);
+      int highestSetBit = (bit1 > bit2) ? bit1 : bit2;
+      b1.set(bit1);
+      b2.set(bit2);
+      b1.or(b2);
+      if (b1.length() != highestSetBit + 1)
+        failCount++;
+      checkSanity(b1, b2);
+    }
+    Assertions.assertEquals(failCount, 0);
+  }
 
-        for (int i = 0; i < 100; i++) {
-            // Create BitSets of different sizes
-            RoaringBitSet b1 = new RoaringBitSet();
-            RoaringBitSet b2 = new RoaringBitSet();
+  @Test
+  public void testEquals() {
+    int failCount = 0;
 
-            // Set some random bits
-            int nextBitToSet = 0;
-            for (int x = 0; x < 10; x++) {
-                nextBitToSet += generator.nextInt(50) + 1;
-                b1.set(nextBitToSet);
-                b2.set(nextBitToSet);
-            }
+    for (int i = 0; i < 100; i++) {
+      // Create BitSets of different sizes
+      RoaringBitSet b1 = new RoaringBitSet();
+      RoaringBitSet b2 = new RoaringBitSet();
 
-            // Verify their equality despite different storage sizes
-            if (!b1.equals(b2))
-                failCount++;
-            checkEquality(b1, b2);
-        }
-        Assertions.assertEquals(failCount, 0);
+      // Set some random bits
+      int nextBitToSet = 0;
+      for (int x = 0; x < 10; x++) {
+        nextBitToSet += generator.nextInt(50) + 1;
+        b1.set(nextBitToSet);
+        b2.set(nextBitToSet);
+      }
+
+      // Verify their equality despite different storage sizes
+      if (!b1.equals(b2))
+        failCount++;
+      checkEquality(b1, b2);
+    }
+    Assertions.assertEquals(failCount, 0);
+  }
+
+  @Test
+  public void testNextSetBit() {
+    int failCount = 0;
+
+    for (int i = 0; i < 100; i++) {
+      int numberOfSetBits = generator.nextInt(100) + 1;
+      RoaringBitSet testSet = new RoaringBitSet();
+      int[] history = new int[numberOfSetBits];
+
+      // Set some random bits and remember them
+      int nextBitToSet = 0;
+      for (int x = 0; x < numberOfSetBits; x++) {
+        nextBitToSet += generator.nextInt(30) + 1;
+        history[x] = nextBitToSet;
+        testSet.set(nextBitToSet);
+      }
+
+      // Verify their retrieval using nextSetBit()
+      int historyIndex = 0;
+      for (int x = testSet.nextSetBit(0); x >= 0; x = testSet.nextSetBit(x + 1)) {
+        if (x != history[historyIndex++])
+          failCount++;
+      }
+
+      checkSanity(testSet);
     }
 
-    @Test
-    public void testNextSetBit() {
-        int failCount = 0;
+    Assertions.assertEquals(failCount, 0);
+  }
 
-        for (int i = 0; i < 100; i++) {
-            int numberOfSetBits = generator.nextInt(100) + 1;
-            RoaringBitSet testSet = new RoaringBitSet();
-            int[] history = new int[numberOfSetBits];
+  @Test
+  public void testNextClearBit() {
+    int failCount = 0;
 
-            // Set some random bits and remember them
-            int nextBitToSet = 0;
-            for (int x = 0; x < numberOfSetBits; x++) {
-                nextBitToSet += generator.nextInt(30) + 1;
-                history[x] = nextBitToSet;
-                testSet.set(nextBitToSet);
-            }
+    for (int i = 0; i < 1000; i++) {
+      RoaringBitSet b = new RoaringBitSet();
+      int[] history = new int[10];
 
-            // Verify their retrieval using nextSetBit()
-            int historyIndex = 0;
-            for (int x = testSet.nextSetBit(0); x >= 0; x = testSet.nextSetBit(x + 1)) {
-                if (x != history[historyIndex++])
-                    failCount++;
-            }
+      // Set all the bits
+      for (int x = 0; x < 256; x++)
+        b.set(x);
 
-            checkSanity(testSet);
-        }
+      // Clear some random bits and remember them
+      int nextBitToClear = 0;
+      for (int x = 0; x < 10; x++) {
+        nextBitToClear += generator.nextInt(24) + 1;
+        history[x] = nextBitToClear;
+        b.clear(nextBitToClear);
+      }
 
-        Assertions.assertEquals(failCount, 0);
+      // Verify their retrieval using nextClearBit()
+      int historyIndex = 0;
+      for (int x = b.nextClearBit(0); x < 256; x = b.nextClearBit(x + 1)) {
+        if (x != history[historyIndex++])
+          failCount++;
+      }
+
+      checkSanity(b);
     }
 
-    @Test
-    public void testNextClearBit() {
-        int failCount = 0;
-
-        for (int i = 0; i < 1000; i++) {
-            RoaringBitSet b = new RoaringBitSet();
-            int[] history = new int[10];
-
-            // Set all the bits
-            for (int x = 0; x < 256; x++)
-                b.set(x);
-
-            // Clear some random bits and remember them
-            int nextBitToClear = 0;
-            for (int x = 0; x < 10; x++) {
-                nextBitToClear += generator.nextInt(24) + 1;
-                history[x] = nextBitToClear;
-                b.clear(nextBitToClear);
-            }
-
-            // Verify their retrieval using nextClearBit()
-            int historyIndex = 0;
-            for (int x = b.nextClearBit(0); x < 256; x = b.nextClearBit(x + 1)) {
-                if (x != history[historyIndex++])
-                    failCount++;
-            }
-
-            checkSanity(b);
-        }
-
-        // regression test for 4350178
-        RoaringBitSet bs = new RoaringBitSet();
-        if (bs.nextClearBit(0) != 0)
-            failCount++;
-        for (int i = 0; i < 64; i++) {
-            bs.set(i);
-            if (bs.nextClearBit(0) != i + 1)
-                failCount++;
-        }
-
-        checkSanity(bs);
-        Assertions.assertEquals(failCount, 0);
+    // regression test for 4350178
+    RoaringBitSet bs = new RoaringBitSet();
+    if (bs.nextClearBit(0) != 0)
+      failCount++;
+    for (int i = 0; i < 64; i++) {
+      bs.set(i);
+      if (bs.nextClearBit(0) != i + 1)
+        failCount++;
     }
 
-    @Test
-    public void testIntersects() {
-        int failCount = 0;
+    checkSanity(bs);
+    Assertions.assertEquals(failCount, 0);
+  }
 
-        for (int i = 0; i < 100; i++) {
-            RoaringBitSet b1 = new RoaringBitSet();
-            RoaringBitSet b2 = new RoaringBitSet();
+  @Test
+  public void testIntersects() {
+    int failCount = 0;
 
-            // Set some random bits in first set
-            int nextBitToSet = 0;
-            for (int x = 0; x < 30; x++) {
-                nextBitToSet = generator.nextInt(255);
-                b1.set(nextBitToSet);
-            }
+    for (int i = 0; i < 100; i++) {
+      RoaringBitSet b1 = new RoaringBitSet();
+      RoaringBitSet b2 = new RoaringBitSet();
 
-            // Set more random bits in second set
-            for (int x = 0; x < 30; x++) {
-                nextBitToSet = generator.nextInt(255);
-                b2.set(nextBitToSet);
-            }
+      // Set some random bits in first set
+      int nextBitToSet = 0;
+      for (int x = 0; x < 30; x++) {
+        nextBitToSet = generator.nextInt(255);
+        b1.set(nextBitToSet);
+      }
 
-            // Make sure they intersect
-            nextBitToSet = generator.nextInt(255);
-            b1.set(nextBitToSet);
-            b2.set(nextBitToSet);
+      // Set more random bits in second set
+      for (int x = 0; x < 30; x++) {
+        nextBitToSet = generator.nextInt(255);
+        b2.set(nextBitToSet);
+      }
 
-            if (!b1.intersects(b2))
-                failCount++;
+      // Make sure they intersect
+      nextBitToSet = generator.nextInt(255);
+      b1.set(nextBitToSet);
+      b2.set(nextBitToSet);
 
-            // Remove the common set bits
-            b1.andNot(b2);
+      if (!b1.intersects(b2))
+        failCount++;
 
-            // Make sure they don't intersect
-            if (b1.intersects(b2))
-                failCount++;
+      // Remove the common set bits
+      b1.andNot(b2);
 
-            checkSanity(b1, b2);
-        }
+      // Make sure they don't intersect
+      if (b1.intersects(b2))
+        failCount++;
 
-        Assertions.assertEquals(failCount, 0);
+      checkSanity(b1, b2);
     }
 
-    @Test
-    public void testCardinality() {
-        int failCount = 0;
+    Assertions.assertEquals(failCount, 0);
+  }
 
-        for (int i = 0; i < 100; i++) {
-            RoaringBitSet b1 = new RoaringBitSet();
+  @Test
+  public void testCardinality() {
+    int failCount = 0;
 
-            // Set a random number of increasing bits
-            int nextBitToSet = 0;
-            int iterations = generator.nextInt(20) + 1;
-            for (int x = 0; x < iterations; x++) {
-                nextBitToSet += generator.nextInt(20) + 1;
-                b1.set(nextBitToSet);
-            }
+    for (int i = 0; i < 100; i++) {
+      RoaringBitSet b1 = new RoaringBitSet();
 
-            if (b1.cardinality() != iterations) {
-                failCount++;
-            }
+      // Set a random number of increasing bits
+      int nextBitToSet = 0;
+      int iterations = generator.nextInt(20) + 1;
+      for (int x = 0; x < iterations; x++) {
+        nextBitToSet += generator.nextInt(20) + 1;
+        b1.set(nextBitToSet);
+      }
 
-            checkSanity(b1);
-        }
+      if (b1.cardinality() != iterations) {
+        failCount++;
+      }
 
-        Assertions.assertEquals(failCount, 0);
+      checkSanity(b1);
     }
 
-    @Test
-    public void testEmpty() {
-        int failCount = 0;
+    Assertions.assertEquals(failCount, 0);
+  }
 
-        RoaringBitSet b1 = new RoaringBitSet();
-        if (!b1.isEmpty())
-            failCount++;
+  @Test
+  public void testEmpty() {
+    int failCount = 0;
 
-        int nextBitToSet = 0;
-        int numberOfSetBits = generator.nextInt(100) + 1;
-        int highestPossibleSetBit = generator.nextInt(1000) + 1;
-        for (int x = 0; x < numberOfSetBits; x++) {
-            nextBitToSet = generator.nextInt(highestPossibleSetBit);
-            b1.set(nextBitToSet);
-            if (b1.isEmpty())
-                failCount++;
-            b1.clear(nextBitToSet);
-            if (!b1.isEmpty())
-                failCount++;
-        }
+    RoaringBitSet b1 = new RoaringBitSet();
+    if (!b1.isEmpty())
+      failCount++;
 
-        Assertions.assertEquals(failCount, 0);
+    int nextBitToSet = 0;
+    int numberOfSetBits = generator.nextInt(100) + 1;
+    int highestPossibleSetBit = generator.nextInt(1000) + 1;
+    for (int x = 0; x < numberOfSetBits; x++) {
+      nextBitToSet = generator.nextInt(highestPossibleSetBit);
+      b1.set(nextBitToSet);
+      if (b1.isEmpty())
+        failCount++;
+      b1.clear(nextBitToSet);
+      if (!b1.isEmpty())
+        failCount++;
     }
 
-    @Test
-    public void testEmpty2() {
-        {
-            RoaringBitSet t = new RoaringBitSet();
-            t.set(100);
-            t.clear(3, 600);
-            checkEmpty(t);
-        }
-        checkEmpty(new RoaringBitSet());
+    Assertions.assertEquals(failCount, 0);
+  }
 
-        RoaringBitSet s = new RoaringBitSet();
-        checkEmpty(s);
-        s.clear(92);
-        checkEmpty(s);
-        s.clear(127, 127);
-        checkEmpty(s);
-        s.set(127, 127);
-        checkEmpty(s);
-        s.set(128, 128);
-        checkEmpty(s);
-        RoaringBitSet empty = new RoaringBitSet();
-        {
-            RoaringBitSet t = new RoaringBitSet();
-            t.and(empty);
-            checkEmpty(t);
-        }
-        {
-            RoaringBitSet t = new RoaringBitSet();
-            t.or(empty);
-            checkEmpty(t);
-        }
-        {
-            RoaringBitSet t = new RoaringBitSet();
-            t.xor(empty);
-            checkEmpty(t);
-        }
-        {
-            RoaringBitSet t = new RoaringBitSet();
-            t.andNot(empty);
-            checkEmpty(t);
-        }
-        {
-            RoaringBitSet t = new RoaringBitSet();
-            t.and(t);
-            checkEmpty(t);
-        }
-        {
-            RoaringBitSet t = new RoaringBitSet();
-            t.or(t);
-            checkEmpty(t);
-        }
-        {
-            RoaringBitSet t = new RoaringBitSet();
-            t.xor(t);
-            checkEmpty(t);
-        }
-        {
-            RoaringBitSet t = new RoaringBitSet();
-            t.andNot(t);
-            checkEmpty(t);
-        }
-        {
-            RoaringBitSet t = new RoaringBitSet();
-            t.and(makeSet(1));
-            checkEmpty(t);
-        }
-        {
-            RoaringBitSet t = new RoaringBitSet();
-            t.and(makeSet(127));
-            checkEmpty(t);
-        }
-        {
-            RoaringBitSet t = new RoaringBitSet();
-            t.and(makeSet(128));
-            checkEmpty(t);
-        }
-        {
-            RoaringBitSet t = new RoaringBitSet();
-            t.flip(7);
-            t.flip(7);
-            checkEmpty(t);
-        }
-        {
-            RoaringBitSet t = new RoaringBitSet();
-            checkEmpty((RoaringBitSet) t.get(200, 300));
-        }
-        {
-            RoaringBitSet t = makeSet(2, 5);
-            Assertions.assertEquals(makeSet(0, 3), t.get(2, 6));
-        }
+  @Test
+  public void testEmpty2() {
+    {
+      RoaringBitSet t = new RoaringBitSet();
+      t.set(100);
+      t.clear(3, 600);
+      checkEmpty(t);
+    }
+    checkEmpty(new RoaringBitSet());
+
+    RoaringBitSet s = new RoaringBitSet();
+    checkEmpty(s);
+    s.clear(92);
+    checkEmpty(s);
+    s.clear(127, 127);
+    checkEmpty(s);
+    s.set(127, 127);
+    checkEmpty(s);
+    s.set(128, 128);
+    checkEmpty(s);
+    RoaringBitSet empty = new RoaringBitSet();
+    {
+      RoaringBitSet t = new RoaringBitSet();
+      t.and(empty);
+      checkEmpty(t);
+    }
+    {
+      RoaringBitSet t = new RoaringBitSet();
+      t.or(empty);
+      checkEmpty(t);
+    }
+    {
+      RoaringBitSet t = new RoaringBitSet();
+      t.xor(empty);
+      checkEmpty(t);
+    }
+    {
+      RoaringBitSet t = new RoaringBitSet();
+      t.andNot(empty);
+      checkEmpty(t);
+    }
+    {
+      RoaringBitSet t = new RoaringBitSet();
+      t.and(t);
+      checkEmpty(t);
+    }
+    {
+      RoaringBitSet t = new RoaringBitSet();
+      t.or(t);
+      checkEmpty(t);
+    }
+    {
+      RoaringBitSet t = new RoaringBitSet();
+      t.xor(t);
+      checkEmpty(t);
+    }
+    {
+      RoaringBitSet t = new RoaringBitSet();
+      t.andNot(t);
+      checkEmpty(t);
+    }
+    {
+      RoaringBitSet t = new RoaringBitSet();
+      t.and(makeSet(1));
+      checkEmpty(t);
+    }
+    {
+      RoaringBitSet t = new RoaringBitSet();
+      t.and(makeSet(127));
+      checkEmpty(t);
+    }
+    {
+      RoaringBitSet t = new RoaringBitSet();
+      t.and(makeSet(128));
+      checkEmpty(t);
+    }
+    {
+      RoaringBitSet t = new RoaringBitSet();
+      t.flip(7);
+      t.flip(7);
+      checkEmpty(t);
+    }
+    {
+      RoaringBitSet t = new RoaringBitSet();
+      checkEmpty((RoaringBitSet) t.get(200, 300));
+    }
+    {
+      RoaringBitSet t = makeSet(2, 5);
+      Assertions.assertEquals(makeSet(0, 3), t.get(2, 6));
+    }
+  }
+
+  @Test
+  public void testLogicalIdentities() {
+    int failCount = 0;
+
+    // Verify that (!b1)|(!b2) == !(b1&b2)
+    for (int i = 0; i < 50; i++) {
+      // Construct two fairly random bitsets
+      RoaringBitSet b1 = new RoaringBitSet();
+      RoaringBitSet b2 = new RoaringBitSet();
+
+      int numberOfSetBits = generator.nextInt(100) + 1;
+      int highestPossibleSetBit = generator.nextInt(1000) + 1;
+
+      for (int x = 0; x < numberOfSetBits; x++) {
+        b1.set(generator.nextInt(highestPossibleSetBit));
+        b2.set(generator.nextInt(highestPossibleSetBit));
+      }
+
+      RoaringBitSet b3 = (RoaringBitSet) b1.clone();
+      RoaringBitSet b4 = (RoaringBitSet) b2.clone();
+
+      for (int x = 0; x < highestPossibleSetBit; x++) {
+        b1.flip(x);
+        b2.flip(x);
+      }
+      b1.or(b2);
+      b3.and(b4);
+      for (int x = 0; x < highestPossibleSetBit; x++)
+        b3.flip(x);
+      if (!b1.equals(b3))
+        failCount++;
+      checkSanity(b1, b2, b3, b4);
     }
 
-    @Test
-    public void testLogicalIdentities() {
-        int failCount = 0;
+    // Verify that (b1&(!b2)|(b2&(!b1) == b1^b2
+    for (int i = 0; i < 50; i++) {
+      // Construct two fairly random bitsets
+      RoaringBitSet b1 = new RoaringBitSet();
+      RoaringBitSet b2 = new RoaringBitSet();
 
-        // Verify that (!b1)|(!b2) == !(b1&b2)
-        for (int i = 0; i < 50; i++) {
-            // Construct two fairly random bitsets
-            RoaringBitSet b1 = new RoaringBitSet();
-            RoaringBitSet b2 = new RoaringBitSet();
+      int numberOfSetBits = generator.nextInt(100) + 1;
+      int highestPossibleSetBit = generator.nextInt(1000) + 1;
 
-            int numberOfSetBits = generator.nextInt(100) + 1;
-            int highestPossibleSetBit = generator.nextInt(1000) + 1;
+      for (int x = 0; x < numberOfSetBits; x++) {
+        b1.set(generator.nextInt(highestPossibleSetBit));
+        b2.set(generator.nextInt(highestPossibleSetBit));
+      }
 
-            for (int x = 0; x < numberOfSetBits; x++) {
-                b1.set(generator.nextInt(highestPossibleSetBit));
-                b2.set(generator.nextInt(highestPossibleSetBit));
-            }
+      RoaringBitSet b3 = (RoaringBitSet) b1.clone();
+      RoaringBitSet b4 = (RoaringBitSet) b2.clone();
+      RoaringBitSet b5 = (RoaringBitSet) b1.clone();
+      RoaringBitSet b6 = (RoaringBitSet) b2.clone();
 
-            RoaringBitSet b3 = (RoaringBitSet) b1.clone();
-            RoaringBitSet b4 = (RoaringBitSet) b2.clone();
-
-            for (int x = 0; x < highestPossibleSetBit; x++) {
-                b1.flip(x);
-                b2.flip(x);
-            }
-            b1.or(b2);
-            b3.and(b4);
-            for (int x = 0; x < highestPossibleSetBit; x++)
-                b3.flip(x);
-            if (!b1.equals(b3))
-                failCount++;
-            checkSanity(b1, b2, b3, b4);
-        }
-
-        // Verify that (b1&(!b2)|(b2&(!b1) == b1^b2
-        for (int i = 0; i < 50; i++) {
-            // Construct two fairly random bitsets
-            RoaringBitSet b1 = new RoaringBitSet();
-            RoaringBitSet b2 = new RoaringBitSet();
-
-            int numberOfSetBits = generator.nextInt(100) + 1;
-            int highestPossibleSetBit = generator.nextInt(1000) + 1;
-
-            for (int x = 0; x < numberOfSetBits; x++) {
-                b1.set(generator.nextInt(highestPossibleSetBit));
-                b2.set(generator.nextInt(highestPossibleSetBit));
-            }
-
-            RoaringBitSet b3 = (RoaringBitSet) b1.clone();
-            RoaringBitSet b4 = (RoaringBitSet) b2.clone();
-            RoaringBitSet b5 = (RoaringBitSet) b1.clone();
-            RoaringBitSet b6 = (RoaringBitSet) b2.clone();
-
-            for (int x = 0; x < highestPossibleSetBit; x++)
-                b2.flip(x);
-            b1.and(b2);
-            for (int x = 0; x < highestPossibleSetBit; x++)
-                b3.flip(x);
-            b3.and(b4);
-            b1.or(b3);
-            b5.xor(b6);
-            if (!b1.equals(b5))
-                failCount++;
-            checkSanity(b1, b2, b3, b4, b5, b6);
-        }
-        Assertions.assertEquals(failCount, 0);
+      for (int x = 0; x < highestPossibleSetBit; x++)
+        b2.flip(x);
+      b1.and(b2);
+      for (int x = 0; x < highestPossibleSetBit; x++)
+        b3.flip(x);
+      b3.and(b4);
+      b1.or(b3);
+      b5.xor(b6);
+      if (!b1.equals(b5))
+        failCount++;
+      checkSanity(b1, b2, b3, b4, b5, b6);
     }
+    Assertions.assertEquals(failCount, 0);
+  }
 
-    private static void checkSanity(RoaringBitSet... sets) {
-        for (RoaringBitSet s : sets) {
-            int len = s.length();
-            int cardinality1 = s.cardinality();
-            int cardinality2 = 0;
-            for (int i = s.nextSetBit(0); i >= 0; i = s.nextSetBit(i + 1)) {
-                Assertions.assertTrue(s.get(i));
-                cardinality2++;
-            }
-            Assertions.assertEquals(s.nextSetBit(len), -1);
-            Assertions.assertEquals(len, s.nextClearBit(len));
-            Assertions.assertEquals((len == 0), s.isEmpty());
-            Assertions.assertEquals(cardinality2, cardinality1);
-            Assertions.assertTrue(len <= s.size());
-            Assertions.assertTrue(len >= 0);
-            Assertions.assertTrue(cardinality1 >= 0);
-        }
+  private static void checkSanity(RoaringBitSet... sets) {
+    for (RoaringBitSet s : sets) {
+      int len = s.length();
+      int cardinality1 = s.cardinality();
+      int cardinality2 = 0;
+      for (int i = s.nextSetBit(0); i >= 0; i = s.nextSetBit(i + 1)) {
+        Assertions.assertTrue(s.get(i));
+        cardinality2++;
+      }
+      Assertions.assertEquals(s.nextSetBit(len), -1);
+      Assertions.assertEquals(len, s.nextClearBit(len));
+      Assertions.assertEquals((len == 0), s.isEmpty());
+      Assertions.assertEquals(cardinality2, cardinality1);
+      Assertions.assertTrue(len <= s.size());
+      Assertions.assertTrue(len >= 0);
+      Assertions.assertTrue(cardinality1 >= 0);
     }
+  }
 
-    private static void checkEquality(RoaringBitSet s, RoaringBitSet t) {
-        checkSanity(s, t);
-        Assertions.assertEquals(t, s);
-        Assertions.assertEquals(t.toString(), s.toString());
-        Assertions.assertEquals(s.length(), t.length());
-        Assertions.assertEquals(s.cardinality(), t.cardinality());
-    }
+  private static void checkEquality(RoaringBitSet s, RoaringBitSet t) {
+    checkSanity(s, t);
+    Assertions.assertEquals(t, s);
+    Assertions.assertEquals(t.toString(), s.toString());
+    Assertions.assertEquals(s.length(), t.length());
+    Assertions.assertEquals(s.cardinality(), t.cardinality());
+  }
 
-    private static RoaringBitSet makeSet(int... elts) {
-        RoaringBitSet s = new RoaringBitSet();
-        for (int elt : elts)
-            s.set(elt);
-        return s;
-    }
+  private static RoaringBitSet makeSet(int... elts) {
+    RoaringBitSet s = new RoaringBitSet();
+    for (int elt : elts)
+      s.set(elt);
+    return s;
+  }
 
-    private static void checkEmpty(RoaringBitSet s) {
-        Assertions.assertTrue(s.isEmpty());
-        Assertions.assertEquals(s.length(), 0);
-        Assertions.assertEquals(s.cardinality(), 0);
-        Assertions.assertEquals(s, new RoaringBitSet());
-        Assertions.assertEquals(s.nextSetBit(0), -1);
-        Assertions.assertEquals(s.nextSetBit(127), -1);
-        Assertions.assertEquals(s.nextSetBit(128), -1);
-        Assertions.assertEquals(s.nextClearBit(0), 0);
-        Assertions.assertEquals(s.nextClearBit(127), 127);
-        Assertions.assertEquals(s.nextClearBit(128), 128);
-        Assertions.assertEquals(s.toString(), "{}");
-        Assertions.assertFalse(s.get(0));
-    }
+  private static void checkEmpty(RoaringBitSet s) {
+    Assertions.assertTrue(s.isEmpty());
+    Assertions.assertEquals(s.length(), 0);
+    Assertions.assertEquals(s.cardinality(), 0);
+    Assertions.assertEquals(s, new RoaringBitSet());
+    Assertions.assertEquals(s.nextSetBit(0), -1);
+    Assertions.assertEquals(s.nextSetBit(127), -1);
+    Assertions.assertEquals(s.nextSetBit(128), -1);
+    Assertions.assertEquals(s.nextClearBit(0), 0);
+    Assertions.assertEquals(s.nextClearBit(127), 127);
+    Assertions.assertEquals(s.nextClearBit(128), 128);
+    Assertions.assertEquals(s.toString(), "{}");
+    Assertions.assertFalse(s.get(0));
+  }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitSetTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitSetTest.java
@@ -296,7 +296,6 @@ public class RoaringBitSetTest {
       RoaringBitSet b2 = new RoaringBitSet();
 
       // Set some random bits in first set and remember them
-      int nextBitToSet = 0;
       for (int x = 0; x < 10; x++)
         b1.set(generator.nextInt(255));
 
@@ -330,7 +329,6 @@ public class RoaringBitSetTest {
       RoaringBitSet b2 = new RoaringBitSet();
 
       // Set some random bits in first set and remember them
-      int nextBitToSet = 0;
       for (int x = 0; x < 10; x++)
         b1.set(generator.nextInt(255));
 
@@ -392,7 +390,6 @@ public class RoaringBitSetTest {
       b3.or(b2);
 
       // Verify the set bits of b3 from the history
-      int historyIndex = 0;
       for (int x = 0; x < 20; x++) {
         if (!b3.get(history[x]))
           failCount++;
@@ -420,7 +417,6 @@ public class RoaringBitSetTest {
       RoaringBitSet b2 = new RoaringBitSet();
 
       // Set some random bits in first set and remember them
-      int nextBitToSet = 0;
       for (int x = 0; x < 10; x++)
         b1.set(generator.nextInt(255));
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitSetTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/RoaringBitSetTest.java
@@ -1,0 +1,912 @@
+package org.roaringbitmap;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Random;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+// From https://github.com/openjdk/jdk/blob/master/test/jdk/java/util/BitSet/BSMethods.java
+@SuppressWarnings("all")
+public class RoaringBitSetTest {
+    private static Random generator = new Random();
+
+    @Test
+    public void testSetGetClearFlip() {
+        int failCount = 0;
+
+        for (int i = 0; i < 100; i++) {
+            RoaringBitSet testSet = new RoaringBitSet();
+            HashSet<Integer> history = new HashSet<>();
+
+            // Set a random number of bits in random places
+            // up to a random maximum
+            int nextBitToSet = 0;
+            int numberOfSetBits = generator.nextInt(100) + 1;
+            int highestPossibleSetBit = generator.nextInt(1000) + 1;
+            for (int x = 0; x < numberOfSetBits; x++) {
+                nextBitToSet = generator.nextInt(highestPossibleSetBit);
+                history.add(Integer.valueOf(nextBitToSet));
+                testSet.set(nextBitToSet);
+            }
+
+            // Make sure each bit is set appropriately
+            for (int x = 0; x < highestPossibleSetBit; x++) {
+                if (testSet.get(x) != history.contains(Integer.valueOf(x)))
+                    failCount++;
+            }
+
+            // Clear the bits
+            Iterator<Integer> setBitIterator = history.iterator();
+            while (setBitIterator.hasNext()) {
+                Integer setBit = setBitIterator.next();
+                testSet.clear(setBit.intValue());
+            }
+
+            // Verify they were cleared
+            for (int x = 0; x < highestPossibleSetBit; x++)
+                if (testSet.get(x))
+                    failCount++;
+            if (testSet.length() != 0)
+                failCount++;
+
+            // Set them with set(int, boolean)
+            setBitIterator = history.iterator();
+            while (setBitIterator.hasNext()) {
+                Integer setBit = setBitIterator.next();
+                testSet.set(setBit.intValue(), true);
+            }
+
+            // Make sure each bit is set appropriately
+            for (int x = 0; x < highestPossibleSetBit; x++) {
+                if (testSet.get(x) != history.contains(Integer.valueOf(x)))
+                    failCount++;
+            }
+
+            // Clear them with set(int, boolean)
+            setBitIterator = history.iterator();
+            while (setBitIterator.hasNext()) {
+                Integer setBit = setBitIterator.next();
+                testSet.set(setBit.intValue(), false);
+            }
+
+            // Verify they were cleared
+            for (int x = 0; x < highestPossibleSetBit; x++)
+                if (testSet.get(x))
+                    failCount++;
+            if (testSet.length() != 0)
+                failCount++;
+
+            // Flip them on
+            setBitIterator = history.iterator();
+            while (setBitIterator.hasNext()) {
+                Integer setBit = setBitIterator.next();
+                testSet.flip(setBit.intValue());
+            }
+
+            // Verify they were flipped
+            for (int x = 0; x < highestPossibleSetBit; x++) {
+                if (testSet.get(x) != history.contains(Integer.valueOf(x)))
+                    failCount++;
+            }
+
+            // Flip them off
+            setBitIterator = history.iterator();
+            while (setBitIterator.hasNext()) {
+                Integer setBit = setBitIterator.next();
+                testSet.flip(setBit.intValue());
+            }
+
+            // Verify they were flipped
+            for (int x = 0; x < highestPossibleSetBit; x++)
+                if (testSet.get(x))
+                    failCount++;
+            if (testSet.length() != 0)
+                failCount++;
+
+            checkSanity(testSet);
+        }
+
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    @Test
+    public void testClear() {
+        int failCount = 0;
+
+        for (int i = 0; i < 1000; i++) {
+            RoaringBitSet b1 = new RoaringBitSet();
+
+            // Make a fairly random bitset
+            int numberOfSetBits = generator.nextInt(100) + 1;
+            int highestPossibleSetBit = generator.nextInt(1000) + 1;
+
+            for (int x = 0; x < numberOfSetBits; x++)
+                b1.set(generator.nextInt(highestPossibleSetBit));
+
+            RoaringBitSet b2 = (RoaringBitSet) b1.clone();
+
+            // Clear out a random range
+            int rangeStart = generator.nextInt(100);
+            int rangeEnd = rangeStart + generator.nextInt(100);
+
+            // Use the clear(int, int) call on b1
+            b1.clear(rangeStart, rangeEnd);
+
+            // Use a loop on b2
+            for (int x = rangeStart; x < rangeEnd; x++)
+                b2.clear(x);
+
+            // Verify their equality
+            if (!b1.equals(b2)) {
+                failCount++;
+            }
+            checkEquality(b1, b2);
+        }
+
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    @Test
+    public void testFlip() {
+        int failCount = 0;
+
+        for (int i = 0; i < 1000; i++) {
+            RoaringBitSet b1 = new RoaringBitSet();
+
+            // Make a fairly random bitset
+            int numberOfSetBits = generator.nextInt(100) + 1;
+            int highestPossibleSetBit = generator.nextInt(1000) + 1;
+
+            for (int x = 0; x < numberOfSetBits; x++)
+                b1.set(generator.nextInt(highestPossibleSetBit));
+
+            RoaringBitSet b2 = (RoaringBitSet) b1.clone();
+
+            // Flip a random range
+            int rangeStart = generator.nextInt(100);
+            int rangeEnd = rangeStart + generator.nextInt(100);
+
+            // Use the flip(int, int) call on b1
+            b1.flip(rangeStart, rangeEnd);
+
+            // Use a loop on b2
+            for (int x = rangeStart; x < rangeEnd; x++)
+                b2.flip(x);
+
+            // Verify their equality
+            if (!b1.equals(b2))
+                failCount++;
+            checkEquality(b1, b2);
+        }
+
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    @Test
+    public void testSet() {
+        int failCount = 0;
+
+        // Test set(int, int)
+        for (int i = 0; i < 1000; i++) {
+            RoaringBitSet b1 = new RoaringBitSet();
+
+            // Make a fairly random bitset
+            int numberOfSetBits = generator.nextInt(100) + 1;
+            int highestPossibleSetBit = generator.nextInt(1000) + 1;
+
+            for (int x = 0; x < numberOfSetBits; x++)
+                b1.set(generator.nextInt(highestPossibleSetBit));
+
+            RoaringBitSet b2 = (RoaringBitSet) b1.clone();
+
+            // Set a random range
+            int rangeStart = generator.nextInt(100);
+            int rangeEnd = rangeStart + generator.nextInt(100);
+
+            // Use the set(int, int) call on b1
+            b1.set(rangeStart, rangeEnd);
+
+            // Use a loop on b2
+            for (int x = rangeStart; x < rangeEnd; x++)
+                b2.set(x);
+
+            // Verify their equality
+            if (!b1.equals(b2)) {
+                failCount++;
+            }
+            checkEquality(b1, b2);
+        }
+
+        // Test set(int, int, boolean)
+        for (int i = 0; i < 100; i++) {
+            RoaringBitSet b1 = new RoaringBitSet();
+
+            // Make a fairly random bitset
+            int numberOfSetBits = generator.nextInt(100) + 1;
+            int highestPossibleSetBit = generator.nextInt(1000) + 1;
+
+            for (int x = 0; x < numberOfSetBits; x++)
+                b1.set(generator.nextInt(highestPossibleSetBit));
+
+            RoaringBitSet b2 = (RoaringBitSet) b1.clone();
+            boolean setOrClear = generator.nextBoolean();
+
+            // Set a random range
+            int rangeStart = generator.nextInt(100);
+            int rangeEnd = rangeStart + generator.nextInt(100);
+
+            // Use the set(int, int, boolean) call on b1
+            b1.set(rangeStart, rangeEnd, setOrClear);
+
+            // Use a loop on b2
+            for (int x = rangeStart; x < rangeEnd; x++)
+                b2.set(x, setOrClear);
+
+            // Verify their equality
+            if (!b1.equals(b2)) {
+                failCount++;
+            }
+            checkEquality(b1, b2);
+        }
+
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    @Test
+    public void testGet() {
+        int failCount = 0;
+
+        for (int i = 0; i < 1000; i++) {
+            RoaringBitSet b1 = new RoaringBitSet();
+
+            // Make a fairly random bitset
+            int numberOfSetBits = generator.nextInt(100) + 1;
+            int highestPossibleSetBit = generator.nextInt(1000) + 1;
+
+            for (int x = 0; x < numberOfSetBits; x++)
+                b1.set(generator.nextInt(highestPossibleSetBit));
+
+            // Get a new set from a random range
+            int rangeStart = generator.nextInt(100);
+            int rangeEnd = rangeStart + generator.nextInt(100);
+
+            RoaringBitSet b2 = (RoaringBitSet) b1.get(rangeStart, rangeEnd);
+
+            RoaringBitSet b3 = new RoaringBitSet();
+            for (int x = rangeStart; x < rangeEnd; x++)
+                b3.set(x - rangeStart, b1.get(x));
+
+            // Verify their equality
+            if (!b2.equals(b3)) {
+                failCount++;
+            }
+            checkEquality(b2, b3);
+        }
+
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    @Test
+    public void testAndNot() {
+        int failCount = 0;
+
+        for (int i = 0; i < 100; i++) {
+            RoaringBitSet b1 = new RoaringBitSet();
+            RoaringBitSet b2 = new RoaringBitSet();
+
+            // Set some random bits in first set and remember them
+            int nextBitToSet = 0;
+            for (int x = 0; x < 10; x++)
+                b1.set(generator.nextInt(255));
+
+            // Set some random bits in second set and remember them
+            for (int x = 10; x < 20; x++)
+                b2.set(generator.nextInt(255));
+
+            // andNot the sets together
+            RoaringBitSet b3 = (RoaringBitSet) b1.clone();
+            b3.andNot(b2);
+
+            // Examine each bit of b3 for errors
+            for (int x = 0; x < 256; x++) {
+                boolean bit1 = b1.get(x);
+                boolean bit2 = b2.get(x);
+                boolean bit3 = b3.get(x);
+                if (!(bit3 == (bit1 & (!bit2))))
+                    failCount++;
+            }
+            checkSanity(b1, b2, b3);
+        }
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    @Test
+    public void testAnd() {
+        int failCount = 0;
+
+        for (int i = 0; i < 100; i++) {
+            RoaringBitSet b1 = new RoaringBitSet();
+            RoaringBitSet b2 = new RoaringBitSet();
+
+            // Set some random bits in first set and remember them
+            int nextBitToSet = 0;
+            for (int x = 0; x < 10; x++)
+                b1.set(generator.nextInt(255));
+
+            // Set more random bits in second set and remember them
+            for (int x = 10; x < 20; x++)
+                b2.set(generator.nextInt(255));
+
+            // And the sets together
+            RoaringBitSet b3 = (RoaringBitSet) b1.clone();
+            b3.and(b2);
+
+            // Examine each bit of b3 for errors
+            for (int x = 0; x < 256; x++) {
+                boolean bit1 = b1.get(x);
+                boolean bit2 = b2.get(x);
+                boolean bit3 = b3.get(x);
+                if (!(bit3 == (bit1 & bit2)))
+                    failCount++;
+            }
+            checkSanity(b1, b2, b3);
+        }
+
+        // `and' that happens to clear the last word
+        RoaringBitSet b4 = makeSet(2, 127);
+        b4.and(makeSet(2, 64));
+        checkSanity(b4);
+        if (!(b4.equals(makeSet(2))))
+            failCount++;
+
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    @Test
+    public void testOr() {
+        int failCount = 0;
+
+        for (int i = 0; i < 100; i++) {
+            RoaringBitSet b1 = new RoaringBitSet();
+            RoaringBitSet b2 = new RoaringBitSet();
+            int[] history = new int[20];
+
+            // Set some random bits in first set and remember them
+            int nextBitToSet = 0;
+            for (int x = 0; x < 10; x++) {
+                nextBitToSet = generator.nextInt(255);
+                history[x] = nextBitToSet;
+                b1.set(nextBitToSet);
+            }
+
+            // Set more random bits in second set and remember them
+            for (int x = 10; x < 20; x++) {
+                nextBitToSet = generator.nextInt(255);
+                history[x] = nextBitToSet;
+                b2.set(nextBitToSet);
+            }
+
+            // Or the sets together
+            RoaringBitSet b3 = (RoaringBitSet) b1.clone();
+            b3.or(b2);
+
+            // Verify the set bits of b3 from the history
+            int historyIndex = 0;
+            for (int x = 0; x < 20; x++) {
+                if (!b3.get(history[x]))
+                    failCount++;
+            }
+
+            // Examine each bit of b3 for errors
+            for (int x = 0; x < 256; x++) {
+                boolean bit1 = b1.get(x);
+                boolean bit2 = b2.get(x);
+                boolean bit3 = b3.get(x);
+                if (!(bit3 == (bit1 | bit2)))
+                    failCount++;
+            }
+            checkSanity(b1, b2, b3);
+        }
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    @Test
+    public void testXor() {
+        int failCount = 0;
+
+        for (int i = 0; i < 100; i++) {
+            RoaringBitSet b1 = new RoaringBitSet();
+            RoaringBitSet b2 = new RoaringBitSet();
+
+            // Set some random bits in first set and remember them
+            int nextBitToSet = 0;
+            for (int x = 0; x < 10; x++)
+                b1.set(generator.nextInt(255));
+
+            // Set more random bits in second set and remember them
+            for (int x = 10; x < 20; x++)
+                b2.set(generator.nextInt(255));
+
+            // Xor the sets together
+            RoaringBitSet b3 = (RoaringBitSet) b1.clone();
+            b3.xor(b2);
+
+            // Examine each bit of b3 for errors
+            for (int x = 0; x < 256; x++) {
+                boolean bit1 = b1.get(x);
+                boolean bit2 = b2.get(x);
+                boolean bit3 = b3.get(x);
+                if (!(bit3 == (bit1 ^ bit2)))
+                    failCount++;
+            }
+            checkSanity(b1, b2, b3);
+            b3.xor(b3);
+            checkEmpty(b3);
+        }
+
+        // xor that happens to clear the last word
+        RoaringBitSet b4 = makeSet(2, 64, 127);
+        b4.xor(makeSet(64, 127));
+        checkSanity(b4);
+        if (!(b4.equals(makeSet(2))))
+            failCount++;
+
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    @Test
+    public void testLength() {
+        int failCount = 0;
+
+        // Test length after set
+        for (int i = 0; i < 100; i++) {
+            RoaringBitSet b1 = new RoaringBitSet();
+            int highestSetBit = 0;
+
+            for (int x = 0; x < 100; x++) {
+                int nextBitToSet = generator.nextInt(255);
+                if (nextBitToSet > highestSetBit)
+                    highestSetBit = nextBitToSet;
+                b1.set(nextBitToSet);
+                if (b1.length() != highestSetBit + 1)
+                    failCount++;
+            }
+            checkSanity(b1);
+        }
+
+        // Test length after flip
+        for (int i = 0; i < 100; i++) {
+            RoaringBitSet b1 = new RoaringBitSet();
+            for (int x = 0; x < 100; x++) {
+                // Flip a random range twice
+                int rangeStart = generator.nextInt(100);
+                int rangeEnd = rangeStart + generator.nextInt(100);
+                b1.flip(rangeStart);
+                b1.flip(rangeStart);
+                if (b1.length() != 0)
+                    failCount++;
+                b1.flip(rangeStart, rangeEnd);
+                b1.flip(rangeStart, rangeEnd);
+                if (b1.length() != 0)
+                    failCount++;
+            }
+            checkSanity(b1);
+        }
+
+        // Test length after or
+        for (int i = 0; i < 100; i++) {
+            RoaringBitSet b1 = new RoaringBitSet();
+            RoaringBitSet b2 = new RoaringBitSet();
+            int bit1 = generator.nextInt(100);
+            int bit2 = generator.nextInt(100);
+            int highestSetBit = (bit1 > bit2) ? bit1 : bit2;
+            b1.set(bit1);
+            b2.set(bit2);
+            b1.or(b2);
+            if (b1.length() != highestSetBit + 1)
+                failCount++;
+            checkSanity(b1, b2);
+        }
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    @Test
+    public void testEquals() {
+        int failCount = 0;
+
+        for (int i = 0; i < 100; i++) {
+            // Create BitSets of different sizes
+            RoaringBitSet b1 = new RoaringBitSet();
+            RoaringBitSet b2 = new RoaringBitSet();
+
+            // Set some random bits
+            int nextBitToSet = 0;
+            for (int x = 0; x < 10; x++) {
+                nextBitToSet += generator.nextInt(50) + 1;
+                b1.set(nextBitToSet);
+                b2.set(nextBitToSet);
+            }
+
+            // Verify their equality despite different storage sizes
+            if (!b1.equals(b2))
+                failCount++;
+            checkEquality(b1, b2);
+        }
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    @Test
+    public void testNextSetBit() {
+        int failCount = 0;
+
+        for (int i = 0; i < 100; i++) {
+            int numberOfSetBits = generator.nextInt(100) + 1;
+            RoaringBitSet testSet = new RoaringBitSet();
+            int[] history = new int[numberOfSetBits];
+
+            // Set some random bits and remember them
+            int nextBitToSet = 0;
+            for (int x = 0; x < numberOfSetBits; x++) {
+                nextBitToSet += generator.nextInt(30) + 1;
+                history[x] = nextBitToSet;
+                testSet.set(nextBitToSet);
+            }
+
+            // Verify their retrieval using nextSetBit()
+            int historyIndex = 0;
+            for (int x = testSet.nextSetBit(0); x >= 0; x = testSet.nextSetBit(x + 1)) {
+                if (x != history[historyIndex++])
+                    failCount++;
+            }
+
+            checkSanity(testSet);
+        }
+
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    @Test
+    public void testNextClearBit() {
+        int failCount = 0;
+
+        for (int i = 0; i < 1000; i++) {
+            RoaringBitSet b = new RoaringBitSet();
+            int[] history = new int[10];
+
+            // Set all the bits
+            for (int x = 0; x < 256; x++)
+                b.set(x);
+
+            // Clear some random bits and remember them
+            int nextBitToClear = 0;
+            for (int x = 0; x < 10; x++) {
+                nextBitToClear += generator.nextInt(24) + 1;
+                history[x] = nextBitToClear;
+                b.clear(nextBitToClear);
+            }
+
+            // Verify their retrieval using nextClearBit()
+            int historyIndex = 0;
+            for (int x = b.nextClearBit(0); x < 256; x = b.nextClearBit(x + 1)) {
+                if (x != history[historyIndex++])
+                    failCount++;
+            }
+
+            checkSanity(b);
+        }
+
+        // regression test for 4350178
+        RoaringBitSet bs = new RoaringBitSet();
+        if (bs.nextClearBit(0) != 0)
+            failCount++;
+        for (int i = 0; i < 64; i++) {
+            bs.set(i);
+            if (bs.nextClearBit(0) != i + 1)
+                failCount++;
+        }
+
+        checkSanity(bs);
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    @Test
+    public void testIntersects() {
+        int failCount = 0;
+
+        for (int i = 0; i < 100; i++) {
+            RoaringBitSet b1 = new RoaringBitSet();
+            RoaringBitSet b2 = new RoaringBitSet();
+
+            // Set some random bits in first set
+            int nextBitToSet = 0;
+            for (int x = 0; x < 30; x++) {
+                nextBitToSet = generator.nextInt(255);
+                b1.set(nextBitToSet);
+            }
+
+            // Set more random bits in second set
+            for (int x = 0; x < 30; x++) {
+                nextBitToSet = generator.nextInt(255);
+                b2.set(nextBitToSet);
+            }
+
+            // Make sure they intersect
+            nextBitToSet = generator.nextInt(255);
+            b1.set(nextBitToSet);
+            b2.set(nextBitToSet);
+
+            if (!b1.intersects(b2))
+                failCount++;
+
+            // Remove the common set bits
+            b1.andNot(b2);
+
+            // Make sure they don't intersect
+            if (b1.intersects(b2))
+                failCount++;
+
+            checkSanity(b1, b2);
+        }
+
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    @Test
+    public void testCardinality() {
+        int failCount = 0;
+
+        for (int i = 0; i < 100; i++) {
+            RoaringBitSet b1 = new RoaringBitSet();
+
+            // Set a random number of increasing bits
+            int nextBitToSet = 0;
+            int iterations = generator.nextInt(20) + 1;
+            for (int x = 0; x < iterations; x++) {
+                nextBitToSet += generator.nextInt(20) + 1;
+                b1.set(nextBitToSet);
+            }
+
+            if (b1.cardinality() != iterations) {
+                failCount++;
+            }
+
+            checkSanity(b1);
+        }
+
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    @Test
+    public void testEmpty() {
+        int failCount = 0;
+
+        RoaringBitSet b1 = new RoaringBitSet();
+        if (!b1.isEmpty())
+            failCount++;
+
+        int nextBitToSet = 0;
+        int numberOfSetBits = generator.nextInt(100) + 1;
+        int highestPossibleSetBit = generator.nextInt(1000) + 1;
+        for (int x = 0; x < numberOfSetBits; x++) {
+            nextBitToSet = generator.nextInt(highestPossibleSetBit);
+            b1.set(nextBitToSet);
+            if (b1.isEmpty())
+                failCount++;
+            b1.clear(nextBitToSet);
+            if (!b1.isEmpty())
+                failCount++;
+        }
+
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    @Test
+    public void testEmpty2() {
+        {
+            RoaringBitSet t = new RoaringBitSet();
+            t.set(100);
+            t.clear(3, 600);
+            checkEmpty(t);
+        }
+        checkEmpty(new RoaringBitSet());
+
+        RoaringBitSet s = new RoaringBitSet();
+        checkEmpty(s);
+        s.clear(92);
+        checkEmpty(s);
+        s.clear(127, 127);
+        checkEmpty(s);
+        s.set(127, 127);
+        checkEmpty(s);
+        s.set(128, 128);
+        checkEmpty(s);
+        RoaringBitSet empty = new RoaringBitSet();
+        {
+            RoaringBitSet t = new RoaringBitSet();
+            t.and(empty);
+            checkEmpty(t);
+        }
+        {
+            RoaringBitSet t = new RoaringBitSet();
+            t.or(empty);
+            checkEmpty(t);
+        }
+        {
+            RoaringBitSet t = new RoaringBitSet();
+            t.xor(empty);
+            checkEmpty(t);
+        }
+        {
+            RoaringBitSet t = new RoaringBitSet();
+            t.andNot(empty);
+            checkEmpty(t);
+        }
+        {
+            RoaringBitSet t = new RoaringBitSet();
+            t.and(t);
+            checkEmpty(t);
+        }
+        {
+            RoaringBitSet t = new RoaringBitSet();
+            t.or(t);
+            checkEmpty(t);
+        }
+        {
+            RoaringBitSet t = new RoaringBitSet();
+            t.xor(t);
+            checkEmpty(t);
+        }
+        {
+            RoaringBitSet t = new RoaringBitSet();
+            t.andNot(t);
+            checkEmpty(t);
+        }
+        {
+            RoaringBitSet t = new RoaringBitSet();
+            t.and(makeSet(1));
+            checkEmpty(t);
+        }
+        {
+            RoaringBitSet t = new RoaringBitSet();
+            t.and(makeSet(127));
+            checkEmpty(t);
+        }
+        {
+            RoaringBitSet t = new RoaringBitSet();
+            t.and(makeSet(128));
+            checkEmpty(t);
+        }
+        {
+            RoaringBitSet t = new RoaringBitSet();
+            t.flip(7);
+            t.flip(7);
+            checkEmpty(t);
+        }
+        {
+            RoaringBitSet t = new RoaringBitSet();
+            checkEmpty((RoaringBitSet) t.get(200, 300));
+        }
+        {
+            RoaringBitSet t = makeSet(2, 5);
+            Assertions.assertEquals(makeSet(0, 3), t.get(2, 6));
+        }
+    }
+
+    @Test
+    public void testLogicalIdentities() {
+        int failCount = 0;
+
+        // Verify that (!b1)|(!b2) == !(b1&b2)
+        for (int i = 0; i < 50; i++) {
+            // Construct two fairly random bitsets
+            RoaringBitSet b1 = new RoaringBitSet();
+            RoaringBitSet b2 = new RoaringBitSet();
+
+            int numberOfSetBits = generator.nextInt(100) + 1;
+            int highestPossibleSetBit = generator.nextInt(1000) + 1;
+
+            for (int x = 0; x < numberOfSetBits; x++) {
+                b1.set(generator.nextInt(highestPossibleSetBit));
+                b2.set(generator.nextInt(highestPossibleSetBit));
+            }
+
+            RoaringBitSet b3 = (RoaringBitSet) b1.clone();
+            RoaringBitSet b4 = (RoaringBitSet) b2.clone();
+
+            for (int x = 0; x < highestPossibleSetBit; x++) {
+                b1.flip(x);
+                b2.flip(x);
+            }
+            b1.or(b2);
+            b3.and(b4);
+            for (int x = 0; x < highestPossibleSetBit; x++)
+                b3.flip(x);
+            if (!b1.equals(b3))
+                failCount++;
+            checkSanity(b1, b2, b3, b4);
+        }
+
+        // Verify that (b1&(!b2)|(b2&(!b1) == b1^b2
+        for (int i = 0; i < 50; i++) {
+            // Construct two fairly random bitsets
+            RoaringBitSet b1 = new RoaringBitSet();
+            RoaringBitSet b2 = new RoaringBitSet();
+
+            int numberOfSetBits = generator.nextInt(100) + 1;
+            int highestPossibleSetBit = generator.nextInt(1000) + 1;
+
+            for (int x = 0; x < numberOfSetBits; x++) {
+                b1.set(generator.nextInt(highestPossibleSetBit));
+                b2.set(generator.nextInt(highestPossibleSetBit));
+            }
+
+            RoaringBitSet b3 = (RoaringBitSet) b1.clone();
+            RoaringBitSet b4 = (RoaringBitSet) b2.clone();
+            RoaringBitSet b5 = (RoaringBitSet) b1.clone();
+            RoaringBitSet b6 = (RoaringBitSet) b2.clone();
+
+            for (int x = 0; x < highestPossibleSetBit; x++)
+                b2.flip(x);
+            b1.and(b2);
+            for (int x = 0; x < highestPossibleSetBit; x++)
+                b3.flip(x);
+            b3.and(b4);
+            b1.or(b3);
+            b5.xor(b6);
+            if (!b1.equals(b5))
+                failCount++;
+            checkSanity(b1, b2, b3, b4, b5, b6);
+        }
+        Assertions.assertEquals(failCount, 0);
+    }
+
+    private static void checkSanity(RoaringBitSet... sets) {
+        for (RoaringBitSet s : sets) {
+            int len = s.length();
+            int cardinality1 = s.cardinality();
+            int cardinality2 = 0;
+            for (int i = s.nextSetBit(0); i >= 0; i = s.nextSetBit(i + 1)) {
+                Assertions.assertTrue(s.get(i));
+                cardinality2++;
+            }
+            Assertions.assertEquals(s.nextSetBit(len), -1);
+            Assertions.assertEquals(len, s.nextClearBit(len));
+            Assertions.assertEquals((len == 0), s.isEmpty());
+            Assertions.assertEquals(cardinality2, cardinality1);
+            Assertions.assertTrue(len <= s.size());
+            Assertions.assertTrue(len >= 0);
+            Assertions.assertTrue(cardinality1 >= 0);
+        }
+    }
+
+    private static void checkEquality(RoaringBitSet s, RoaringBitSet t) {
+        checkSanity(s, t);
+        Assertions.assertEquals(t, s);
+        Assertions.assertEquals(t.toString(), s.toString());
+        Assertions.assertEquals(s.length(), t.length());
+        Assertions.assertEquals(s.cardinality(), t.cardinality());
+    }
+
+    private static RoaringBitSet makeSet(int... elts) {
+        RoaringBitSet s = new RoaringBitSet();
+        for (int elt : elts)
+            s.set(elt);
+        return s;
+    }
+
+    private static void checkEmpty(RoaringBitSet s) {
+        Assertions.assertTrue(s.isEmpty());
+        Assertions.assertEquals(s.length(), 0);
+        Assertions.assertEquals(s.cardinality(), 0);
+        Assertions.assertEquals(s, new RoaringBitSet());
+        Assertions.assertEquals(s.nextSetBit(0), -1);
+        Assertions.assertEquals(s.nextSetBit(127), -1);
+        Assertions.assertEquals(s.nextSetBit(128), -1);
+        Assertions.assertEquals(s.nextClearBit(0), 0);
+        Assertions.assertEquals(s.nextClearBit(127), 127);
+        Assertions.assertEquals(s.nextClearBit(128), 128);
+        Assertions.assertEquals(s.toString(), "{}");
+        Assertions.assertFalse(s.get(0));
+    }
+}


### PR DESCRIPTION
### SUMMARY

Add a `BitSet` implementation based on RoaringBitmap to make users could migrate `BitSet` to `RoaringBitmap` easier.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
