### PR TITLE
fix the bsi topk bug

### DIFF
--- a/bsi/src/main/java/org/roaringbitmap/bsi/buffer/BitSliceIndexBase.java
+++ b/bsi/src/main/java/org/roaringbitmap/bsi/buffer/BitSliceIndexBase.java
@@ -2,6 +2,7 @@ package org.roaringbitmap.bsi.buffer;
 
 import org.roaringbitmap.BatchIterator;
 import org.roaringbitmap.IntConsumer;
+import org.roaringbitmap.IntIterator;
 import org.roaringbitmap.bsi.BitmapSliceIndex;
 import org.roaringbitmap.bsi.BitmapSliceIndex.Operation;
 import org.roaringbitmap.bsi.Pair;
@@ -324,7 +325,14 @@ public class BitSliceIndexBase {
 
     MutableRoaringBitmap F = ImmutableRoaringBitmap.or(G, E);
     long n = F.getLongCardinality() - k;
-    F.remove(0L, (long) F.select((int) n));
+    if (n > 0) {
+      // turn off n bits from E in F
+      IntIterator iterator = E.getIntIterator();
+      while (iterator.hasNext() && n > 0) {
+        F.remove(iterator.next());
+        n--;
+      }
+    }
     assert (F.getLongCardinality() == k);
     return F;
   }

--- a/bsi/src/main/java/org/roaringbitmap/bsi/buffer/BitSliceIndexBase.java
+++ b/bsi/src/main/java/org/roaringbitmap/bsi/buffer/BitSliceIndexBase.java
@@ -305,6 +305,10 @@ public class BitSliceIndexBase {
           "TopK param error,cardinality:" + fixedFoundSet.getLongCardinality() + " k:" + k);
     }
 
+    if (k == 0) {
+      return new MutableRoaringBitmap();
+    }
+
     MutableRoaringBitmap G = new MutableRoaringBitmap();
     ImmutableRoaringBitmap E = fixedFoundSet;
 

--- a/bsi/src/test/java/org/roaringbitmap/bsi/BufferBSITest.java
+++ b/bsi/src/test/java/org/roaringbitmap/bsi/BufferBSITest.java
@@ -436,4 +436,21 @@ public class BufferBSITest {
     MutableRoaringBitmap top = bsi.topK(null, 1);
     System.out.println(top);
   }
+
+  @Test
+  public void testTopK2() {
+      MutableBitSliceIndex bsi = new MutableBitSliceIndex();
+      bsi.setValue(0, 0);
+      bsi.setValue(1, 6);
+      bsi.setValue(2, 1);
+      bsi.setValue(3, 7);
+      bsi.setValue(4, 0);
+      bsi.setValue(5, 9);
+      bsi.setValue(6, 9);
+      bsi.setValue(7, 8);
+      bsi.setValue(8, 9);
+      bsi.setValue(9, 8);
+
+    Assertions.assertEquals(bsi.topK(null, 4), MutableRoaringBitmap.bitmapOf(5, 6, 8, 9));
+  }
 }

--- a/bsi/src/test/java/org/roaringbitmap/bsi/BufferBSITest.java
+++ b/bsi/src/test/java/org/roaringbitmap/bsi/BufferBSITest.java
@@ -439,18 +439,19 @@ public class BufferBSITest {
 
   @Test
   public void testTopK2() {
-      MutableBitSliceIndex bsi = new MutableBitSliceIndex();
-      bsi.setValue(0, 0);
-      bsi.setValue(1, 6);
-      bsi.setValue(2, 1);
-      bsi.setValue(3, 7);
-      bsi.setValue(4, 0);
-      bsi.setValue(5, 9);
-      bsi.setValue(6, 9);
-      bsi.setValue(7, 8);
-      bsi.setValue(8, 9);
-      bsi.setValue(9, 8);
+    MutableBitSliceIndex bsi = new MutableBitSliceIndex();
+    bsi.setValue(0, 0);
+    bsi.setValue(1, 6);
+    bsi.setValue(2, 1);
+    bsi.setValue(3, 7);
+    bsi.setValue(4, 0);
+    bsi.setValue(5, 9);
+    bsi.setValue(6, 9);
+    bsi.setValue(7, 8);
+    bsi.setValue(8, 9);
+    bsi.setValue(9, 8);
 
     Assertions.assertEquals(bsi.topK(null, 4), MutableRoaringBitmap.bitmapOf(5, 6, 8, 9));
+    Assertions.assertEquals(bsi.topK(null, 0), MutableRoaringBitmap.bitmapOf());
   }
 }


### PR DESCRIPTION
### SUMMARY
According to the [Bit-sliced index arithmetic](https://dl.acm.org/doi/10.1145/376284.375669), the topk if n too many rows in F, turn off n bits from E in F.

### Automated Checks

- [ ] I have run `./gradlew test` and made sure that my PR does not break any unit test.
