### PR TITLE
Changes for adding container size

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/ImmutableBitmapDataProvider.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/ImmutableBitmapDataProvider.java
@@ -319,6 +319,14 @@ public interface ImmutableBitmapDataProvider {
   int[] toArray();
 
   /**
+   * Returns the number of containers in the bitmap.
+   *
+   * @return the number of containers
+   */
+  int getContainerCount();
+
+
+  /**
    * An internal class to help provide streams.
    * Sad but true the interface of IntIterator and PrimitiveIterator.OfInt
    * Does not match. Otherwise it would be easier to just make IntIterator

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -3381,5 +3381,13 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
     return xor(bitmaps, (long) rangeStart, (long) rangeEnd);
   }
 
+  /**
+   * Returns the number of containers in the bitmap.
+   *
+   * @return the number of containers
+   */
+  public int getContainerCount() {
+    return highLowContainer.size();
+  }
 
 }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -3386,6 +3386,7 @@ public class RoaringBitmap implements Cloneable, Serializable, Iterable<Integer>
    *
    * @return the number of containers
    */
+  @Override
   public int getContainerCount() {
     return highLowContainer.size();
   }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -2038,5 +2038,12 @@ public class ImmutableRoaringBitmap
     answer.append('}');
     return answer.toString();
   }
-
+  /**
+   * Returns the number of containers in the bitmap.
+   *
+   * @return the number of containers
+   */
+  public int getContainerCount() {
+    return highLowContainer.size();
+  }
 }

--- a/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -2038,11 +2038,13 @@ public class ImmutableRoaringBitmap
     answer.append('}');
     return answer.toString();
   }
+
   /**
    * Returns the number of containers in the bitmap.
    *
    * @return the number of containers
    */
+  @Override
   public int getContainerCount() {
     return highLowContainer.size();
   }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/TestRoaringBitmap.java
@@ -5577,4 +5577,14 @@ public class TestRoaringBitmap {
         }
     }
 
+    @Test
+    public void testContainerSizeRoaringBitmapMultiple() {
+        RoaringBitmap r = RoaringBitmap.bitmapOfRange(1, 1000000);
+        assertEquals(16, r.getContainerCount());
+    }
+    @Test
+    public void testContainerSizeRoaringBitmapSingle() {
+        RoaringBitmap r = RoaringBitmap.bitmapOfRange(1, 100);
+        assertEquals(1, r.getContainerCount());
+    }
 }

--- a/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
+++ b/RoaringBitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
@@ -1588,4 +1588,14 @@ public class TestImmutableRoaringBitmap {
   public void invalidCookie() {
     assertThrows(InvalidRoaringFormat.class, () -> new ImmutableRoaringBitmap(ByteBuffer.allocate(8)));
   }
+  @Test
+  public void testContainerSizeRoaringBitmapMultiple() {
+    ImmutableRoaringBitmap r = ImmutableRoaringBitmap.bitmapOf(1, 1000000);
+    assertEquals(2, r.getContainerCount());
+  }
+  @Test
+  public void testContainerSizeRoaringBitmapSingle() {
+    ImmutableRoaringBitmap r = ImmutableRoaringBitmap.bitmapOf(1);
+    assertEquals(1, r.getContainerCount());
+  }
 }


### PR DESCRIPTION
### SUMMARY
https://github.com/RoaringBitmap/RoaringBitmap/issues/611

This PR adds the getContainerCount() method as a public method in both RoaringBitmap and ImmutableRoaringBitmap classes. This method will provide users with the ability to retrieve the number of containers in a bitmap, which can be useful for understanding the internal structure and memory usage of the bitmap.

It will help pinot in some specific usecases : https://github.com/RoaringBitmap/RoaringBitmap/issues/608#issuecomment-1364722016

### Automated Checks
![image](https://github.com/user-attachments/assets/d8be5272-194a-4a1d-9dee-e25f14de69e7)

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
- [x] I have run `./gradlew checkstyleMain` or the equivalent and corrected the formatting warnings reported.
