### PR TITLE
Skip over empty words in RunContainer#contains(BitmapContainer)

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -821,7 +821,7 @@ public final class RunContainer extends Container implements Cloneable {
     int stop = start + getLength(ir);
     while(ib < bitmapContainer.bitmap.length && ir < runCount) {
       long w = bitmapContainer.bitmap[ib];
-      while (true) {
+      while (w != 0) {
         long r = ib * 64L + Long.numberOfTrailingZeros(w);
         if (r < start) {
           return false;
@@ -837,9 +837,6 @@ public final class RunContainer extends Container implements Cloneable {
           w = bitmapContainer.bitmap[ib];
         } else {
           w &= w - 1;
-          if (w == 0) {
-            break;
-          }
         }
       }
       if(w == 0) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -819,13 +819,13 @@ public final class RunContainer extends Container implements Cloneable {
     char ib = 0, ir = 0;
     int start = getValue(ir);
     int stop = start + getLength(ir);
-    while(ib < bitmapContainer.bitmap.length && ir < runCount) {
+    while (ib < bitmapContainer.bitmap.length && ir < runCount) {
       long w = bitmapContainer.bitmap[ib];
       while (w != 0) {
         long r = ib * 64L + Long.numberOfTrailingZeros(w);
         if (r < start) {
           return false;
-        } else if(r > stop) {
+        } else if (r > stop) {
           ++ir;
           if (ir == runCount) {
             break;
@@ -839,15 +839,15 @@ public final class RunContainer extends Container implements Cloneable {
           w &= w - 1;
         }
       }
-      if(w == 0) {
+      if (w == 0) {
         ++ib;
       } else {
         return false;
       }
     }
-    if(ib < bitmapContainer.bitmap.length) {
-      for(; ib < bitmapContainer.bitmap.length ; ib++) {
-        if(bitmapContainer.bitmap[ib] != 0) {
+    if (ib < bitmapContainer.bitmap.length) {
+      for (; ib < bitmapContainer.bitmap.length; ib++) {
+        if (bitmapContainer.bitmap[ib] != 0) {
           return false;
         }
       }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -2730,7 +2730,7 @@ public final class MappeableRunContainer extends MappeableContainer implements C
     int stop = start + getLength(0);
     while(ib < MappeableBitmapContainer.MAX_CAPACITY / 64 && ir < runCount) {
       long w = bitmapContainer.bitmap.get(ib);
-      while (true) {
+      while (w != 0) {
         long r = ib * 64 + Long.numberOfTrailingZeros(w);
         if (r < start) {
           return false;
@@ -2747,9 +2747,6 @@ public final class MappeableRunContainer extends MappeableContainer implements C
           w = bitmapContainer.bitmap.get(ib);
         } else {
           w &= w - 1;
-          if (w == 0) {
-            break;
-          }
         }
       }
       if(w == 0) {

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/MappeableRunContainer.java
@@ -2728,7 +2728,7 @@ public final class MappeableRunContainer extends MappeableContainer implements C
     char ib = 0, ir = 0;
     int start = getValue(0);
     int stop = start + getLength(0);
-    while(ib < MappeableBitmapContainer.MAX_CAPACITY / 64 && ir < runCount) {
+    while (ib < MappeableBitmapContainer.MAX_CAPACITY / 64 && ir < runCount) {
       long w = bitmapContainer.bitmap.get(ib);
       while (w != 0) {
         long r = ib * 64 + Long.numberOfTrailingZeros(w);
@@ -2749,15 +2749,15 @@ public final class MappeableRunContainer extends MappeableContainer implements C
           w &= w - 1;
         }
       }
-      if(w == 0) {
+      if (w == 0) {
         ++ib;
       } else {
         return false;
       }
     }
-    if(ib < MappeableBitmapContainer.MAX_CAPACITY / 64) {
-      for(; ib < MappeableBitmapContainer.MAX_CAPACITY / 64 ; ib++) {
-        if(bitmapContainer.bitmap.get(ib) != 0) {
+    if (ib < MappeableBitmapContainer.MAX_CAPACITY / 64) {
+      for (; ib < MappeableBitmapContainer.MAX_CAPACITY / 64; ib++) {
+        if (bitmapContainer.bitmap.get(ib) != 0) {
           return false;
         }
       }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRunContainer.java
@@ -3386,6 +3386,13 @@ public class TestRunContainer {
   }
 
   @Test
+  public void testContainsBitmapContainer_SkipEmptyWords() {
+    Container rc = new RunContainer().add(128, 512);
+    Container subset = new BitmapContainer().add(256, 320);
+    assertTrue(rc.contains(subset));
+  }
+
+  @Test
   public void testContainsRunContainer_EmptyContainsEmpty() {
     Container rc = new RunContainer();
     Container subset = new RunContainer();

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRunContainer.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestRunContainer.java
@@ -2287,6 +2287,13 @@ public class TestRunContainer {
   }
 
   @Test
+  public void testContainsMappeableBitmapContainer_SkipEmptyWords() {
+    MappeableContainer rc = new MappeableRunContainer().add(128, 512);
+    MappeableContainer subset = new MappeableBitmapContainer().add(256, 320);
+    assertTrue(rc.contains(subset));
+  }
+
+  @Test
   public void testContainsMappeableRunContainer_EmptyContainsEmpty() {
     MappeableContainer rc = new MappeableRunContainer();
     MappeableContainer subset = new MappeableRunContainer();


### PR DESCRIPTION
### SUMMARY

Discovered last week while running fuzz tests.

When an empty word is encountered, it takes the first value from the next bitset in the array.
This value can be smaller than the current range start resulting in incorrect result.

Example from unit tests:
```java
    Container rc = new RunContainer().add(128, 512);
    Container subset = new BitmapContainer().add(256, 320);
```
Since the first bitset is empty, it would look for 64 (0 * 64 + 64 trailing zeros), but our range starts at 128.

The issue can be also reproduced by running `intersectsContainsRemove` in fuzz-tests.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
