### PR TITLE
document hasNext in BatchIterator

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BatchIterator.java
@@ -12,8 +12,8 @@ public interface BatchIterator extends Cloneable {
   int nextBatch(int[] buffer);
 
   /**
-   * Returns true is there are more values to get.
-   * @return whether the iterator is exhaused or not.
+   * Returns true is there possibly are more values to get.
+   * @return whether the iterator is known to be exhaused.
    */
   boolean hasNext();
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapBatchIterator.java
@@ -31,7 +31,7 @@ public final class BitmapBatchIterator implements ContainerBatchIterator {
 
   @Override
   public boolean hasNext() {
-    return wordIndex < 1024;
+    return wordIndex < 1024; // there might be more values
   }
 
   @Override

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BitmapBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BitmapBatchIterator.java
@@ -33,7 +33,7 @@ public final class BitmapBatchIterator implements ContainerBatchIterator {
 
   @Override
   public boolean hasNext() {
-    return wordIndex < 1024;
+    return wordIndex < 1024; // there might be more values
   }
 
   @Override


### PR DESCRIPTION
### SUMMARY

Correct the documentation, thus fixing issue https://github.com/RoaringBitmap/RoaringBitmap/issues/730

When using a BatchIterator, hasNext may return true even if the iterator is exhausted. The user will get back 0 values in the next call.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
