### PR TITLE
Fix an issue that may cause RoaringBSI's fountSet to not work

### DIFF
--- a/bsi/src/main/java/org/roaringbitmap/bsi/RoaringBitmapSliceIndex.java
+++ b/bsi/src/main/java/org/roaringbitmap/bsi/RoaringBitmapSliceIndex.java
@@ -459,9 +459,9 @@ public class RoaringBitmapSliceIndex implements BitmapSliceIndex {
       case LT:
         return RoaringBitmap.and(LT, fixedFoundSet);
       case LE:
-        return RoaringBitmap.or(LT, EQ);
+        return RoaringBitmap.and(RoaringBitmap.or(LT, EQ), fixedFoundSet);
       case GE:
-        return RoaringBitmap.or(GT, EQ);
+        return RoaringBitmap.and(RoaringBitmap.or(GT, EQ), fixedFoundSet);
       default:
         throw new IllegalArgumentException("");
     }

--- a/bsi/src/test/java/org/roaringbitmap/bsi/RBBsiTest.java
+++ b/bsi/src/test/java/org/roaringbitmap/bsi/RBBsiTest.java
@@ -252,6 +252,19 @@ public class RBBsiTest {
 
         result = bsi.compare(BitmapSliceIndex.Operation.GE, 100, 0, null);
         Assertions.assertTrue(result.isEmpty());
+
+        RoaringBitmap foundSet = RoaringBitmap.bitmapOf(51, 52, 53);
+
+        result = bsi.compare(BitmapSliceIndex.Operation.GE, 50, 0, foundSet);
+        Assertions.assertTrue(result.getLongCardinality() == 3);
+        Assertions.assertArrayEquals(IntStream.range(51, 54).toArray(), result.toArray());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.GE, 0, 0, foundSet);
+        Assertions.assertTrue(result.getLongCardinality() == 3);
+        Assertions.assertArrayEquals(IntStream.range(51, 54).toArray(), result.toArray());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.GE, Integer.MAX_VALUE, 0, foundSet);
+        Assertions.assertTrue(result.isEmpty());
     }
 
     @Test
@@ -280,6 +293,19 @@ public class RBBsiTest {
         Assertions.assertArrayEquals(IntStream.range(1, 100).toArray(), result.toArray());
 
         result = bsi.compare(BitmapSliceIndex.Operation.LE, 0, 0, null);
+        Assertions.assertTrue(result.isEmpty());
+
+        RoaringBitmap foundSet = RoaringBitmap.bitmapOf(1, 2, 3);
+
+        result = bsi.compare(BitmapSliceIndex.Operation.LE, 50, 0, foundSet);
+        Assertions.assertTrue(result.getLongCardinality() == 3);
+        Assertions.assertArrayEquals(IntStream.range(1, 4).toArray(), result.toArray());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.LE, Integer.MAX_VALUE, 0, foundSet);
+        Assertions.assertTrue(result.getLongCardinality() == 3);
+        Assertions.assertArrayEquals(IntStream.range(1, 4).toArray(), result.toArray());
+
+        result = bsi.compare(BitmapSliceIndex.Operation.LE, 0, 0, foundSet);
         Assertions.assertTrue(result.isEmpty());
     }
 


### PR DESCRIPTION
Fix an issue that may cause RoaringBSI's fountSet to not work  ##correctly when doing LE and GE comparisons.

### SUMMARY
- A small change to [RoaringBitmapSliceIndex.java](https://github.com/RoaringBitmap/RoaringBitmap/compare/master...iszhangpch:fix-bsi-compare-issue?expand=1#diff-d48ea435f24454253ec7b2478435a8be06fe8848421e223ec0203c7797bd13bf)

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
