### PR TITLE
readVInt causes inability to deserialize long data

### DIFF
--- a/bsi/src/main/java/org/roaringbitmap/bsi/longlong/Roaring64BitmapSliceIndex.java
+++ b/bsi/src/main/java/org/roaringbitmap/bsi/longlong/Roaring64BitmapSliceIndex.java
@@ -206,8 +206,8 @@ public class Roaring64BitmapSliceIndex {
     this.clear();
 
     // read meta
-    this.minValue = WritableUtils.readVInt(in);
-    this.maxValue = WritableUtils.readVInt(in);
+    this.minValue = WritableUtils.readVLong(in);
+    this.maxValue = WritableUtils.readVLong(in);
     this.runOptimized = in.readBoolean();
 
     // read ebm


### PR DESCRIPTION
### SUMMARY
This pull request resolves the issue mentioned in https://github.com/RoaringBitmap/RoaringBitmap/issues/764.

### Automated Checks

- [ ] I have run `./gradlew test` and made sure that my PR does not break any unit test.
