### PR TITLE
Add BSI based on Roaring64Bitmap

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/art/KeyIterator.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/art/KeyIterator.java
@@ -26,6 +26,10 @@ public class KeyIterator implements Iterator<byte[]> {
     return current.getKeyBytes();
   }
 
+  public byte[] peekNext() {
+    return leafNodeIterator.peekNext().getKeyBytes();
+  }
+
   public long nextKey() {
     return current.getKey();
   }
@@ -34,6 +38,7 @@ public class KeyIterator implements Iterator<byte[]> {
     return current.getContainerIdx();
   }
 
+  @Override
   public void remove() {
     leafNodeIterator.remove();
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/HighLowContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/HighLowContainer.java
@@ -148,6 +148,23 @@ public class HighLowContainer {
   }
 
   /**
+   * Compares two unsigned byte arrays for order.
+   * Result is a negative integer, zero, or a positive integer
+   * as the first array is less than, equal to, or greater than the second.
+   * @return result of comparing
+   */
+  public static int compareUnsigned(byte[] a, byte[] b) {
+    for (int i = 0; i < Math.min(a.length, b.length); i++) {
+      int aVal = a[i] & 0xff;
+      int bVal = b[i] & 0xff;
+      if (aVal != bVal) {
+        return Integer.compare(aVal, bVal);
+      }
+    }
+    return Integer.compare(a.length, b.length);
+  }
+
+  /**
    * serialize into the ByteBuffer in little endian
    * @param buffer the ByteBuffer should be large enough to hold the data
    * @throws IOException indicate exception happened

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/HighLowContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/HighLowContainer.java
@@ -154,6 +154,12 @@ public class HighLowContainer {
    * @return result of comparing
    */
   public static int compareUnsigned(byte[] a, byte[] b) {
+    if (a == null) {
+      return b == null ? 0 : 1;
+    }
+    if (b == null) {
+      return -1;
+    }
     for (int i = 0; i < Math.min(a.length, b.length); i++) {
       int aVal = a[i] & 0xff;
       int bVal = b[i] & 0xff;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -438,8 +438,8 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
         long containerIdx2 = it2.currentContainerIdx();
         Container container1 = x1.highLowContainer.getContainer(containerIdx1);
         Container container2 = x2.highLowContainer.getContainer(containerIdx2);
-        Container orResult = container1.xor(container2);
-        result.highLowContainer.put(highKey1, orResult);
+        Container xorResult = container1.xor(container2);
+        result.highLowContainer.put(highKey1, xorResult);
 
         highKey1 = it1.hasNext() ? it1.next() : null;
         highKey2 = it2.hasNext() ? it2.next() : null;

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -602,12 +602,18 @@ public class TestRoaring64Bitmap {
     left.addLong(123);
     right.addLong(234);
 
+    Roaring64Bitmap orNotInPlace = Roaring64Bitmap.or(left, right);
     left.or(right);
 
     assertEquals(2, left.getLongCardinality());
 
     assertEquals(123, left.select(0));
     assertEquals(234, left.select(1));
+
+    assertEquals(2, orNotInPlace.getLongCardinality());
+
+    assertEquals(123, orNotInPlace.select(0));
+    assertEquals(234, orNotInPlace.select(1));
   }
 
   @Test
@@ -619,6 +625,7 @@ public class TestRoaring64Bitmap {
     left.addLong(Long.MAX_VALUE);
     right.addLong(234);
 
+    Roaring64Bitmap orNotInPlace = Roaring64Bitmap.or(left, right);
     left.or(right);
 
     assertEquals(3, left.getLongCardinality());
@@ -626,6 +633,12 @@ public class TestRoaring64Bitmap {
     assertEquals(123, left.select(0));
     assertEquals(234, left.select(1));
     assertEquals(Long.MAX_VALUE, left.select(2));
+
+    assertEquals(3, orNotInPlace.getLongCardinality());
+
+    assertEquals(123, orNotInPlace.select(0));
+    assertEquals(234, orNotInPlace.select(1));
+    assertEquals(Long.MAX_VALUE, orNotInPlace.select(2));
   }
 
   @Test
@@ -636,12 +649,18 @@ public class TestRoaring64Bitmap {
     left.addLong(123);
     right.addLong(Long.MAX_VALUE / 2);
 
+    Roaring64Bitmap orNotInPlace = Roaring64Bitmap.or(left, right);
     left.or(right);
 
     assertEquals(2, left.getLongCardinality());
 
     assertEquals(123, left.select(0));
     assertEquals(Long.MAX_VALUE / 2, left.select(1));
+
+    assertEquals(2, orNotInPlace.getLongCardinality());
+
+    assertEquals(123, orNotInPlace.select(0));
+    assertEquals(Long.MAX_VALUE / 2, orNotInPlace.select(1));
   }
 
 
@@ -653,12 +672,18 @@ public class TestRoaring64Bitmap {
     left.addLong(123);
     right.addLong(Long.MAX_VALUE);
 
+    Roaring64Bitmap orNotInPlace = Roaring64Bitmap.or(left, right);
     left.or(right);
 
     assertEquals(2, left.getLongCardinality());
 
     assertEquals(123, left.select(0));
     assertEquals(Long.MAX_VALUE, left.select(1));
+
+    assertEquals(2, orNotInPlace.getLongCardinality());
+
+    assertEquals(123, orNotInPlace.select(0));
+    assertEquals(Long.MAX_VALUE, orNotInPlace.select(1));
   }
 
   @Test
@@ -694,11 +719,16 @@ public class TestRoaring64Bitmap {
     right.addLong(345);
 
     // We have 1 shared value: 234
+    Roaring64Bitmap xorNotInPlace = Roaring64Bitmap.xor(left, right);
     left.xor(right);
 
     assertEquals(2, left.getLongCardinality());
     assertEquals(123, left.select(0));
     assertEquals(345, left.select(1));
+
+    assertEquals(2, xorNotInPlace.getLongCardinality());
+    assertEquals(123, xorNotInPlace.select(0));
+    assertEquals(345, xorNotInPlace.select(1));
   }
 
   @Test
@@ -711,11 +741,16 @@ public class TestRoaring64Bitmap {
     right.addLong(234);
     right.addLong(345);
 
+    Roaring64Bitmap xorNotInPlace = Roaring64Bitmap.xor(left, right);
     left.xor(right);
 
     assertEquals(2, left.getLongCardinality());
     assertEquals(123, left.select(0));
     assertEquals(345, left.select(1));
+
+    assertEquals(2, xorNotInPlace.getLongCardinality());
+    assertEquals(123, xorNotInPlace.select(0));
+    assertEquals(345, xorNotInPlace.select(1));
   }
 
   @Test
@@ -727,11 +762,16 @@ public class TestRoaring64Bitmap {
     right.addLong(Long.MAX_VALUE);
 
     // We have 1 shared value: 234
+    Roaring64Bitmap xorNotInPlace = Roaring64Bitmap.xor(left, right);
     left.xor(right);
 
     assertEquals(2, left.getLongCardinality());
     assertEquals(123, left.select(0));
     assertEquals(Long.MAX_VALUE, left.select(1));
+
+    assertEquals(2, xorNotInPlace.getLongCardinality());
+    assertEquals(123, xorNotInPlace.select(0));
+    assertEquals(Long.MAX_VALUE, xorNotInPlace.select(1));
   }
 
   @Test
@@ -744,10 +784,14 @@ public class TestRoaring64Bitmap {
     right.addLong(Long.MAX_VALUE);
 
     // We have 1 shared value: 234
+    Roaring64Bitmap xorNotInPlace = Roaring64Bitmap.xor(left, right);
     left.xor(right);
 
     assertEquals(1, left.getLongCardinality());
     assertEquals(123, left.select(0));
+
+    assertEquals(1, xorNotInPlace.getLongCardinality());
+    assertEquals(123, xorNotInPlace.select(0));
   }
 
 
@@ -762,10 +806,14 @@ public class TestRoaring64Bitmap {
     right.addLong(345);
 
     // We have 1 shared value: 234
+    Roaring64Bitmap andNotInPlace = Roaring64Bitmap.and(left, right);
     left.and(right);
 
     assertEquals(1, left.getLongCardinality());
     assertEquals(234, left.select(0));
+
+    assertEquals(1, andNotInPlace.getLongCardinality());
+    assertEquals(234, andNotInPlace.select(0));
   }
 
   @Test
@@ -777,10 +825,14 @@ public class TestRoaring64Bitmap {
     right.addLong(123);
 
     // We have 1 shared value: 234
+    Roaring64Bitmap andNotInPlace = Roaring64Bitmap.and(left, right);
     left.and(right);
 
     assertEquals(1, left.getLongCardinality());
     assertEquals(123, left.select(0));
+
+    assertEquals(1, andNotInPlace.getLongCardinality());
+    assertEquals(123, andNotInPlace.select(0));
   }
 
   @Test
@@ -792,17 +844,24 @@ public class TestRoaring64Bitmap {
     Roaring64Bitmap left = Roaring64Bitmap.bitmapOf(leftData);
     Roaring64Bitmap right = Roaring64Bitmap.bitmapOf(rightData);
 
+    Roaring64Bitmap andNotInPlace = Roaring64Bitmap.and(left, right);
     left.and(right);
 
     Roaring64Bitmap swapLeft = Roaring64Bitmap.bitmapOf(rightData);
     Roaring64Bitmap swapRight = Roaring64Bitmap.bitmapOf(leftData);
 
+    Roaring64Bitmap swapAndNotInPlace = Roaring64Bitmap.and(left, right);
     swapLeft.and(swapRight);
 
     assertEquals(0, left.getLongCardinality());
     assertEquals(0, swapLeft.getLongCardinality());
     assertThrows(IllegalArgumentException.class, () -> left.select(0));
     assertThrows(IllegalArgumentException.class, () -> swapLeft.select(0));
+
+    assertEquals(0, andNotInPlace.getLongCardinality());
+    assertEquals(0, swapAndNotInPlace.getLongCardinality());
+    assertThrows(IllegalArgumentException.class, () -> andNotInPlace.select(0));
+    assertThrows(IllegalArgumentException.class, () -> swapAndNotInPlace.select(0));
   }
 
   @Test
@@ -813,9 +872,11 @@ public class TestRoaring64Bitmap {
     Roaring64Bitmap bitmap2 = new Roaring64Bitmap();
     bitmap2.addLong(1);
     //bit and
+    Roaring64Bitmap andNotInPlace = Roaring64Bitmap.and(bitmap, bitmap2);
     bitmap.and(bitmap2);
     //to array
     Assertions.assertDoesNotThrow(bitmap::toArray);
+    Assertions.assertDoesNotThrow(andNotInPlace::toArray);
   }
 
   @Test
@@ -842,12 +903,118 @@ public class TestRoaring64Bitmap {
     right.addLong(Long.MAX_VALUE);
 
     // We have 1 shared value: 234
+    Roaring64Bitmap andNotInPlace = Roaring64Bitmap.and(left, right);
     left.and(right);
 
     assertEquals(1, left.getLongCardinality());
     assertEquals(Long.MAX_VALUE, left.select(0));
+
+    assertEquals(1, andNotInPlace.getLongCardinality());
+    assertEquals(Long.MAX_VALUE, andNotInPlace.select(0));
   }
 
+  @Test
+  public void intersecttest() {
+    final Roaring64Bitmap rr1 = new Roaring64Bitmap();
+    final Roaring64Bitmap rr2 = new Roaring64Bitmap();
+    for (int k = 0; k < 40000; ++k) {
+      rr1.add(2 * k);
+      rr2.add(2 * k + 1);
+    }
+    assertFalse(Roaring64Bitmap.intersects(rr1, rr2));
+    rr1.add(2 * 500 + 1);
+    assertTrue(Roaring64Bitmap.intersects(rr1, rr2));
+    final Roaring64Bitmap rr3 = new Roaring64Bitmap();
+    rr3.add(2 * 501 + 1);
+    assertTrue(Roaring64Bitmap.intersects(rr3, rr2));
+    assertFalse(Roaring64Bitmap.intersects(rr3, rr1));
+    for (int k = 0; k < 40000; ++k) {
+      rr1.add(2 * k + 1);
+    }
+    rr1.runOptimize();
+    assertTrue(Roaring64Bitmap.intersects(rr1, rr2));
+  }
+
+  @Test
+  public void andcounttest() {
+    // This is based on andtest
+    final Roaring64Bitmap rr = new Roaring64Bitmap();
+    for (int k = 0; k < 4000; ++k) {
+      rr.add(k);
+    }
+    rr.add(100000);
+    rr.add(110000);
+    final Roaring64Bitmap rr2 = new Roaring64Bitmap();
+    rr2.add(13);
+    final Roaring64Bitmap rrand = Roaring64Bitmap.and(rr, rr2);
+    assertEquals(rrand.getCardinality(), Roaring64Bitmap.andCardinality(rr, rr2));
+    assertEquals(rrand.getCardinality(), Roaring64Bitmap.andCardinality(rr2, rr));
+    rr.and(rr2);
+    assertEquals(rrand.getCardinality(), Roaring64Bitmap.andCardinality(rr2, rr));
+  }
+
+  @Test
+  public void andCounttest3() {
+    // This is based on andtest3
+    final int[] arrayand = new int[11256];
+    int pos = 0;
+    final Roaring64Bitmap rr = new Roaring64Bitmap();
+    for (int k = 4000; k < 4256; ++k) {
+      rr.add(k);
+    }
+    for (int k = 65536; k < 65536 + 4000; ++k) {
+      rr.add(k);
+    }
+    for (int k = 3 * 65536; k < 3 * 65536 + 1000; ++k) {
+      rr.add(k);
+    }
+    for (int k = 3 * 65536 + 1000; k < 3 * 65536 + 7000; ++k) {
+      rr.add(k);
+    }
+    for (int k = 3 * 65536 + 7000; k < 3 * 65536 + 9000; ++k) {
+      rr.add(k);
+    }
+    for (int k = 4 * 65536; k < 4 * 65536 + 7000; ++k) {
+      rr.add(k);
+    }
+    for (int k = 6 * 65536; k < 6 * 65536 + 10000; ++k) {
+      rr.add(k);
+    }
+    for (int k = 8 * 65536; k < 8 * 65536 + 1000; ++k) {
+      rr.add(k);
+    }
+    for (int k = 9 * 65536; k < 9 * 65536 + 30000; ++k) {
+      rr.add(k);
+    }
+    final Roaring64Bitmap rr2 = new Roaring64Bitmap();
+    for (int k = 4000; k < 4256; ++k) {
+      rr2.add(k);
+      arrayand[pos++] = k;
+    }
+    for (int k = 65536; k < 65536 + 4000; ++k) {
+      rr2.add(k);
+      arrayand[pos++] = k;
+    }
+    for (int k = 3 * 65536 + 1000; k < 3 * 65536 + 7000; ++k) {
+      rr2.add(k);
+      arrayand[pos++] = k;
+    }
+    for (int k = 6 * 65536; k < 6 * 65536 + 1000; ++k) {
+      rr2.add(k);
+      arrayand[pos++] = k;
+    }
+    for (int k = 7 * 65536; k < 7 * 65536 + 1000; ++k) {
+      rr2.add(k);
+    }
+    for (int k = 10 * 65536; k < 10 * 65536 + 5000; ++k) {
+      rr2.add(k);
+    }
+
+    final Roaring64Bitmap rrand = Roaring64Bitmap.and(rr, rr2);
+    final int rrandCount = Roaring64Bitmap.andCardinality(rr, rr2);
+
+    assertEquals(rrand.getCardinality(), rrandCount);
+  }
 
   @Test
   public void testAndNotSingleBucket() {
@@ -860,10 +1027,14 @@ public class TestRoaring64Bitmap {
     right.addLong(345);
 
     // We have 1 shared value: 234
+    Roaring64Bitmap andNotNotInPlace = Roaring64Bitmap.andNot(left, right);
     left.andNot(right);
 
     assertEquals(1, left.getLongCardinality());
     assertEquals(123, left.select(0));
+
+    assertEquals(1, andNotNotInPlace.getLongCardinality());
+    assertEquals(123, andNotNotInPlace.select(0));
   }
 
   @Test
@@ -875,10 +1046,14 @@ public class TestRoaring64Bitmap {
     right.addLong(234);
 
     // We have 1 shared value: 234
+    Roaring64Bitmap andNotNotInPlace = Roaring64Bitmap.andNot(left, right);
     left.andNot(right);
 
     assertEquals(1, left.getLongCardinality());
     assertEquals(123, left.select(0));
+
+    assertEquals(1, andNotNotInPlace.getLongCardinality());
+    assertEquals(123, andNotNotInPlace.select(0));
   }
 
   @Test
@@ -890,10 +1065,14 @@ public class TestRoaring64Bitmap {
     right.addLong(Long.MAX_VALUE);
 
     // We have 1 shared value: 234
+    Roaring64Bitmap andNotNotInPlace = Roaring64Bitmap.andNot(left, right);
     left.andNot(right);
 
     assertEquals(1, left.getLongCardinality());
     assertEquals(123, left.select(0));
+
+    assertEquals(1, andNotNotInPlace.getLongCardinality());
+    assertEquals(123, andNotNotInPlace.select(0));
   }
 
   @Test
@@ -906,10 +1085,14 @@ public class TestRoaring64Bitmap {
     right.addLong(Long.MAX_VALUE);
 
     // We have 1 shared value: 234
+    Roaring64Bitmap andNotNotInPlace = Roaring64Bitmap.andNot(left, right);
     left.andNot(right);
 
     assertEquals(1, left.getLongCardinality());
     assertEquals(123, left.select(0));
+
+    assertEquals(1, andNotNotInPlace.getLongCardinality());
+    assertEquals(123, andNotNotInPlace.select(0));
   }
 
   @Test

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -947,10 +947,10 @@ public class TestRoaring64Bitmap {
     final Roaring64Bitmap rr2 = new Roaring64Bitmap();
     rr2.add(13);
     final Roaring64Bitmap rrand = Roaring64Bitmap.and(rr, rr2);
-    assertEquals(rrand.getCardinality(), Roaring64Bitmap.andCardinality(rr, rr2));
-    assertEquals(rrand.getCardinality(), Roaring64Bitmap.andCardinality(rr2, rr));
+    assertEquals(rrand.getLongCardinality(), Roaring64Bitmap.andCardinality(rr, rr2));
+    assertEquals(rrand.getLongCardinality(), Roaring64Bitmap.andCardinality(rr2, rr));
     rr.and(rr2);
-    assertEquals(rrand.getCardinality(), Roaring64Bitmap.andCardinality(rr2, rr));
+    assertEquals(rrand.getLongCardinality(), Roaring64Bitmap.andCardinality(rr2, rr));
   }
 
   @Test
@@ -1011,9 +1011,9 @@ public class TestRoaring64Bitmap {
     }
 
     final Roaring64Bitmap rrand = Roaring64Bitmap.and(rr, rr2);
-    final int rrandCount = Roaring64Bitmap.andCardinality(rr, rr2);
+    final long rrandCount = Roaring64Bitmap.andCardinality(rr, rr2);
 
-    assertEquals(rrand.getCardinality(), rrandCount);
+    assertEquals(rrand.getLongCardinality(), rrandCount);
   }
 
   @Test

--- a/bsi/src/main/java/org/roaringbitmap/bsi/longlong/Roaring64BitmapSliceIndex.java
+++ b/bsi/src/main/java/org/roaringbitmap/bsi/longlong/Roaring64BitmapSliceIndex.java
@@ -407,7 +407,7 @@ public class Roaring64BitmapSliceIndex {
    * @return columnId set we found in this bsi with giving conditions, using RoaringBitmap to express
    * see https://github.com/lemire/BitSliceIndex/blob/master/src/main/java/org/roaringbitmap/circuits/comparator/BasicComparator.java
    */
-  private Roaring64Bitmap oNeilCompare(BitmapSliceIndex.Operation operation, int predicate, Roaring64Bitmap foundSet) {
+  private Roaring64Bitmap oNeilCompare(BitmapSliceIndex.Operation operation, long predicate, Roaring64Bitmap foundSet) {
     Roaring64Bitmap fixedFoundSet = foundSet == null ? this.ebM : foundSet;
 
     Roaring64Bitmap GT = new Roaring64Bitmap();
@@ -416,7 +416,7 @@ public class Roaring64BitmapSliceIndex {
 
 
     for (int i = this.bitCount() - 1; i >= 0; i--) {
-      int bit = (predicate >> i) & 1;
+      int bit = (int) ((predicate >> i) & 1);
       if (bit == 1) {
         LT = Roaring64Bitmap.or(LT, Roaring64Bitmap.andNot(EQ, this.bA[i]));
         EQ = Roaring64Bitmap.and(EQ, this.bA[i]);
@@ -457,7 +457,7 @@ public class Roaring64BitmapSliceIndex {
    * @param foundSet     columnId set we want compare,using RoaringBitmap to express
    * @return columnId set we found in this bsi with giving conditions, using RoaringBitmap to express
    */
-  public Roaring64Bitmap compare(BitmapSliceIndex.Operation operation, int startOrValue, int end, Roaring64Bitmap foundSet) {
+  public Roaring64Bitmap compare(BitmapSliceIndex.Operation operation, long startOrValue, long end, Roaring64Bitmap foundSet) {
     Roaring64Bitmap result = compareUsingMinMax(operation, startOrValue, end, foundSet);
     if (result != null) {
       return result;
@@ -490,7 +490,7 @@ public class Roaring64BitmapSliceIndex {
     }
   }
 
-  private Roaring64Bitmap compareUsingMinMax(BitmapSliceIndex.Operation operation, int startOrValue, int end, Roaring64Bitmap foundSet) {
+  private Roaring64Bitmap compareUsingMinMax(BitmapSliceIndex.Operation operation, long startOrValue, long end, Roaring64Bitmap foundSet) {
     Roaring64Bitmap all = foundSet == null ? ebM.clone() : Roaring64Bitmap.and(ebM, foundSet);
     Roaring64Bitmap empty = new Roaring64Bitmap();
 

--- a/bsi/src/main/java/org/roaringbitmap/bsi/longlong/Roaring64BitmapSliceIndex.java
+++ b/bsi/src/main/java/org/roaringbitmap/bsi/longlong/Roaring64BitmapSliceIndex.java
@@ -1,0 +1,571 @@
+package org.roaringbitmap.bsi.longlong;
+
+import org.roaringbitmap.bsi.BitmapSliceIndex;
+import org.roaringbitmap.bsi.Pair;
+import org.roaringbitmap.bsi.WritableUtils;
+import org.roaringbitmap.longlong.Roaring64Bitmap;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.IntStream;
+
+public class Roaring64BitmapSliceIndex {
+  /**
+   * the maxValue of this bsi
+   */
+  private long maxValue;
+
+  /**
+   * the minValue of this bsi
+   */
+  private long minValue;
+
+  /**
+   * the bit component slice Array of this bsi
+   */
+  private Roaring64Bitmap[] bA;
+
+  /**
+   * the exist bitmap of this bsi which means the columnId have value in this bsi
+   */
+  private Roaring64Bitmap ebM;
+
+
+  private Boolean runOptimized = false;
+
+  /**
+   * NewBSI constructs a new BSI.  Min/Max values are optional.  If set to 0
+   * then the underlying BSI will be automatically sized.
+   */
+  public Roaring64BitmapSliceIndex(long minValue, long maxValue) {
+    if (minValue < 0) {
+      throw new IllegalArgumentException("Values should be non-negative");
+    }
+
+    this.bA = new Roaring64Bitmap[64 - Long.numberOfLeadingZeros(maxValue)];
+    for (int i = 0; i < bA.length; i++) {
+      this.bA[i] = new Roaring64Bitmap();
+    }
+
+    this.ebM = new Roaring64Bitmap();
+  }
+
+  /**
+   * NewDefaultBSI constructs an auto-sized BSI
+   */
+  public Roaring64BitmapSliceIndex() {
+    this(0L, 0L);
+  }
+
+  public void add(Roaring64BitmapSliceIndex otherBsi) {
+    if (null == otherBsi || otherBsi.ebM.isEmpty()) {
+      return;
+    }
+
+    this.ebM.or(otherBsi.ebM);
+    if (otherBsi.bitCount() > this.bitCount()) {
+      grow(otherBsi.bitCount());
+    }
+
+    for (int i = 0; i < otherBsi.bitCount(); i++) {
+      this.addDigit(otherBsi.bA[i], i);
+    }
+
+    // update min and max after adding
+    this.minValue = minValue();
+    this.maxValue = maxValue();
+  }
+
+  private void addDigit(Roaring64Bitmap foundSet, int i) {
+    Roaring64Bitmap carry = Roaring64Bitmap.and(this.bA[i], foundSet);
+    this.bA[i].xor(foundSet);
+    if (!carry.isEmpty()) {
+      if (i + 1 >= this.bitCount()) {
+        grow(this.bitCount() + 1);
+      }
+      this.addDigit(carry, i + 1);
+    }
+
+  }
+
+  private long minValue() {
+    if (ebM.isEmpty()) {
+      return 0;
+    }
+
+    Roaring64Bitmap minValuesId = ebM;
+    for (int i = bA.length - 1; i >= 0; i -= 1) {
+      Roaring64Bitmap tmp = Roaring64Bitmap.andNot(minValuesId, bA[i]);
+      if (!tmp.isEmpty()) {
+        minValuesId = tmp;
+      }
+    }
+
+    return valueAt(minValuesId.first());
+  }
+
+  private long maxValue() {
+    if (ebM.isEmpty()) {
+      return 0;
+    }
+
+    Roaring64Bitmap maxValuesId = ebM;
+    for (int i = bA.length - 1; i >= 0; i -= 1) {
+      Roaring64Bitmap tmp = Roaring64Bitmap.and(maxValuesId, bA[i]);
+      if (!tmp.isEmpty()) {
+        maxValuesId = tmp;
+      }
+    }
+
+    return valueAt(maxValuesId.first());
+  }
+
+  private long valueAt(long columnId) {
+    int value = 0;
+    for (int i = 0; i < this.bitCount(); i += 1) {
+      if (this.bA[i].contains(columnId)) {
+        value |= (1 << i);
+      }
+    }
+
+    return value;
+  }
+
+  /**
+   * RunOptimize attempts to further compress the runs of consecutive values found in the bitmap
+   */
+  public void runOptimize() {
+    this.ebM.runOptimize();
+
+    for (Roaring64Bitmap integers : this.bA) {
+      integers.runOptimize();
+    }
+    this.runOptimized = true;
+  }
+
+  /**
+   * hasRunCompression returns true if the bitmap benefits from run compression
+   */
+
+  public boolean hasRunCompression() {
+    return this.runOptimized;
+  }
+
+  /**
+   * GetExistenceBitmap returns a pointer to the underlying existence bitmap of the BSI
+   */
+
+  public Roaring64Bitmap getExistenceBitmap() {
+    return this.ebM;
+  }
+
+  public int bitCount() {
+    return this.bA.length;
+  }
+
+  public long getLongCardinality() {
+    return this.ebM.getLongCardinality();
+  }
+
+  /**
+   * GetValue gets the value at the column ID.  Second param will be false for non-existence values.
+   */
+  public Pair<Long, Boolean> getValue(long columnId) {
+    boolean exists = this.ebM.contains(columnId);
+    if (!exists) {
+      return Pair.newPair(0L, false);
+    }
+
+    return Pair.newPair(valueAt(columnId), true);
+  }
+
+
+  private void clear() {
+    this.maxValue = 0;
+    this.minValue = 0;
+    this.ebM = null;
+    this.bA = null;
+  }
+
+  public void serialize(DataOutput output) throws IOException {
+    // write meta
+    WritableUtils.writeVLong(output, minValue);
+    WritableUtils.writeVLong(output, maxValue);
+    output.writeBoolean(this.runOptimized);
+
+    // write ebm
+    this.ebM.serialize(output);
+
+    // write ba
+    WritableUtils.writeVInt(output, this.bA.length);
+    for (Roaring64Bitmap rb : this.bA) {
+      rb.serialize(output);
+    }
+  }
+
+  public void deserialize(DataInput in) throws IOException {
+    this.clear();
+
+    // read meta
+    this.minValue = WritableUtils.readVInt(in);
+    this.maxValue = WritableUtils.readVInt(in);
+    this.runOptimized = in.readBoolean();
+
+    // read ebm
+    Roaring64Bitmap ebm = new Roaring64Bitmap();
+    ebm.deserialize(in);
+    this.ebM = ebm;
+
+    // read ba
+    int bitDepth = WritableUtils.readVInt(in);
+    Roaring64Bitmap[] ba = new Roaring64Bitmap[bitDepth];
+    for (int i = 0; i < bitDepth; i++) {
+      Roaring64Bitmap rb = new Roaring64Bitmap();
+      rb.deserialize(in);
+      ba[i] = rb;
+    }
+    this.bA = ba;
+  }
+
+  public void serialize(ByteBuffer buffer) throws IOException {
+    // write meta
+    buffer.putLong(this.minValue);
+    buffer.putLong(this.maxValue);
+    buffer.put(this.runOptimized ? (byte) 1 : (byte) 0);
+    // write ebm
+    this.ebM.serialize(buffer);
+
+    // write ba
+    buffer.putInt(this.bA.length);
+    for (Roaring64Bitmap rb : this.bA) {
+      rb.serialize(buffer);
+    }
+  }
+
+  public void deserialize(ByteBuffer buffer) throws IOException {
+    this.clear();
+    // read meta
+    this.minValue = buffer.getLong();
+    this.maxValue = buffer.getLong();
+    this.runOptimized = buffer.get() == (byte) 1;
+
+    // read ebm
+    Roaring64Bitmap ebm = new Roaring64Bitmap();
+    ebm.deserialize(buffer);
+    this.ebM = ebm;
+    // read ba
+    buffer.position(buffer.position() + ebm.getSizeInBytes());
+    int bitDepth = buffer.getInt();
+    Roaring64Bitmap[] ba = new Roaring64Bitmap[bitDepth];
+    for (int i = 0; i < bitDepth; i++) {
+      Roaring64Bitmap rb = new Roaring64Bitmap();
+      rb.deserialize(buffer);
+      ba[i] = rb;
+      buffer.position(buffer.position() + rb.getSizeInBytes());
+    }
+    this.bA = ba;
+  }
+
+  public int serializedSizeInBytes() {
+    int size = 0;
+    for (Roaring64Bitmap rb : this.bA) {
+      size += rb.getSizeInBytes();
+    }
+    return 8 + 8 + 1 + 4 + this.ebM.getSizeInBytes() + size;
+  }
+
+  /**
+   * valueExists tests whether the value exists.
+   */
+  public boolean valueExist(Long columnId) {
+    return this.ebM.contains(columnId.intValue());
+  }
+
+  /**
+   * SetValue sets a value for a given columnID.
+   */
+  public void setValue(long columnId, long value) {
+    ensureCapacityInternal(value, value);
+    setValueInternal(columnId, value);
+  }
+
+  private void setValueInternal(long columnId, long value) {
+    for (int i = 0; i < this.bitCount(); i += 1) {
+      if ((value & (1L << i)) > 0) {
+        this.bA[i].add(columnId);
+      } else {
+        this.bA[i].remove(columnId);
+      }
+    }
+    this.ebM.add(columnId);
+  }
+
+  private void ensureCapacityInternal(long minValue, long maxValue) {
+    if (ebM.isEmpty()) {
+      this.minValue = minValue;
+      this.maxValue = maxValue;
+      grow(Long.toBinaryString(maxValue).length());
+    } else if (this.minValue > minValue) {
+      this.minValue = minValue;
+    } else if (this.maxValue < maxValue) {
+      this.maxValue = maxValue;
+      grow(Long.toBinaryString(maxValue).length());
+    }
+  }
+
+  private void grow(int newBitDepth) {
+    int oldBitDepth = this.bA.length;
+
+    if (oldBitDepth >= newBitDepth) {
+      return;
+    }
+
+    Roaring64Bitmap[] newBA = new Roaring64Bitmap[newBitDepth];
+    if (oldBitDepth != 0) {
+      System.arraycopy(this.bA, 0, newBA, 0, oldBitDepth);
+    }
+
+    for (int i = newBitDepth - 1; i >= oldBitDepth; i--) {
+      newBA[i] = new Roaring64Bitmap();
+      if (this.runOptimized) {
+        newBA[i].runOptimize();
+      }
+    }
+    this.bA = newBA;
+  }
+
+  public void setValues(List<Pair<Long, Long>> values) {
+    long maxValue = values.stream().mapToLong(Pair::getRight).filter(Objects::nonNull).max().getAsLong();
+    long minValue = values.stream().mapToLong(Pair::getRight).filter(Objects::nonNull).min().getAsLong();
+    ensureCapacityInternal(minValue, maxValue);
+    for (Pair<Long, Long> pair : values) {
+      setValueInternal(pair.getKey(), pair.getValue());
+    }
+  }
+
+  /**
+   * merge will merge 2 bsi into current
+   * merge API was designed for distributed computing
+   * note: current and other bsi has no intersection
+   *
+   * @param otherBsi other bsi we need merge
+   */
+  public void merge(Roaring64BitmapSliceIndex otherBsi) {
+
+    if (null == otherBsi || otherBsi.ebM.isEmpty()) {
+      return;
+    }
+
+    // todo whether we need this
+    if (Roaring64Bitmap.intersects(this.ebM, otherBsi.ebM)) {
+      throw new IllegalArgumentException("merge can be used only in bsiA  bsiB  is null");
+    }
+
+    int bitDepth = Integer.max(this.bitCount(), otherBsi.bitCount());
+    Roaring64Bitmap[] newBA = new Roaring64Bitmap[bitDepth];
+    for (int i = 0; i < bitDepth; i++) {
+      Roaring64Bitmap current = i < this.bA.length ? this.bA[i] : new Roaring64Bitmap();
+      Roaring64Bitmap other = i < otherBsi.bA.length ? otherBsi.bA[i] : new Roaring64Bitmap();
+      newBA[i] = Roaring64Bitmap.or(current, other);
+      if (this.runOptimized || otherBsi.runOptimized) {
+        newBA[i].runOptimize();
+      }
+    }
+    this.bA = newBA;
+    this.ebM.or(otherBsi.ebM);
+    this.runOptimized = this.runOptimized || otherBsi.runOptimized;
+    this.maxValue = Long.max(this.maxValue, otherBsi.maxValue);
+    this.minValue = Long.min(this.minValue, otherBsi.minValue);
+  }
+
+  @Override
+  public Roaring64BitmapSliceIndex clone() {
+    Roaring64BitmapSliceIndex bitSliceIndex = new Roaring64BitmapSliceIndex();
+    bitSliceIndex.minValue = this.minValue;
+    bitSliceIndex.maxValue = this.maxValue;
+    bitSliceIndex.ebM = this.ebM.clone();
+    Roaring64Bitmap[] cloneBA = new Roaring64Bitmap[this.bitCount()];
+    for (int i = 0; i < cloneBA.length; i++) {
+      cloneBA[i] = this.bA[i].clone();
+    }
+    bitSliceIndex.bA = cloneBA;
+    bitSliceIndex.runOptimized = this.runOptimized;
+
+    return bitSliceIndex;
+  }
+
+  /**
+   * O'Neil range using a bit-sliced index
+   *
+   * @param operation compare operation
+   * @param predicate the value we found filter
+   * @param foundSet  columnId set we want compare,using RoaringBitmap to express
+   * @return columnId set we found in this bsi with giving conditions, using RoaringBitmap to express
+   * see https://github.com/lemire/BitSliceIndex/blob/master/src/main/java/org/roaringbitmap/circuits/comparator/BasicComparator.java
+   */
+  private Roaring64Bitmap oNeilCompare(BitmapSliceIndex.Operation operation, int predicate, Roaring64Bitmap foundSet) {
+    Roaring64Bitmap fixedFoundSet = foundSet == null ? this.ebM : foundSet;
+
+    Roaring64Bitmap GT = new Roaring64Bitmap();
+    Roaring64Bitmap LT = new Roaring64Bitmap();
+    Roaring64Bitmap EQ = this.ebM;
+
+
+    for (int i = this.bitCount() - 1; i >= 0; i--) {
+      int bit = (predicate >> i) & 1;
+      if (bit == 1) {
+        LT = Roaring64Bitmap.or(LT, Roaring64Bitmap.andNot(EQ, this.bA[i]));
+        EQ = Roaring64Bitmap.and(EQ, this.bA[i]);
+      } else {
+        GT = Roaring64Bitmap.or(GT, Roaring64Bitmap.and(EQ, this.bA[i]));
+        EQ = Roaring64Bitmap.andNot(EQ, this.bA[i]);
+      }
+
+    }
+    EQ = Roaring64Bitmap.and(fixedFoundSet, EQ);
+    switch (operation) {
+      case EQ:
+        return EQ;
+      case NEQ:
+        return Roaring64Bitmap.andNot(fixedFoundSet, EQ);
+      case GT:
+        return Roaring64Bitmap.and(GT, fixedFoundSet);
+      case LT:
+        return Roaring64Bitmap.and(LT, fixedFoundSet);
+      case LE:
+        return Roaring64Bitmap.or(LT, EQ);
+      case GE:
+        return Roaring64Bitmap.or(GT, EQ);
+      default:
+        throw new IllegalArgumentException("");
+    }
+  }
+
+  /**
+   * BSI Compare using single thread
+   * this Function compose algorithm from O'Neil and Owen Kaser
+   * the GE algorithm is from Owen since the performance is better.  others are from O'Neil
+   *
+   * @param operation
+   * @param startOrValue the start or value of comparison, when the comparison operation is range, it's start,
+   *                     when others,it's value.
+   * @param end          the end value of comparison. when the comparison operation is not range,the end = 0
+   * @param foundSet     columnId set we want compare,using RoaringBitmap to express
+   * @return columnId set we found in this bsi with giving conditions, using RoaringBitmap to express
+   */
+  public Roaring64Bitmap compare(BitmapSliceIndex.Operation operation, int startOrValue, int end, Roaring64Bitmap foundSet) {
+    Roaring64Bitmap result = compareUsingMinMax(operation, startOrValue, end, foundSet);
+    if (result != null) {
+      return result;
+    }
+
+    switch (operation) {
+      case EQ:
+        return oNeilCompare(BitmapSliceIndex.Operation.EQ, startOrValue, foundSet);
+      case NEQ:
+        return oNeilCompare(BitmapSliceIndex.Operation.NEQ, startOrValue, foundSet);
+      case GE:
+        return oNeilCompare(BitmapSliceIndex.Operation.GE, startOrValue, foundSet);
+      case GT: {
+        return oNeilCompare(BitmapSliceIndex.Operation.GT, startOrValue, foundSet);
+      }
+      case LT:
+        return oNeilCompare(BitmapSliceIndex.Operation.LT, startOrValue, foundSet);
+
+      case LE:
+        return oNeilCompare(BitmapSliceIndex.Operation.LE, startOrValue, foundSet);
+
+      case RANGE: {
+        Roaring64Bitmap left = oNeilCompare(BitmapSliceIndex.Operation.GE, startOrValue, foundSet);
+        Roaring64Bitmap right = oNeilCompare(BitmapSliceIndex.Operation.LE, end, foundSet);
+
+        return Roaring64Bitmap.and(left, right);
+      }
+      default:
+        throw new IllegalArgumentException("not support operation!");
+    }
+  }
+
+  private Roaring64Bitmap compareUsingMinMax(BitmapSliceIndex.Operation operation, int startOrValue, int end, Roaring64Bitmap foundSet) {
+    Roaring64Bitmap all = foundSet == null ? ebM.clone() : Roaring64Bitmap.and(ebM, foundSet);
+    Roaring64Bitmap empty = new Roaring64Bitmap();
+
+    switch (operation) {
+      case LT:
+        if (startOrValue > maxValue) {
+          return all;
+        } else if (startOrValue <= minValue) {
+          return empty;
+        }
+
+        break;
+      case LE:
+        if (startOrValue >= maxValue) {
+          return all;
+        } else if (startOrValue < minValue) {
+          return empty;
+        }
+
+        break;
+      case GT:
+        if (startOrValue < minValue) {
+          return all;
+        } else if (startOrValue >= maxValue) {
+          return empty;
+        }
+
+        break;
+      case GE:
+        if (startOrValue <= minValue) {
+          return all;
+        } else if (startOrValue > maxValue) {
+          return empty;
+        }
+
+        break;
+      case EQ:
+        if (minValue == maxValue && minValue == startOrValue) {
+          return all;
+        } else if (startOrValue < minValue || startOrValue > maxValue) {
+          return empty;
+        }
+
+        break;
+      case NEQ:
+        if (minValue == maxValue) {
+          return minValue == startOrValue ? empty : all;
+        }
+
+        break;
+      case RANGE:
+        if (startOrValue <= minValue && end >= maxValue) {
+          return all;
+        } else if (startOrValue > maxValue || end < minValue) {
+          return empty;
+        }
+
+        break;
+      default:
+        return null;
+    }
+
+    return null;
+  }
+
+  public Pair<Long, Long> sum(Roaring64Bitmap foundSet) {
+    if (null == foundSet || foundSet.isEmpty()) {
+      return Pair.newPair(0L, 0L);
+    }
+    long count = foundSet.getLongCardinality();
+
+    Long sum = IntStream.range(0, this.bitCount())
+        .mapToLong(x -> (1L << x) * Roaring64Bitmap.andCardinality(this.bA[x], foundSet))
+        .sum();
+
+    return Pair.newPair(sum, count);
+  }
+}

--- a/bsi/src/main/java/org/roaringbitmap/bsi/longlong/Roaring64BitmapSliceIndex.java
+++ b/bsi/src/main/java/org/roaringbitmap/bsi/longlong/Roaring64BitmapSliceIndex.java
@@ -437,9 +437,9 @@ public class Roaring64BitmapSliceIndex {
       case LT:
         return Roaring64Bitmap.and(LT, fixedFoundSet);
       case LE:
-        return Roaring64Bitmap.or(LT, EQ);
+        return Roaring64Bitmap.and(Roaring64Bitmap.or(LT, EQ), fixedFoundSet);
       case GE:
-        return Roaring64Bitmap.or(GT, EQ);
+        return Roaring64Bitmap.and(Roaring64Bitmap.or(GT, EQ), fixedFoundSet);
       default:
         throw new IllegalArgumentException("");
     }

--- a/bsi/src/test/java/org/roaringbitmap/bsi/R64BSITest.java
+++ b/bsi/src/test/java/org/roaringbitmap/bsi/R64BSITest.java
@@ -1,0 +1,331 @@
+package org.roaringbitmap.bsi;
+
+import org.junit.jupiter.api.*;
+import org.roaringbitmap.bsi.longlong.Roaring64BitmapSliceIndex;
+import org.roaringbitmap.longlong.Roaring64Bitmap;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+public class R64BSITest {
+  private Map<Long, Long> testDataSet = new HashMap<>();
+
+  private Roaring64BitmapSliceIndex bsi;
+
+  @BeforeEach
+  public void setup() {
+    LongStream.range(1, 100).forEach(x -> testDataSet.put(x, x));
+    bsi = new Roaring64BitmapSliceIndex(1, 99);
+    testDataSet.forEach((k, v) -> {
+      bsi.setValue(k, v);
+    });
+  }
+
+  @Test
+  public void testSetAndGet() {
+    LongStream.range(1, 100).forEach(x -> {
+      Pair<Long, Boolean> pair = bsi.getValue(x);
+      Assertions.assertTrue(pair.getRight());
+      Assertions.assertEquals((long) pair.getKey(), x);
+    });
+
+    IntStream.range(1, 100).forEach(x -> {
+      Pair<Long, Boolean> pair = bsi.getValue(x);
+      Assertions.assertTrue(pair.getRight());
+      Assertions.assertEquals((long) pair.getKey(), x);
+    });
+  }
+
+  @Test
+  public void testMerge() {
+    Roaring64BitmapSliceIndex bsiA = new Roaring64BitmapSliceIndex();
+    IntStream.range(1, 100).forEach(x -> bsiA.setValue(x, x));
+    Roaring64BitmapSliceIndex bsiB = new Roaring64BitmapSliceIndex();
+    IntStream.range(100, 199).forEach(x -> bsiB.setValue(x, x));
+    Assertions.assertEquals(bsiA.getExistenceBitmap().getLongCardinality(), 99);
+    Assertions.assertEquals(bsiB.getExistenceBitmap().getLongCardinality(), 99);
+    bsiA.merge(bsiB);
+    IntStream.range(1, 199).forEach(x -> {
+      Pair<Long, Boolean> bsiValue = bsiA.getValue(x);
+      Assertions.assertTrue(bsiValue.getRight());
+      Assertions.assertEquals((long) bsiValue.getKey(), x);
+    });
+  }
+
+
+  @Test
+  public void testClone() {
+    Roaring64BitmapSliceIndex bsi = new Roaring64BitmapSliceIndex(1, 99);
+    List<Pair<Long, Long>> collect = testDataSet.entrySet()
+        .stream().map(x -> Pair.newPair(x.getKey(), x.getValue())).collect(Collectors.toList());
+
+    bsi.setValues(collect);
+
+    Assertions.assertEquals(bsi.getExistenceBitmap().getLongCardinality(), 99);
+    final Roaring64BitmapSliceIndex clone = bsi.clone();
+
+    IntStream.range(1, 100).forEach(x -> {
+      Pair<Long, Boolean> bsiValue = clone.getValue(x);
+      Assertions.assertTrue(bsiValue.getRight());
+      Assertions.assertEquals((long) bsiValue.getKey(), x);
+    });
+  }
+
+
+  @Test
+  public void testAdd() {
+    Roaring64BitmapSliceIndex bsiA = new Roaring64BitmapSliceIndex();
+    LongStream.range(1, 100).forEach(x -> bsiA.setValue(x, x));
+    Roaring64BitmapSliceIndex bsiB = new Roaring64BitmapSliceIndex();
+    LongStream.range(1, 120).forEach(x -> bsiB.setValue(x, x));
+
+    bsiA.add(bsiB);
+
+    LongStream.range(1, 120).forEach(x -> {
+      Pair<Long, Boolean> bsiValue = bsiA.getValue(x);
+      Assertions.assertTrue(bsiValue.getRight());
+      if (x < 100) {
+        Assertions.assertEquals((long) bsiValue.getKey(), x * 2);
+      } else {
+        Assertions.assertEquals((long) bsiValue.getKey(), x);
+      }
+
+    });
+  }
+
+  @Test
+  public void testAddAndEvaluate() {
+    Roaring64BitmapSliceIndex bsiA = new Roaring64BitmapSliceIndex();
+    IntStream.range(1, 100).forEach(x -> bsiA.setValue(x, x));
+    Roaring64BitmapSliceIndex bsiB = new Roaring64BitmapSliceIndex();
+    IntStream.range(1, 120).forEach(x -> bsiB.setValue(120 - x, x));
+
+    bsiA.add(bsiB);
+
+    Roaring64Bitmap result = bsiA.compare(BitmapSliceIndex.Operation.EQ, 120, 0, null);
+    Assertions.assertEquals(99, result.getLongCardinality());
+    Assertions.assertArrayEquals(result.toArray(), LongStream.range(1, 100).toArray());
+
+    result = bsiA.compare(BitmapSliceIndex.Operation.RANGE, 1, 20, null);
+    Assertions.assertEquals(20, result.getLongCardinality());
+    Assertions.assertArrayEquals(result.toArray(), LongStream.range(100, 120).toArray());
+  }
+
+
+  @Test
+  public void TestIO4Stream() throws IOException {
+    Roaring64BitmapSliceIndex bsi = new Roaring64BitmapSliceIndex(1, 99);
+    LongStream.range(1, 100).forEach(x -> bsi.setValue(x, x));
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream bdo = new DataOutputStream(bos);
+    bsi.serialize(bdo);
+    byte[] data = bos.toByteArray();
+
+    Roaring64BitmapSliceIndex newBsi = new Roaring64BitmapSliceIndex();
+
+    ByteArrayInputStream bis = new ByteArrayInputStream(data);
+    DataInputStream bdi = new DataInputStream(bis);
+    newBsi.deserialize(bdi);
+
+    Assertions.assertEquals(newBsi.getExistenceBitmap().getLongCardinality(), 99);
+
+    LongStream.range(1, 100).forEach(x -> {
+      Pair<Long, Boolean> bsiValue = newBsi.getValue(x);
+      Assertions.assertTrue(bsiValue.getRight());
+      Assertions.assertEquals((long) bsiValue.getKey(), x);
+    });
+  }
+
+  @Test
+  public void testIO4Buffer() throws IOException {
+    Roaring64BitmapSliceIndex bsi = new Roaring64BitmapSliceIndex(1, 99);
+    LongStream.range(1, 100).forEach(x -> bsi.setValue(x, x));
+    ByteBuffer buffer = ByteBuffer.allocate(bsi.serializedSizeInBytes());
+    bsi.serialize(buffer);
+
+    byte[] data = buffer.array();
+    Roaring64BitmapSliceIndex newBsi = new Roaring64BitmapSliceIndex();
+    newBsi.deserialize(ByteBuffer.wrap(data));
+    Assertions.assertEquals(newBsi.getExistenceBitmap().getLongCardinality(), 99);
+
+    LongStream.range(1, 100).forEach(x -> {
+      Pair<Long, Boolean> bsiValue = newBsi.getValue(x);
+      Assertions.assertTrue(bsiValue.getRight());
+      Assertions.assertEquals((long) bsiValue.getKey(), x);
+    });
+  }
+
+
+  @Test
+  public void testIOFromExternal() {
+    Roaring64BitmapSliceIndex bsi = new Roaring64BitmapSliceIndex(1, 99);
+    LongStream.range(1, 100).forEach(x -> bsi.setValue(x, x));
+
+    LongStream.range(1, 100).forEach(x -> {
+      Pair<Long, Boolean> bsiValue = bsi.getValue(x);
+      Assertions.assertTrue(bsiValue.getRight());
+      Assertions.assertEquals((long) bsiValue.getKey(), x);
+    });
+  }
+
+
+  @Test
+  public void testEQ() {
+    Roaring64BitmapSliceIndex bsi = new Roaring64BitmapSliceIndex(1, 99);
+    LongStream.range(1, 100).forEach(x -> {
+      if (x <= 50) {
+        bsi.setValue(x, 1);
+      } else {
+        bsi.setValue(x, x);
+      }
+
+    });
+
+    Roaring64Bitmap bitmap = bsi.compare(BitmapSliceIndex.Operation.EQ, 1, 0, null);
+    Assertions.assertEquals(50L, bitmap.getLongCardinality());
+
+  }
+
+  @Test
+  public void testNotEQ() {
+    bsi = new Roaring64BitmapSliceIndex();
+    bsi.setValue(1, 99);
+    bsi.setValue(2, 1);
+    bsi.setValue(3, 50);
+
+    Roaring64Bitmap result = bsi.compare(BitmapSliceIndex.Operation.NEQ, 99, 0, null);
+    Assertions.assertEquals(2, result.getLongCardinality());
+    Assertions.assertArrayEquals(new long[]{2, 3}, result.toArray());
+
+    result = bsi.compare(BitmapSliceIndex.Operation.NEQ, 100, 0, null);
+    Assertions.assertEquals(3, result.getLongCardinality());
+    Assertions.assertArrayEquals(new long[]{1, 2, 3}, result.toArray());
+
+    bsi = new Roaring64BitmapSliceIndex();
+    bsi.setValue(1, 99);
+    bsi.setValue(2, 99);
+    bsi.setValue(3, 99);
+
+    result = bsi.compare(BitmapSliceIndex.Operation.NEQ, 99, 0, null);
+    Assertions.assertTrue(result.isEmpty());
+
+    result = bsi.compare(BitmapSliceIndex.Operation.NEQ, 1, 0, null);
+    Assertions.assertEquals(3, result.getLongCardinality());
+    Assertions.assertArrayEquals(new long[]{1, 2, 3}, result.toArray());
+  }
+
+
+  // parallel operation test
+
+  @Test
+  public void testGT() {
+    Roaring64Bitmap result = bsi.compare(BitmapSliceIndex.Operation.GT, 50, 0, null);
+    Assertions.assertEquals(49, result.getLongCardinality());
+    Assertions.assertArrayEquals(LongStream.range(51, 100).toArray(), result.toArray());
+
+    result = bsi.compare(BitmapSliceIndex.Operation.GT, 0, 0, null);
+    Assertions.assertEquals(99, result.getLongCardinality());
+    Assertions.assertArrayEquals(LongStream.range(1, 100).toArray(), result.toArray());
+
+    result = bsi.compare(BitmapSliceIndex.Operation.GT, 99, 0, null);
+    Assertions.assertTrue(result.isEmpty());
+  }
+
+
+  @Test
+  public void testGE() {
+    Roaring64Bitmap result = bsi.compare(BitmapSliceIndex.Operation.GE, 50, 0, null);
+    Assertions.assertEquals(50, result.getLongCardinality());
+    Assertions.assertArrayEquals(LongStream.range(50, 100).toArray(), result.toArray());
+
+    result = bsi.compare(BitmapSliceIndex.Operation.GE, 1, 0, null);
+    Assertions.assertEquals(99, result.getLongCardinality());
+    Assertions.assertArrayEquals(LongStream.range(1, 100).toArray(), result.toArray());
+
+    result = bsi.compare(BitmapSliceIndex.Operation.GE, 100, 0, null);
+    Assertions.assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testLT() {
+    Roaring64Bitmap result = bsi.compare(BitmapSliceIndex.Operation.LT, 50, 0, null);
+    Assertions.assertEquals(49, result.getLongCardinality());
+    Assertions.assertArrayEquals(LongStream.range(1, 50).toArray(), result.toArray());
+
+    result = bsi.compare(BitmapSliceIndex.Operation.LT, Integer.MAX_VALUE, 0, null);
+    Assertions.assertEquals(99, result.getLongCardinality());
+    Assertions.assertArrayEquals(LongStream.range(1, 100).toArray(), result.toArray());
+
+    result = bsi.compare(BitmapSliceIndex.Operation.LT, 1, 0, null);
+    Assertions.assertTrue(result.isEmpty());
+  }
+
+
+  @Test
+  public void testLE() {
+    Roaring64Bitmap result = bsi.compare(BitmapSliceIndex.Operation.LE, 50, 0, null);
+    Assertions.assertEquals(50, result.getLongCardinality());
+    Assertions.assertArrayEquals(LongStream.range(1, 51).toArray(), result.toArray());
+
+    result = bsi.compare(BitmapSliceIndex.Operation.LE, Integer.MAX_VALUE, 0, null);
+    Assertions.assertEquals(99, result.getLongCardinality());
+    Assertions.assertArrayEquals(LongStream.range(1, 100).toArray(), result.toArray());
+
+    result = bsi.compare(BitmapSliceIndex.Operation.LE, 0, 0, null);
+    Assertions.assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testRANGE() {
+    Roaring64Bitmap result = bsi.compare(BitmapSliceIndex.Operation.RANGE, 10, 20, null);
+    Assertions.assertEquals(11, result.getLongCardinality());
+    Assertions.assertArrayEquals(LongStream.range(10, 21).toArray(), result.toArray());
+
+    result = bsi.compare(BitmapSliceIndex.Operation.RANGE, 1, 200, null);
+    Assertions.assertEquals(99, result.getLongCardinality());
+    Assertions.assertArrayEquals(LongStream.range(1, 100).toArray(), result.toArray());
+
+    result = bsi.compare(BitmapSliceIndex.Operation.RANGE, 1000, 2000, null);
+    Assertions.assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testSum() {
+    Roaring64BitmapSliceIndex bsi = new Roaring64BitmapSliceIndex(1, 99);
+    LongStream.range(1, 100).forEach(x -> bsi.setValue(x, x));
+
+    Roaring64Bitmap foundSet = Roaring64Bitmap.bitmapOf(LongStream.range(1, 51).toArray());
+
+    Pair<Long, Long> sumPair = bsi.sum(foundSet);
+
+    System.out.println("sum:" + sumPair.toString());
+
+    long sum = LongStream.range(1, 51).sum();
+    long count = LongStream.range(1, 51).count();
+
+    Assertions.assertTrue(sumPair.getLeft().intValue() == sum && sumPair.getRight() == count);
+  }
+
+  @Test
+  public void testValueZero() {
+    bsi = new Roaring64BitmapSliceIndex();
+    bsi.setValue(0, 0);
+    bsi.setValue(1, 0);
+    bsi.setValue(2, 1);
+
+    Roaring64Bitmap result = bsi.compare(BitmapSliceIndex.Operation.EQ, 0, 0, null);
+    Assertions.assertEquals(2, result.getLongCardinality());
+    Assertions.assertArrayEquals(new long[]{0, 1}, result.toArray());
+
+    result = bsi.compare(BitmapSliceIndex.Operation.EQ, 1, 0, null);
+    Assertions.assertEquals(1, result.getLongCardinality());
+    Assertions.assertArrayEquals(new long[]{2}, result.toArray());
+  }
+}
+

--- a/bsi/src/test/java/org/roaringbitmap/bsi/R64BSITest.java
+++ b/bsi/src/test/java/org/roaringbitmap/bsi/R64BSITest.java
@@ -327,5 +327,44 @@ public class R64BSITest {
     Assertions.assertEquals(1, result.getLongCardinality());
     Assertions.assertArrayEquals(new long[]{2}, result.toArray());
   }
+
+  @Test
+  public void testTopK() {
+    bsi = new Roaring64BitmapSliceIndex();
+    bsi.setValue(1, 3);
+    bsi.setValue(2, 6);
+    bsi.setValue(3, 4);
+    bsi.setValue(4, 10);
+    bsi.setValue(5, 7);
+    Roaring64Bitmap re = bsi.topK(bsi.getExistenceBitmap(), 2);
+    Assertions.assertEquals(re, Roaring64Bitmap.bitmapOf(4, 5));
+  }
+
+  @Test
+  public void testTranspose() {
+    bsi = new Roaring64BitmapSliceIndex();
+    bsi.setValue(1, 2);
+    bsi.setValue(2, 4);
+    bsi.setValue(3, 4);
+    bsi.setValue(4, 8);
+    bsi.setValue(5, 8);
+    Roaring64Bitmap re = bsi.transpose(null);
+    Assertions.assertEquals(re, Roaring64Bitmap.bitmapOf(2, 4, 8));
+  }
+
+  @Test
+  public void testTransposeWithCount() {
+    bsi = new Roaring64BitmapSliceIndex();
+    bsi.setValue(1, 2);
+    bsi.setValue(2, 4);
+    bsi.setValue(3, 4);
+    bsi.setValue(4, 8);
+    bsi.setValue(5, 8);
+    Roaring64BitmapSliceIndex re = bsi.transposeWithCount(null);
+    Assertions.assertEquals(re.getExistenceBitmap(), Roaring64Bitmap.bitmapOf(2, 4, 8));
+    Assertions.assertEquals(re.getValue(2).getKey(), 1);
+    Assertions.assertEquals(re.getValue(4).getKey(), 2);
+    Assertions.assertEquals(re.getValue(8).getKey(), 2);
+  }
 }
 


### PR DESCRIPTION
### SUMMARY
- Add BSI based on Roaring64Bitmap so as to support (column id:bigint, value:bigint)

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
