### PR TITLE
Fix overflow in ImmutableRoaringBitmap#flip

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -630,19 +630,19 @@ public class ImmutableRoaringBitmap
     answer.getMappeableRoaringArray().appendCopiesUntil(bm.highLowContainer, hbStart);
 
     final int max = (BufferUtil.maxLowBit());
-    for (char hb = hbStart; hb <= hbLast; ++hb) {
-      final int containerStart = (hb == hbStart) ? (lbStart) : 0;
-      final int containerLast = (hb == hbLast) ? (lbLast) : max;
+    for (int hb = hbStart; hb <= hbLast; ++hb) {
+      final int containerStart = (hb == hbStart) ? lbStart : 0;
+      final int containerLast = (hb == hbLast) ? lbLast : max;
 
-      final int i = bm.highLowContainer.getIndex(hb);
-      final int j = answer.getMappeableRoaringArray().getIndex(hb);
+      final int i = bm.highLowContainer.getIndex((char) hb);
+      final int j = answer.getMappeableRoaringArray().getIndex((char) hb);
       assert j < 0;
 
       if (i >= 0) {
         final MappeableContainer c =
             bm.highLowContainer.getContainerAtIndex(i).not(containerStart, containerLast + 1);
         if (!c.isEmpty()) {
-          answer.getMappeableRoaringArray().insertNewKeyValueAt(-j - 1, hb, c);
+          answer.getMappeableRoaringArray().insertNewKeyValueAt(-j - 1, (char) hb, c);
         }
 
       } else { // *think* the range of ones must never be
@@ -650,7 +650,9 @@ public class ImmutableRoaringBitmap
         answer
             .getMappeableRoaringArray()
             .insertNewKeyValueAt(
-                -j - 1, hb, MappeableContainer.rangeOfOnes(containerStart, containerLast + 1));
+                -j - 1,
+                (char) hb,
+                MappeableContainer.rangeOfOnes(containerStart, containerLast + 1));
       }
     }
     // copy the containers after the active area.

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
@@ -338,7 +338,7 @@ public class TestImmutableRoaringBitmap {
   }
 
   @Test
-  public void fliptest1() {
+  public void testMutableRoaringBitmapFlip() {
     final MutableRoaringBitmap rb = new MutableRoaringBitmap();
     rb.add(0);
     rb.add(2);
@@ -350,7 +350,17 @@ public class TestImmutableRoaringBitmap {
   }
 
   @Test
-  public void fliptest2() {
+  public void testMutableRoaringBitmapFlip_WithRangeEndInMaxHighBitsContainer() {
+    final MutableRoaringBitmap rb = MutableRoaringBitmap.bitmapOfRange(0L, 3L);
+
+    final MutableRoaringBitmap actual = MutableRoaringBitmap.flip(rb, (1L << 32) - 3, 1L << 32);
+    final MutableRoaringBitmap expected = MutableRoaringBitmap.bitmapOf(0, 1, 2, -3, -2, -1);
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testImmutableRoaringBitmapFlip() {
     final MutableRoaringBitmap rb = new MutableRoaringBitmap();
     rb.add(0);
     rb.add(2);
@@ -359,6 +369,16 @@ public class TestImmutableRoaringBitmap {
     result.add(1);
 
     assertEquals(result, rb2);
+  }
+
+  @Test
+  public void testImmutableRoaringBitmapFlip_WithRangeEndInMaxHighBitsContainer() {
+    final MutableRoaringBitmap rb = MutableRoaringBitmap.bitmapOfRange(0L, 3L);
+
+    final MutableRoaringBitmap actual = ImmutableRoaringBitmap.flip(rb, (1L << 32) - 3, 1L << 32);
+    final MutableRoaringBitmap expected = MutableRoaringBitmap.bitmapOf(0, 1, 2, -3, -2, -1);
+
+    assertEquals(expected, actual);
   }
 
   @Test


### PR DESCRIPTION
### SUMMARY

Fixes overflow in ImmutableRoaringBitmap#flip that occurs when range ends in the highest possible 16-bit key (65535) container.

This includes range ends from `(1L << 32) - (1 << 16)` to `(1L << 32)`

MutableRoaringBItmap doesn't have this issue, but included test for both.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
