### PR TITLE
add getSignedIntIterator to roaring bitmaps 

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ImmutableBitmapDataProvider.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ImmutableBitmapDataProvider.java
@@ -72,8 +72,6 @@ public interface ImmutableBitmapDataProvider {
   PeekableIntIterator getIntIterator();
 
   /**
-   * For better performance, consider using the {@link #forEach forEach} method when unsigned
-   *     integer ascending sorted order is sufficient.
    * @return a custom iterator over set bits, the bits are traversed in signed integer ascending
    *     sorted order
    */

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ImmutableBitmapDataProvider.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ImmutableBitmapDataProvider.java
@@ -65,13 +65,23 @@ public interface ImmutableBitmapDataProvider {
   void forEach(IntConsumer ic);
 
   /**
-   * For better performance, consider the Use the {@link #forEach forEach} method.
-   * @return a custom iterator over set bits, the bits are traversed in ascending sorted order
+   * For better performance, consider using the {@link #forEach forEach} method.
+   * @return a custom iterator over set bits, the bits are traversed in unsigned integer ascending
+   *     sorted order
    */
   PeekableIntIterator getIntIterator();
 
   /**
-   * @return a custom iterator over set bits, the bits are traversed in descending sorted order
+   * For better performance, consider using the {@link #forEach forEach} method when unsigned
+   *     integer ascending sorted order is sufficient.
+   * @return a custom iterator over set bits, the bits are traversed in signed integer ascending
+   *     sorted order
+   */
+  PeekableIntIterator getSignedIntIterator();
+
+  /**
+   * @return a custom iterator over set bits, the bits are traversed in unsigned integer descending
+   *     sorted order
    */
   IntIterator getReverseIntIterator();
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -65,7 +65,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     private RoaringIntIterator(final boolean signedIntSort) {
       char index = 0;
       if (signedIntSort) {
-        // skip to starting at positive signed integers
+        // skip to starting at negative signed integers
         final int containerSize = RoaringBitmap.this.highLowContainer.size();
         while (index < containerSize
             && RoaringBitmap.this.highLowContainer.getKeyAtIndex(index) < (1 << 15)) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -2132,7 +2132,8 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
    *
    * For better performance, consider using the {@link #forEach forEach} method.
    *
-   * @return a custom iterator over set bits, the bits are traversed in ascending sorted order
+   * @return a custom iterator over set bits, the bits are traversed in unsigned integer ascending
+   *     sorted order
    */
   @Override
   public PeekableIntIterator getIntIterator() {
@@ -2140,9 +2141,6 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
   }
 
   /**
-   * For better performance, consider using the {@link #forEach forEach} method when unsigned
-   * integer ascending sorted order is sufficient.
-   *
    * @return a custom iterator over set bits, the bits are traversed in signed integer ascending
    *     sorted order
    */

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -1375,9 +1375,6 @@ public class ImmutableRoaringBitmap
   }
 
   /**
-   * For better performance, consider the Use the {@link #forEach forEach} method when unsigned
-   * integer ascending sorted order is sufficient.
-   *
    * @return a custom iterator over set bits, the bits are traversed in signed integer ascending
    *     sorted order
    */

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -92,7 +92,7 @@ public class ImmutableRoaringBitmap
       char index = 0;
       if (signedIntSort) {
         wrap = true;
-        // skip to starting at positive signed integers
+        // skip to starting at negative signed integers
         final int containerSize = ImmutableRoaringBitmap.this.highLowContainer.size();
         while (index < containerSize
             && ImmutableRoaringBitmap.this.highLowContainer.getKeyAtIndex(index) < (1 << 15)) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -74,8 +74,9 @@ public class ImmutableRoaringBitmap
     implements Iterable<Integer>, Cloneable, ImmutableBitmapDataProvider {
 
   private final class ImmutableRoaringIntIterator implements PeekableIntIterator {
-    private MappeableContainerPointer cp =
-        ImmutableRoaringBitmap.this.highLowContainer.getContainerPointer();
+    private boolean wrap;
+    private MappeableContainerPointer cp;
+    private int iterations = 0;
 
     private int hs = 0;
 
@@ -84,6 +85,27 @@ public class ImmutableRoaringBitmap
     private boolean ok;
 
     public ImmutableRoaringIntIterator() {
+      this(false);
+    }
+
+    public ImmutableRoaringIntIterator(final boolean signedIntSort) {
+      char index = 0;
+      if (signedIntSort) {
+        wrap = true;
+        // skip to starting at positive signed integers
+        final int containerSize = ImmutableRoaringBitmap.this.highLowContainer.size();
+        while (index < containerSize
+            && ImmutableRoaringBitmap.this.highLowContainer.getKeyAtIndex(index) < (1 << 15)) {
+          ++index;
+        }
+        if(index >= containerSize) {
+          index = 0;
+          wrap = false;
+        }
+      } else {
+        wrap = false;
+      }
+      cp = ImmutableRoaringBitmap.this.highLowContainer.getContainerPointer(index);
       nextContainer();
     }
 
@@ -97,6 +119,8 @@ public class ImmutableRoaringBitmap
         if(this.cp != null) {
           x.cp = this.cp.clone();
         }
+        x.wrap = this.wrap;
+        x.iterations = this.iterations;
         return x;
       } catch (CloneNotSupportedException e) {
         return null;// will not happen
@@ -120,10 +144,21 @@ public class ImmutableRoaringBitmap
 
 
     private void nextContainer() {
-      ok = cp.hasContainer();
-      if (ok) {
-        iter = cp.getContainer().getCharIterator();
-        hs = (cp.key()) << 16;
+      final int containerSize = ImmutableRoaringBitmap.this.highLowContainer.size();
+      if(wrap || iterations < containerSize) {
+        ok = cp.hasContainer();
+        if (!ok && wrap && iterations < containerSize) {
+          cp = ImmutableRoaringBitmap.this.highLowContainer.getContainerPointer();
+          wrap = false;
+          ok = cp.hasContainer();
+        }
+        if (ok) {
+          iter = cp.getContainer().getCharIterator();
+          hs = (cp.key()) << 16;
+          ++iterations;
+        }
+      } else {
+        ok = false;
       }
     }
 
@@ -1331,11 +1366,24 @@ public class ImmutableRoaringBitmap
   /**
    * For better performance, consider the Use the {@link #forEach forEach} method.
    *
-   * @return a custom iterator over set bits, the bits are traversed in ascending sorted order
+   * @return a custom iterator over set bits, the bits are traversed in unsigned integer ascending
+   *     sorted order
    */
   @Override
   public PeekableIntIterator getIntIterator() {
-    return new ImmutableRoaringIntIterator();
+    return new ImmutableRoaringIntIterator(false);
+  }
+
+  /**
+   * For better performance, consider the Use the {@link #forEach forEach} method when unsigned
+   * integer ascending sorted order is sufficient.
+   *
+   * @return a custom iterator over set bits, the bits are traversed in signed integer ascending
+   *     sorted order
+   */
+  @Override
+  public PeekableIntIterator getSignedIntIterator() {
+    return new ImmutableRoaringIntIterator(true);
   }
 
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestIterators.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestIterators.java
@@ -11,10 +11,12 @@ import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -53,16 +55,16 @@ public class TestIterators {
   }
 
   private static int[] takeSortedAndDistinct(Random source, int count) {
-    LinkedHashSet<Integer> ints = new LinkedHashSet<Integer>(count);
+    HashSet<Integer> ints = new HashSet<Integer>(count);
     for (int size = 0; size < count; size++) {
       int next;
       do {
-        next = Math.abs(source.nextInt());
+        next = source.nextInt();
       } while (!ints.add(next));
     }
-    int[] unboxed = Ints.toArray(ints);
-    Arrays.sort(unboxed);
-    return unboxed;
+    ArrayList<Integer> list = new ArrayList<Integer>(ints);
+    list.sort(Integer::compareUnsigned);
+    return Ints.toArray(list);
   }
 
   @Test
@@ -77,6 +79,7 @@ public class TestIterators {
   public void testEmptyIteration() {
     assertFalse(RoaringBitmap.bitmapOf().iterator().hasNext());
     assertFalse(RoaringBitmap.bitmapOf().getIntIterator().hasNext());
+    assertFalse(RoaringBitmap.bitmapOf().getSignedIntIterator().hasNext());
     assertFalse(RoaringBitmap.bitmapOf().getReverseIntIterator().hasNext());
   }
 
@@ -88,27 +91,32 @@ public class TestIterators {
 
     final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
     final List<Integer> intIteratorCopy = asList(bitmap.getIntIterator());
+    final List<Integer> signedIntIteratorCopy = asList(bitmap.getSignedIntIterator());
     final List<Integer> reverseIntIteratorCopy = asList(bitmap.getReverseIntIterator());
 
     assertEquals(bitmap.getCardinality(), iteratorCopy.size());
     assertEquals(bitmap.getCardinality(), intIteratorCopy.size());
+    assertEquals(bitmap.getCardinality(), signedIntIteratorCopy.size());
     assertEquals(bitmap.getCardinality(), reverseIntIteratorCopy.size());
     assertEquals(Ints.asList(data), iteratorCopy);
     assertEquals(Ints.asList(data), intIteratorCopy);
+    assertEquals(Ints.asList(data).stream().sorted().collect(Collectors.toList()), signedIntIteratorCopy);
     assertEquals(Lists.reverse(Ints.asList(data)), reverseIntIteratorCopy);
   }
 
   @Test
   public void testSmallIteration() {
-    RoaringBitmap bitmap = RoaringBitmap.bitmapOf(1, 2, 3);
+    RoaringBitmap bitmap = RoaringBitmap.bitmapOf(1, 2, 3, -1);
 
     final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
     final List<Integer> intIteratorCopy = asList(bitmap.getIntIterator());
+    final List<Integer> signedIntIteratorCopy = asList(bitmap.getSignedIntIterator());
     final List<Integer> reverseIntIteratorCopy = asList(bitmap.getReverseIntIterator());
 
-    assertEquals(ImmutableList.of(1, 2, 3), iteratorCopy);
-    assertEquals(ImmutableList.of(1, 2, 3), intIteratorCopy);
-    assertEquals(ImmutableList.of(3, 2, 1), reverseIntIteratorCopy);
+    assertEquals(ImmutableList.of(1, 2, 3, -1), iteratorCopy);
+    assertEquals(ImmutableList.of(1, 2, 3, -1), intIteratorCopy);
+    assertEquals(ImmutableList.of(-1, 1, 2, 3), signedIntIteratorCopy);
+    assertEquals(ImmutableList.of(-1, 3, 2, 1), reverseIntIteratorCopy);
   }
   
   @Test

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestIterators.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestIterators.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -61,16 +62,16 @@ public class TestIterators {
 
 
   private static int[] takeSortedAndDistinct(Random source, int count) {
-    LinkedHashSet<Integer> ints = new LinkedHashSet<Integer>(count);
+    HashSet<Integer> ints = new HashSet<Integer>(count);
     for (int size = 0; size < count; size++) {
       int next;
       do {
-        next = Math.abs(source.nextInt());
+        next = source.nextInt();
       } while (!ints.add(next));
     }
-    int[] unboxed = Ints.toArray(ints);
-    Arrays.sort(unboxed);
-    return unboxed;
+    ArrayList<Integer> list = new ArrayList<Integer>(ints);
+    list.sort(Integer::compareUnsigned);
+    return Ints.toArray(list);
   }
 
   // https://github.com/RoaringBitmap/RoaringBitmap/issues/475
@@ -109,6 +110,7 @@ public class TestIterators {
   public void testEmptyIteration() {
     assertFalse(MutableRoaringBitmap.bitmapOf().iterator().hasNext());
     assertFalse(MutableRoaringBitmap.bitmapOf().getIntIterator().hasNext());
+    assertFalse(MutableRoaringBitmap.bitmapOf().getSignedIntIterator().hasNext());
     assertFalse(MutableRoaringBitmap.bitmapOf().getReverseIntIterator().hasNext());
   }
 
@@ -121,83 +123,93 @@ public class TestIterators {
 
     final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
     final List<Integer> intIteratorCopy = asList(bitmap.getIntIterator());
+    final List<Integer> signedIntIteratorCopy = asList(bitmap.getSignedIntIterator());
     final List<Integer> reverseIntIteratorCopy = asList(bitmap.getReverseIntIterator());
 
     assertEquals(bitmap.getCardinality(), iteratorCopy.size());
     assertEquals(bitmap.getCardinality(), intIteratorCopy.size());
+    assertEquals(bitmap.getCardinality(), signedIntIteratorCopy.size());
     assertEquals(bitmap.getCardinality(), reverseIntIteratorCopy.size());
     assertEquals(Ints.asList(data), iteratorCopy);
     assertEquals(Ints.asList(data), intIteratorCopy);
+    assertEquals(Ints.asList(data).stream().sorted().collect(Collectors.toList()), signedIntIteratorCopy);
     assertEquals(Lists.reverse(Ints.asList(data)), reverseIntIteratorCopy);
   }
-
 
 
   @Test
   public void testIteration1() {
     final Random source = new Random(0xcb000a2b9b5bdfb6l);
     final int[] data1 = takeSortedAndDistinct(source, 450000);
-    final int[] data = Arrays.copyOf(data1, data1.length + 50000);
 
-    HashSet<Integer> data1Members = new HashSet<Integer>();
+    HashSet<Integer> data1Members = new HashSet<Integer>(data1.length);
     for (int i : data1) {
       data1Members.add(i);
     }
+    final List<Integer> data = new ArrayList<>(data1.length + 50000);
+    data.addAll(data1Members);
 
     int counter = 77777;
-    for (int i = data1.length; i < data.length; ++i) {
+    for (int i = data1.length; i < data.size(); ++i) {
       // ensure uniqueness
       while (data1Members.contains(counter)) {
         ++counter;
       }
-      data[i] = counter; // must be unique
+      data.set(i, counter); // must be unique
       counter++;
       if (i % 15 == 0) {
         counter += 10; // runs of length 15 or so, with gaps of 10
       }
     }
-    Arrays.sort(data);
+    data.sort(Integer::compareUnsigned);
 
-    MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(data);
+    MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(Ints.toArray(data));
     bitmap.runOptimize(); // result should have some runcontainers and some non.
 
     final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
     final List<Integer> intIteratorCopy = asList(bitmap.getIntIterator());
+    final List<Integer> signedIntIteratorCopy = asList(bitmap.getSignedIntIterator());
     final List<Integer> reverseIntIteratorCopy = asList(bitmap.getReverseIntIterator());
 
     assertEquals(bitmap.getCardinality(), iteratorCopy.size());
     assertEquals(bitmap.getCardinality(), intIteratorCopy.size());
+    assertEquals(bitmap.getCardinality(), signedIntIteratorCopy.size());
     assertEquals(bitmap.getCardinality(), reverseIntIteratorCopy.size());
-    assertEquals(Ints.asList(data), iteratorCopy);
-    assertEquals(Ints.asList(data), intIteratorCopy);
-    assertEquals(Lists.reverse(Ints.asList(data)), reverseIntIteratorCopy);
+    assertEquals(data, iteratorCopy);
+    assertEquals(data, intIteratorCopy);
+    assertEquals(data.stream().sorted().collect(Collectors.toList()), signedIntIteratorCopy);
+    assertEquals(Lists.reverse(data), reverseIntIteratorCopy);
   }
 
   @Test
   public void testSmallIteration() {
-    MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(1, 2, 3);
+    MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(1, 2, 3, -1);
 
     final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
     final List<Integer> intIteratorCopy = asList(bitmap.getIntIterator());
+    final List<Integer> signedIntIteratorCopy = asList(bitmap.getSignedIntIterator());
     final List<Integer> reverseIntIteratorCopy = asList(bitmap.getReverseIntIterator());
 
-    assertEquals(ImmutableList.of(1, 2, 3), iteratorCopy);
-    assertEquals(ImmutableList.of(1, 2, 3), intIteratorCopy);
-    assertEquals(ImmutableList.of(3, 2, 1), reverseIntIteratorCopy);
+    assertEquals(ImmutableList.of(1, 2, 3, -1), iteratorCopy);
+    assertEquals(ImmutableList.of(1, 2, 3, -1), intIteratorCopy);
+    assertEquals(ImmutableList.of(-1, 1, 2, 3), signedIntIteratorCopy);
+    assertEquals(ImmutableList.of(-1, 3, 2, 1), reverseIntIteratorCopy);
   }
 
   @Test
   public void testSmallIteration1() {
-    MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(1, 2, 3);
+    MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(1, 2, 3, -1);
     bitmap.runOptimize();
 
     final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
     final List<Integer> intIteratorCopy = asList(bitmap.getIntIterator());
+    final List<Integer> signedIntIteratorCopy = asList(bitmap.getSignedIntIterator());
     final List<Integer> reverseIntIteratorCopy = asList(bitmap.getReverseIntIterator());
 
-    assertEquals(ImmutableList.of(1, 2, 3), iteratorCopy);
-    assertEquals(ImmutableList.of(1, 2, 3), intIteratorCopy);
-    assertEquals(ImmutableList.of(3, 2, 1), reverseIntIteratorCopy);
+    assertEquals(ImmutableList.of(1, 2, 3, -1), iteratorCopy);
+    assertEquals(ImmutableList.of(1, 2, 3, -1), intIteratorCopy);
+    assertEquals(ImmutableList.of(-1, 1, 2, 3), signedIntIteratorCopy);
+    assertEquals(ImmutableList.of(-1, 3, 2, 1), reverseIntIteratorCopy);
   }
   
   


### PR DESCRIPTION
### SUMMARY
Add getSignedIntIterator to roaring bitmaps

We sometimes use roaring bitmaps for iterative filtering where the opposite side of the join is sorted using signed comparison. This adds a function for creating a peekable int iterator to more easily allow that. This is considerably more efficient and easier than implementing the sorted iterator on the client side.

Tests are added for both roaring bitmaps and immutable roaring bitmaps. As well, existing int iterator tests have been improved to use integers above 2^31 in the test iterators, which was missing by only taking the absolute value of the random integers.

### Automated Checks

- [X] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [X] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
