### PR TITLE
fix hasNext behaviour for BitmapBatchIterator #730

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/BitmapBatchIterator.java
@@ -31,7 +31,17 @@ public final class BitmapBatchIterator implements ContainerBatchIterator {
 
   @Override
   public boolean hasNext() {
-    return wordIndex < 1024;
+    if (wordIndex > 1023) {
+      return false;
+    }
+    while (word == 0) {
+      ++wordIndex;
+      if (wordIndex == 1024) { // reached end without a non-empty word
+        return false;
+      }
+      word = bitmap.bitmap[wordIndex];
+    }
+    return true; // found some non-empty word, so hasNext
   }
 
   @Override

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BitmapBatchIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/BitmapBatchIterator.java
@@ -33,7 +33,17 @@ public final class BitmapBatchIterator implements ContainerBatchIterator {
 
   @Override
   public boolean hasNext() {
-    return wordIndex < 1024;
+    if (wordIndex > 1023) {
+      return false;
+    }
+    while (word == 0) {
+      ++wordIndex;
+      if (wordIndex == 1024) { // reached end without a non-empty word
+        return false;
+      }
+      word = bitmap.bitmap.get(wordIndex);
+    }
+    return true; // found some non-empty word, so hasNext
   }
 
   @Override

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/ContainerBatchIteratorTest.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/ContainerBatchIteratorTest.java
@@ -3,6 +3,7 @@ package org.roaringbitmap;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -14,8 +15,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.copyOfRange;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @Execution(ExecutionMode.CONCURRENT)
 public class ContainerBatchIteratorTest {
@@ -146,6 +146,13 @@ public class ContainerBatchIteratorTest {
                 "Failure with batch size " + batchSize + " and container type " + container.getContainerName());
         }
         assertEquals(expectedValues.length, cardinality);
+    }
+
+    // https://github.com/RoaringBitmap/RoaringBitmap/issues/730
+    @Test
+    public void testHasNextBitmapIterator() {
+        BitmapContainer container = new BitmapContainer(); // create an empty container
+        assertFalse(container.getBatchIterator().hasNext());
     }
 
     private Container createContainer(int[] expectedValues) {


### PR DESCRIPTION
### SUMMARY
- Adds a failing test to validate behaviour is correct after fix
- Modifies hasNext implementation for Bitmap container iterator 
- `BitmapBatchIterator.hasNext` now returns accurate result for Bitmap container with no remaining elements
- This adds some perf overhead, which seems tolerable given this is a batched iterator and those extra steps will anyways happen in `BitmapBatchIterator.next`

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
