### PR TITLE
Implement signed first/last methods

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ImmutableBitmapDataProvider.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ImmutableBitmapDataProvider.java
@@ -197,20 +197,32 @@ public interface ImmutableBitmapDataProvider {
   int select(int j);
 
   /**
-   * Get the first (smallest) integer in this RoaringBitmap,
-   * that is, return the minimum of the set.
-   * @return the first (smallest) integer
+   * Get the smallest unsigned (first) integer in this RoaringBitmap.
+   * @return the smallest unsigned (first) integer
    * @throws NoSuchElementException if empty
    */
   int first();
 
   /**
-   * Get the last (largest) integer in this RoaringBitmap,
-   * that is, return the maximum of the set.
-   * @return the last (largest) integer
+   * Get the largest unsigned (last) integer in this RoaringBitmap.
+   * @return the largest unsigned (last) integer
    * @throws NoSuchElementException if empty
    */
   int last();
+
+  /**
+   * Get the smallest signed integer in this RoaringBitmap.
+   * @return the smallest signed integer
+   * @throws NoSuchElementException if empty
+   */
+  int firstSigned();
+
+  /**
+   * Get the largest signed integer in this RoaringBitmap.
+   * @return the largest signed integer
+   * @throws NoSuchElementException if empty
+   */
+  int lastSigned();
 
   /**
    * Returns the first value equal to or larger than the provided value

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringArray.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringArray.java
@@ -966,8 +966,8 @@ public final class RoaringArray implements Cloneable, Externalizable, Appendable
   }
 
   /**
-   * Gets the first value in the array
-   * @return the first value in the array
+   * Gets the smallest unsigned (first) integer in the array.
+   * @return the smallest unsigned (first) integer in the array
    * @throws NoSuchElementException if empty
    */
   public int first() {
@@ -978,8 +978,8 @@ public final class RoaringArray implements Cloneable, Externalizable, Appendable
   }
 
   /**
-   * Gets the last value in the array
-   * @return the last value in the array
+   * Gets the largest unsigned (last) integer in the array.
+   * @return the largest unsigned (last) integer in the array
    * @throws NoSuchElementException if empty
    */
   public int last() {
@@ -989,8 +989,40 @@ public final class RoaringArray implements Cloneable, Externalizable, Appendable
     return lastKey << 16 | container.last();
   }
 
+  /**
+   * Gets the smallest signed integer in the array.
+   * @return the smallest signed integer in the array
+   * @throws NoSuchElementException if empty
+   */
+  public int firstSigned() {
+    assertNonEmpty();
+    int index = advanceUntil((char) (1 << 15), -1);
+    if (index == size) { // no negatives
+      index = 0;
+    }
+    char key = keys[index];
+    Container container = values[index];
+    return key << 16 | container.first();
+  }
+
+  /**
+   * Gets the largest signed integer in the array.
+   * @return the largest signed integer in the array
+   * @throws NoSuchElementException if empty
+   */
+  public int lastSigned() {
+    assertNonEmpty();
+    int index = advanceUntil((char) (1 << 15), -1) - 1;
+    if (index == -1) { // no positives
+      index += size;
+    }
+    char key = keys[index];
+    Container container = values[index];
+    return key << 16 | container.last();
+  }
+
   private void assertNonEmpty() {
-    if(size == 0) {
+    if (size == 0) {
       throw new NoSuchElementException("Empty RoaringArray");
     }
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -2978,6 +2978,16 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     return highLowContainer.last();
   }
 
+  @Override
+  public int firstSigned() {
+    return highLowContainer.firstSigned();
+  }
+
+  @Override
+  public int lastSigned() {
+    return highLowContainer.lastSigned();
+  }
+
   /**
    * Serialize this bitmap.
    *

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringArray.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringArray.java
@@ -493,8 +493,32 @@ public final class ImmutableRoaringArray implements PointableRoaringArray {
     return lastKey << 16 | container.last();
   }
 
+  @Override
+  public int firstSigned() {
+    assertNonEmpty();
+    int index = advanceUntil((char) (1 << 15), -1);
+    if (index == size) { // no negatives
+      index = 0;
+    }
+    char key = getKeyAtIndex(index);
+    MappeableContainer container = getContainerAtIndex(index);
+    return key << 16 | container.first();
+  }
+
+  @Override
+  public int lastSigned() {
+    assertNonEmpty();
+    int index = advanceUntil((char) (1 << 15), -1) - 1;
+    if (index == -1) { // no positives
+      index += size;
+    }
+    char key = getKeyAtIndex(index);
+    MappeableContainer container = getContainerAtIndex(index);
+    return key << 16 | container.last();
+  }
+
   private void assertNonEmpty() {
-    if(size == 0) {
+    if (size == 0) {
       throw new NoSuchElementException("Empty ImmutableRoaringArray");
     }
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -1770,21 +1770,11 @@ public class ImmutableRoaringBitmap
                + this.getCardinality() + ".");
   }
 
-  /**
-   * Get the smallest unsigned (first) integer in this RoaringBitmap.
-   * @return the smallest unsigned (first) integer
-   * @throws NoSuchElementException if empty
-   */
   @Override
   public int first() {
     return highLowContainer.first();
   }
 
-  /**
-   * Get the largest unsigned (last) integer in this RoaringBitmap.
-   * @return the largest unsigned (last) integer
-   * @throws NoSuchElementException if empty
-   */
   @Override
   public int last() {
     return highLowContainer.last();

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -1770,11 +1770,9 @@ public class ImmutableRoaringBitmap
                + this.getCardinality() + ".");
   }
 
-
   /**
-   * Get the first (smallest) integer in this RoaringBitmap,
-   * that is, returns the minimum of the set.
-   * @return the first (smallest) integer
+   * Get the smallest unsigned (first) integer in this RoaringBitmap.
+   * @return the smallest unsigned (first) integer
    * @throws NoSuchElementException if empty
    */
   @Override
@@ -1783,14 +1781,23 @@ public class ImmutableRoaringBitmap
   }
 
   /**
-   * Get the last (largest) integer in this RoaringBitmap,
-   * that is, returns the maximum of the set.
-   * @return the last (largest) integer
+   * Get the largest unsigned (last) integer in this RoaringBitmap.
+   * @return the largest unsigned (last) integer
    * @throws NoSuchElementException if empty
    */
   @Override
   public int last() {
     return highLowContainer.last();
+  }
+
+  @Override
+  public int firstSigned() {
+    return highLowContainer.firstSigned();
+  }
+
+  @Override
+  public int lastSigned() {
+    return highLowContainer.lastSigned();
   }
 
   @Override

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
@@ -799,8 +799,32 @@ public final class MutableRoaringArray implements Cloneable, Externalizable, Poi
     return lastKey << 16 | container.last();
   }
 
