### PR TITLE
Fix advanceIfNeeded in signed int iterators and simplify finding starting container index

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -50,7 +50,7 @@ import org.roaringbitmap.longlong.LongUtils;
 public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>, Externalizable,
     ImmutableBitmapDataProvider, BitmapDataProvider, AppendableStorage<Container> {
 
-  private final class RoaringIntIterator implements PeekableIntIterator {
+  private class RoaringIntIterator implements PeekableIntIterator {
     private char startingContainerIndex;
     private int hs = 0;
 
@@ -66,12 +66,8 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
       char index = 0;
       if (signedIntSort) {
         // skip to starting at negative signed integers
-        final int containerSize = RoaringBitmap.this.highLowContainer.size();
-        while (index < containerSize
-            && RoaringBitmap.this.highLowContainer.getKeyAtIndex(index) < (1 << 15)) {
-          ++index;
-        }
-        if(index >= containerSize) {
+        index = (char) RoaringBitmap.this.highLowContainer.advanceUntil((char) (1 << 15), 0);
+        if (index >= RoaringBitmap.this.highLowContainer.size()) {
           index = 0;
         }
       }
@@ -135,7 +131,6 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     public int peekNext() {
       return (iter.peekNext()) | hs;
     }
-
 
   }
 

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -51,35 +51,27 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     ImmutableBitmapDataProvider, BitmapDataProvider, AppendableStorage<Container> {
 
   private class RoaringIntIterator implements PeekableIntIterator {
-    private char startingContainerIndex;
+    private final char startingContainerIndex;
     private int hs = 0;
 
     private PeekableCharIterator iter;
 
     private int pos = 0;
 
-    private RoaringIntIterator() {
-      this(false);
+    public RoaringIntIterator() {
+      this.startingContainerIndex = findStartingContainerIndex();
+      nextContainer();
     }
 
-    private RoaringIntIterator(final boolean signedIntSort) {
-      char index = 0;
-      if (signedIntSort) {
-        // skip to starting at negative signed integers
-        index = (char) RoaringBitmap.this.highLowContainer.advanceUntil((char) (1 << 15), 0);
-        if (index >= RoaringBitmap.this.highLowContainer.size()) {
-          index = 0;
-        }
-      }
-      this.startingContainerIndex = index;
-      nextContainer();
+    char findStartingContainerIndex() {
+      return 0;
     }
 
     @Override
     public PeekableIntIterator clone() {
       try {
         RoaringIntIterator x = (RoaringIntIterator) super.clone();
-        if(this.iter != null) {
+        if (this.iter != null) {
           x.iter = this.iter.clone();
         }
         return x;
@@ -114,7 +106,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
 
     @Override
     public void advanceIfNeeded(int minval) {
-      while (hasNext() && ((hs >>> 16) < (minval >>> 16))) {
+      while (hasNext() && shouldAdvanceContainer(hs, minval)) {
         ++pos;
         nextContainer();
       }
@@ -127,9 +119,32 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
       }
     }
 
+    boolean shouldAdvanceContainer(final int hs, final int minval) {
+      return (hs >>> 16) < (minval >>> 16);
+    }
+
     @Override
     public int peekNext() {
       return (iter.peekNext()) | hs;
+    }
+
+  }
+
+  private final class RoaringSignedIntIterator extends RoaringIntIterator {
+
+    @Override
+    char findStartingContainerIndex() {
+      // skip to starting at negative signed integers
+      char index = (char) RoaringBitmap.this.highLowContainer.advanceUntil((char) (1 << 15), 0);
+      if (index >= RoaringBitmap.this.highLowContainer.size()) {
+        index = 0;
+      }
+      return index;
+    }
+
+    @Override
+    boolean shouldAdvanceContainer(final int hs, final int minval) {
+      return (hs >> 16) < (minval >> 16);
     }
 
   }
@@ -2132,7 +2147,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
    */
   @Override
   public PeekableIntIterator getIntIterator() {
-    return new RoaringIntIterator(false);
+    return new RoaringIntIterator();
   }
 
   /**
@@ -2141,7 +2156,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
    */
   @Override
   public PeekableIntIterator getSignedIntIterator() {
-    return new RoaringIntIterator(true);
+    return new RoaringSignedIntIterator();
   }
 
   /**

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -135,8 +135,8 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     @Override
     char findStartingContainerIndex() {
       // skip to starting at negative signed integers
-      char index = (char) RoaringBitmap.this.highLowContainer.advanceUntil((char) (1 << 15), 0);
-      if (index >= RoaringBitmap.this.highLowContainer.size()) {
+      char index = (char) RoaringBitmap.this.highLowContainer.advanceUntil((char) (1 << 15), -1);
+      if (index == RoaringBitmap.this.highLowContainer.size()) {
         index = 0;
       }
       return index;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -73,7 +73,7 @@ import static org.roaringbitmap.buffer.MutableRoaringBitmap.rangeSanityCheck;
 public class ImmutableRoaringBitmap
     implements Iterable<Integer>, Cloneable, ImmutableBitmapDataProvider {
 
-  private final class ImmutableRoaringIntIterator implements PeekableIntIterator {
+  private class ImmutableRoaringIntIterator implements PeekableIntIterator {
     private boolean wrap;
     private MappeableContainerPointer cp;
     private int iterations = 0;
@@ -85,34 +85,24 @@ public class ImmutableRoaringBitmap
     private boolean ok;
 
     public ImmutableRoaringIntIterator() {
-      this(false);
-    }
-
-    public ImmutableRoaringIntIterator(final boolean signedIntSort) {
-      char index = 0;
-      if (signedIntSort) {
-        wrap = true;
-        // skip to starting at negative signed integers
-        index = (char) ImmutableRoaringBitmap.this.highLowContainer.advanceUntil((char) (1 << 15), 0);
-        if (index >= ImmutableRoaringBitmap.this.highLowContainer.size()) {
-          index = 0;
-          wrap = false;
-        }
-      } else {
-        wrap = false;
-      }
+      char index = findStartingContainerIndex();
+      wrap = index != 0;
       cp = ImmutableRoaringBitmap.this.highLowContainer.getContainerPointer(index);
       nextContainer();
+    }
+
+    char findStartingContainerIndex() {
+      return 0;
     }
 
     @Override
     public PeekableIntIterator clone() {
       try {
         ImmutableRoaringIntIterator x = (ImmutableRoaringIntIterator) super.clone();
-        if(this.iter != null) {
+        if (this.iter != null) {
           x.iter = this.iter.clone();
         }
-        if(this.cp != null) {
+        if (this.cp != null) {
           x.cp = this.cp.clone();
         }
         x.wrap = this.wrap;
@@ -140,7 +130,7 @@ public class ImmutableRoaringBitmap
 
     private void nextContainer() {
       final int containerSize = ImmutableRoaringBitmap.this.highLowContainer.size();
-      if(wrap || iterations < containerSize) {
+      if (wrap || iterations < containerSize) {
         ok = cp.hasContainer();
         if (!ok && wrap && iterations < containerSize) {
           cp = ImmutableRoaringBitmap.this.highLowContainer.getContainerPointer();
@@ -159,7 +149,7 @@ public class ImmutableRoaringBitmap
 
     @Override
     public void advanceIfNeeded(int minval) {
-      while (hasNext() && ((hs >>> 16) < (minval >>> 16))) {
+      while (hasNext() && shouldAdvanceContainer(hs, minval)) {
         cp.advance();
         nextContainer();
       }
@@ -172,6 +162,10 @@ public class ImmutableRoaringBitmap
       }
     }
 
+    boolean shouldAdvanceContainer(final int hs, final int minval) {
+      return (hs >>> 16) < (minval >>> 16);
+    }
+
     @Override
     public int peekNext() {
       return (iter.peekNext()) | hs;
@@ -179,6 +173,23 @@ public class ImmutableRoaringBitmap
 
   }
 
+  private class ImmutableRoaringSignedIntIterator extends ImmutableRoaringIntIterator {
+
+    @Override
+    char findStartingContainerIndex() {
+      // skip to starting at negative signed integers
+      char index = (char) ImmutableRoaringBitmap.this.highLowContainer.advanceUntil((char) (1 << 15), 0);
+      if (index >= ImmutableRoaringBitmap.this.highLowContainer.size()) {
+        index = 0;
+      }
+      return index;
+    }
+
+    @Override
+    boolean shouldAdvanceContainer(final int hs, final int minval) {
+      return (hs >> 16) < (minval >> 16);
+    }
+  }
 
   private final class ImmutableRoaringReverseIntIterator implements IntIterator {
     private MappeableContainerPointer cp = ImmutableRoaringBitmap.this.highLowContainer
@@ -1429,7 +1440,7 @@ public class ImmutableRoaringBitmap
    */
   @Override
   public PeekableIntIterator getIntIterator() {
-    return new ImmutableRoaringIntIterator(false);
+    return new ImmutableRoaringIntIterator();
   }
 
   /**
@@ -1438,9 +1449,8 @@ public class ImmutableRoaringBitmap
    */
   @Override
   public PeekableIntIterator getSignedIntIterator() {
-    return new ImmutableRoaringIntIterator(true);
+    return new ImmutableRoaringSignedIntIterator();
   }
-
 
   /**
    * @return a custom iterator over set bits, the bits are traversed in descending sorted order

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -178,8 +178,9 @@ public class ImmutableRoaringBitmap
     @Override
     char findStartingContainerIndex() {
       // skip to starting at negative signed integers
-      char index = (char) ImmutableRoaringBitmap.this.highLowContainer.advanceUntil((char) (1 << 15), 0);
-      if (index >= ImmutableRoaringBitmap.this.highLowContainer.size()) {
+      char index = (char)
+          ImmutableRoaringBitmap.this.highLowContainer.advanceUntil((char) (1 << 15), -1);
+      if (index == ImmutableRoaringBitmap.this.highLowContainer.size()) {
         index = 0;
       }
       return index;

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -93,12 +93,8 @@ public class ImmutableRoaringBitmap
       if (signedIntSort) {
         wrap = true;
         // skip to starting at negative signed integers
-        final int containerSize = ImmutableRoaringBitmap.this.highLowContainer.size();
-        while (index < containerSize
-            && ImmutableRoaringBitmap.this.highLowContainer.getKeyAtIndex(index) < (1 << 15)) {
-          ++index;
-        }
-        if(index >= containerSize) {
+        index = (char) ImmutableRoaringBitmap.this.highLowContainer.advanceUntil((char) (1 << 15), 0);
+        if (index >= ImmutableRoaringBitmap.this.highLowContainer.size()) {
           index = 0;
           wrap = false;
         }
@@ -142,7 +138,6 @@ public class ImmutableRoaringBitmap
       return x;
     }
 
-
     private void nextContainer() {
       final int containerSize = ImmutableRoaringBitmap.this.highLowContainer.size();
       if(wrap || iterations < containerSize) {
@@ -181,7 +176,6 @@ public class ImmutableRoaringBitmap
     public int peekNext() {
       return (iter.peekNext()) | hs;
     }
-
 
   }
 

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestIterators.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestIterators.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -54,7 +55,7 @@ public class TestIterators {
     });
   }
 
-  private static int[] takeSortedAndDistinct(Random source, int count) {
+  private static int[] takeSortedAndDistinct(Random source, int count, Comparator<Integer> comparator) {
     HashSet<Integer> ints = new HashSet<Integer>(count);
     for (int size = 0; size < count; size++) {
       int next;
@@ -63,7 +64,7 @@ public class TestIterators {
       } while (!ints.add(next));
     }
     ArrayList<Integer> list = new ArrayList<Integer>(ints);
-    list.sort(Integer::compareUnsigned);
+    list.sort(comparator);
     return Ints.toArray(list);
   }
 
@@ -86,7 +87,7 @@ public class TestIterators {
   @Test
   public void testIteration() {
     final Random source = new Random(0xcb000a2b9b5bdfb6l);
-    final int[] data = takeSortedAndDistinct(source, 450000);
+    final int[] data = takeSortedAndDistinct(source, 450000, Integer::compareUnsigned);
     RoaringBitmap bitmap = RoaringBitmap.bitmapOf(data);
 
     final List<Integer> iteratorCopy = ImmutableList.copyOf(bitmap.iterator());
@@ -121,26 +122,55 @@ public class TestIterators {
 
   @Test
   public void testSkips() {
-    final Random source = new Random(0xcb000a2b9b5bdfb6l);
-    final int[] data = takeSortedAndDistinct(source, 45000);
+    final Random source = new Random(0xcb000a2b9b5bdfb6L);
+    final int[] data = takeSortedAndDistinct(source, 45000, Integer::compareUnsigned);
     RoaringBitmap bitmap = RoaringBitmap.bitmapOf(data);
     PeekableIntIterator pii = bitmap.getIntIterator();
-    for(int i = 0; i < data.length; ++i) {
+    for (int i = 0; i < data.length; ++i) {
       pii.advanceIfNeeded(data[i]);
       assertEquals(data[i], pii.peekNext());
     }
     pii = bitmap.getIntIterator();
-    for(int i = 0; i < data.length; ++i) {
+    for (int i = 0; i < data.length; ++i) {
       pii.advanceIfNeeded(data[i]);
       assertEquals(data[i], pii.next());
     }
     pii = bitmap.getIntIterator();
-    for(int i = 1; i < data.length; ++i) {
-      pii.advanceIfNeeded(data[i-1]);
+    for (int i = 1; i < data.length; ++i) {
+      pii.advanceIfNeeded(data[i - 1]);
       pii.next();
-      assertEquals(data[i],pii.peekNext() );
+      assertEquals(data[i], pii.peekNext());
     }
     bitmap.getIntIterator().advanceIfNeeded(-1);// should not crash
+  }
+
+  @Test
+  public void testSkipsSignedIterator() {
+    final Random source = new Random(0xcb000a2b9b5bdfb6L);
+    int[] data = takeSortedAndDistinct(source, 45000, Integer::compare);
+    RoaringBitmap bitmap = RoaringBitmap.bitmapOf(data);
+
+    PeekableIntIterator pii = bitmap.getSignedIntIterator();
+    for (int i = 0; i < data.length; ++i) {
+      pii.advanceIfNeeded(data[i]);
+      assertEquals(data[i], pii.peekNext());
+    }
+    pii = bitmap.getSignedIntIterator();
+    for (int i = data.length - 1; i >= 0; --i) { // no backward advancing
+      pii.advanceIfNeeded(data[i]);
+      assertEquals(data[data.length - 1], pii.peekNext());
+    }
+    pii = bitmap.getSignedIntIterator();
+    for (int i = 0; i < data.length; ++i) {
+      pii.advanceIfNeeded(data[i]);
+      assertEquals(data[i], pii.next());
+    }
+    pii = bitmap.getSignedIntIterator();
+    for (int i = 1; i < data.length; ++i) {
+      pii.advanceIfNeeded(data[i - 1]);
+      pii.next();
+      assertEquals(data[i], pii.peekNext());
+    }
   }
 
   @Test


### PR DESCRIPTION
### SUMMARY

- Fixes advanceIfNeeded in signed int iterators 
  Take into account sign bits while iterating over containers. Previously it would skip over positive signed integers after advancing to a negative signed integer. For signed int iterator this should work the oppositive way, positives come after negatives.
- Use advanceUntil to find starting container index in signed int iterators
  This should find starting containers much faster, as it's using binary search instead of doing a sequential scan.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
