### PR TITLE
improve: Optimize RoaringBitSet.get(int fromIndex, int toIndex)

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitSet.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitSet.java
@@ -1,6 +1,7 @@
 package org.roaringbitmap;
 
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.stream.IntStream;
 
 /**
@@ -71,9 +72,15 @@ public class RoaringBitSet extends BitSet {
 
   @Override
   public BitSet get(int fromIndex, int toIndex) {
-    BitSet bitSet = BitSetUtil.bitsetOf(roaringBitmap);
-    bitSet = bitSet.get(fromIndex, toIndex);
-    return new RoaringBitSet(fromBitSet(bitSet));
+    return new RoaringBitSet(
+            RoaringBitmap.addOffset(
+                    // get the subset of the bitmap for the given range
+                    RoaringBitmap.or(Collections.singleton(roaringBitmap).iterator(),
+                            (long) fromIndex, (long) toIndex),
+                    // shift the bits to start from index 0
+                    -fromIndex
+            )
+    );
   }
 
   @Override


### PR DESCRIPTION
### SUMMARY

- RoaringBitSet was added in 1.1.0 release
- The `get(int fromIndex, int toIndex)` method implementation wasn't optimal
  - It would first make an entire java.util.BitSet instance and then use that for getting the subset
- This PR uses RoaringBitmap's methods for the implementation of `get(int fromIndex, int toIndex)` instead of relying on `java.util.BitSet` for the implementation.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