+  @Override
+  public int firstSigned() {
+    assertNonEmpty();
+    int index = advanceUntil((char) (1 << 15), -1);
+    if (index == size) { // no negatives
+      index = 0;
+    }
+    char key = getKeyAtIndex(index);
+    MappeableContainer container = getContainerAtIndex(index);
+    return key << 16 | container.first();
+  }
+
+  @Override
+  public int lastSigned() {
+    assertNonEmpty();
+    int index = advanceUntil((char) (1 << 15), -1) - 1;
+    if (index == -1) { // no positives
+      index += size;
+    }
+    char key = getKeyAtIndex(index);
+    MappeableContainer container = getContainerAtIndex(index);
+    return key << 16 | container.last();
+  }
+
   private void assertNonEmpty() {
-    if(size == 0) {
+    if (size == 0) {
       throw new NoSuchElementException("Empty MutableRoaringArray");
     }
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/PointableRoaringArray.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/PointableRoaringArray.java
@@ -135,14 +135,26 @@ public interface PointableRoaringArray extends Cloneable {
   int size();
 
   /**
-   * Gets the first value in the array
-   * @return te first value in the array
+   * Gets the smallest unsigned (first) integer in the array.
+   * @return the smallest unsigned (first) integer in the array
    */
   int first();
 
   /**
-   * Gets the last value in the array
-   * @return te last value in the array
+   * Gets the largest unsigned (last) integer in the array.
+   * @return the largest unsigned (last) integer in the array
    */
   int last();
+
+  /**
+   * Gets the smallest signed integer in the array.
+   * @return the smallest signed integer in the array
+   */
+  int firstSigned();
+
+  /**
+   * Gets the largest signed integer in the array.
+   * @return the largest signed integer in the array
+   */
+  int lastSigned();
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -12,6 +12,8 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.*;
 import java.nio.ByteBuffer;
@@ -5140,6 +5142,33 @@ public class TestRoaringBitmap {
         bitmap.add(777);
 
         assertEquals(-7, bitmap.last());
+    }
+
+    @Test
+    public void testFirstLastSigned() {
+        RoaringBitmap bitmap = RoaringBitmap.bitmapOf(1_111_111, 3_333_333);
+        assertEquals(1_111_111, bitmap.firstSigned());
+        assertEquals(3_333_333, bitmap.lastSigned());
+
+        bitmap = RoaringBitmap.bitmapOf(-3_333_333, 3_333_333);
+        assertEquals(-3_333_333, bitmap.firstSigned());
+        assertEquals(3_333_333, bitmap.lastSigned());
+
+        bitmap = RoaringBitmap.bitmapOf(-3_333_333, -1_111_111);
+        assertEquals(-3_333_333, bitmap.firstSigned());
+        assertEquals(-1_111_111, bitmap.lastSigned());
+
+        bitmap = RoaringBitmap.bitmapOfRange(0, 1L << 32);
+        assertEquals(Integer.MIN_VALUE, bitmap.firstSigned());
+        assertEquals(Integer.MAX_VALUE, bitmap.lastSigned());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {Integer.MIN_VALUE, -65_536, 0, 65_536, Integer.MAX_VALUE})
+    public void testFirstLastSigned_SingleValueBitmap(int value) {
+        RoaringBitmap bitmap = RoaringBitmap.bitmapOf(value);
+        assertEquals(value, bitmap.firstSigned());
+        assertEquals(value, bitmap.lastSigned());
     }
 
     @Test

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
@@ -8,6 +8,8 @@ package org.roaringbitmap.buffer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.roaringbitmap.*;
 
 import java.io.DataOutputStream;
@@ -1402,6 +1404,34 @@ public class TestImmutableRoaringBitmap {
     bitmap.add(777);
 
     assertEquals(-7, bitmap.last());
+  }
+
+  @Test
+  public void testFirstLastSigned() {
+    MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(1_111_111, 3_333_333);
+
+    assertEquals(1_111_111, bitmap.firstSigned());
+    assertEquals(3_333_333, bitmap.lastSigned());
+
+    bitmap = MutableRoaringBitmap.bitmapOf(-3_333_333, 3_333_333);
+    assertEquals(-3_333_333, bitmap.firstSigned());
+    assertEquals(3_333_333, bitmap.lastSigned());
+
+    bitmap = MutableRoaringBitmap.bitmapOf(-3_333_333, -1_111_111);
+    assertEquals(-3_333_333, bitmap.firstSigned());
+    assertEquals(-1_111_111, bitmap.lastSigned());
+
+    bitmap = MutableRoaringBitmap.bitmapOfRange(0, 1L << 32);
+    assertEquals(Integer.MIN_VALUE, bitmap.firstSigned());
+    assertEquals(Integer.MAX_VALUE, bitmap.lastSigned());
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {Integer.MIN_VALUE, -65_536, 0, 65_536, Integer.MAX_VALUE})
+  public void testFirstLastSigned_SingleValueBitmap(int value) {
+    MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(value);
+    assertEquals(value, bitmap.firstSigned());
+    assertEquals(value, bitmap.lastSigned());
   }
 
   @Test


### PR DESCRIPTION
### SUMMARY

Proposal, following up on https://github.com/RoaringBitmap/RoaringBitmap/pull/736#issuecomment-2214234248

Adds firstSigned and lastSigned methods that return minimum signed and maximum signed integer in bitmap, respectively.

In java world, depending on the usage, we are often more interested in signed minimums and maximums.

The same thing can be achieved by combining nextValue/previousValue with last/first.
This just adds a cleaner and a slightly more efficient way to do it.

Not sure about the naming, if it's going to cause confusion. Open to suggestions.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
