### PR TITLE
[bugfix] Cloning empty Roaring64Bitmap now does not throw an exception.

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/longlong/HighLowContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/longlong/HighLowContainer.java
@@ -185,7 +185,9 @@ public class HighLowContainer {
         buffer.order() == LITTLE_ENDIAN ? buffer : buffer.slice().order(LITTLE_ENDIAN);
     if (art.isEmpty()) {
       byteBuffer.put(EMPTY_TAG);
-      buffer.position(buffer.position() + byteBuffer.position());
+      if (byteBuffer != buffer) {
+        buffer.position(buffer.position() + byteBuffer.position());
+      }
       return;
     } else {
       byteBuffer.put(NOT_EMPTY_TAG);

--- a/roaringbitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -2565,4 +2565,9 @@ public class TestRoaring64Bitmap {
     }
     assertEquals(2, addressSpace.getIntCardinality());
   }
+
+  @Test
+  public void testEmptyRoaring64BitmapClonesWithoutException() {
+    assertEquals(new Roaring64Bitmap(), new Roaring64Bitmap().clone());
+  }
 }


### PR DESCRIPTION
### SUMMARY
```
new Roaring64Bitmap().clone();
```
throws an exception.
PR fixes the issue.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
