### PR TITLE
Fix previousValue not returning correct results in some cases

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -2851,7 +2851,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     char key = Util.highbits(fromValue);
     int containerIndex = highLowContainer.advanceUntil(key, -1);
     if (containerIndex == highLowContainer.size()) {
-      return last();
+      return Util.toUnsignedLong(last());
     }
     if (highLowContainer.getKeyAtIndex(containerIndex) > key) {
       // target absent, key of first container after target too high

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -2854,7 +2854,8 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
       return last();
     }
     if (highLowContainer.getKeyAtIndex(containerIndex) > key) {
-      return -1L;
+      // target absent, key of first container after target too high
+      --containerIndex;
     }
     long prevSetBit = -1L;
     while (containerIndex != -1 && prevSetBit == -1L) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -1815,7 +1815,7 @@ public class ImmutableRoaringBitmap
     char key = highbits(fromValue);
     int containerIndex = highLowContainer.advanceUntil(key, -1);
     if (containerIndex == highLowContainer.size()) {
-      return last();
+      return Util.toUnsignedLong(last());
     }
     if (highLowContainer.getKeyAtIndex(containerIndex) > key) {
       // target absent, key of first container after target too high

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -1818,7 +1818,8 @@ public class ImmutableRoaringBitmap
       return last();
     }
     if (highLowContainer.getKeyAtIndex(containerIndex) > key) {
-      return -1L;
+      // target absent, key of first container after target too high
+      --containerIndex;
     }
     long prevSetBit = -1L;
     while (containerIndex != -1 && containerIndex < highLowContainer.size() && prevSetBit == -1L) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -1822,7 +1822,7 @@ public class ImmutableRoaringBitmap
       --containerIndex;
     }
     long prevSetBit = -1L;
-    while (containerIndex != -1 && containerIndex < highLowContainer.size() && prevSetBit == -1L) {
+    while (containerIndex != -1 && prevSetBit == -1L) {
       char containerKey = highLowContainer.getKeyAtIndex(containerIndex);
       MappeableContainer container = highLowContainer.getContainerAtIndex(containerIndex);
       int bit = (containerKey < key

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -5361,6 +5361,17 @@ public class TestRoaringBitmap {
     }
 
     @Test
+    public void testPreviousValue_AbsentTargetContainer() {
+        RoaringBitmap bitmap = RoaringBitmap.bitmapOf(-1, 2, 3, 131072);
+        assertEquals(3, bitmap.previousValue(65536));
+        assertEquals(131072, bitmap.previousValue(Integer.MAX_VALUE));
+        assertEquals(131072, bitmap.previousValue(-131072));
+
+        bitmap = RoaringBitmap.bitmapOf(131072);
+        assertEquals(-1, bitmap.previousValue(65536));
+    }
+
+    @Test
     public void testRangeCardinalityAtBoundary() {
         // See https://github.com/RoaringBitmap/RoaringBitmap/issues/285
         RoaringBitmap r = new RoaringBitmap();

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -5372,6 +5372,12 @@ public class TestRoaringBitmap {
     }
 
     @Test
+    public void testPreviousValue_LastReturnedAsUnsignedLong() {
+        RoaringBitmap bitmap = RoaringBitmap.bitmapOf(-650002, -650001, -650000);
+        assertEquals(Util.toUnsignedLong(-650000), bitmap.previousValue(-1));
+    }
+
+    @Test
     public void testRangeCardinalityAtBoundary() {
         // See https://github.com/RoaringBitmap/RoaringBitmap/issues/285
         RoaringBitmap r = new RoaringBitmap();

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
@@ -1509,6 +1509,12 @@ public class TestImmutableRoaringBitmap {
   }
 
   @Test
+  public void testPreviousValue_LastReturnedAsUnsignedLong() {
+    MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(-650002, -650001, -650000);
+    assertEquals(Util.toUnsignedLong(-650000), bitmap.previousValue(-1));
+  }
+
+  @Test
   public void testRangeCardinalityAtBoundary() {
     // See https://github.com/RoaringBitmap/RoaringBitmap/issues/285
     MutableRoaringBitmap r = new MutableRoaringBitmap();

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
@@ -1498,6 +1498,17 @@ public class TestImmutableRoaringBitmap {
   }
 
   @Test
+  public void testPreviousValue_AbsentTargetContainer() {
+    MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(-1, 2, 3, 131072);
+    assertEquals(3, bitmap.previousValue(65536));
+    assertEquals(131072, bitmap.previousValue(Integer.MAX_VALUE));
+    assertEquals(131072, bitmap.previousValue(-131072));
+
+    bitmap = MutableRoaringBitmap.bitmapOf(131072);
+    assertEquals(-1, bitmap.previousValue(65536));
+  }
+
+  @Test
   public void testRangeCardinalityAtBoundary() {
     // See https://github.com/RoaringBitmap/RoaringBitmap/issues/285
     MutableRoaringBitmap r = new MutableRoaringBitmap();


### PR DESCRIPTION
### SUMMARY

Recently came across this issue, while I was trying to find maximum signed integer using previousValue, where it would simply just return -1 (not found) in some cases (but not all). This first issue is only happening when target container is absent and a container exists with higher key.

While looking at the code, also noticed that last is not returned as unsigned long as promised by the api. This second issue is only happening when target container is absent and no container exists with higher key.

Both cases are covered with test cases.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
