### PR TITLE
issue-773-don't mutate in isEmpty

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
@@ -1483,14 +1483,17 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
     return size;
   }
 
-  @Override
   /**
    * Returns true if the bitmap is empty (i.e., has no set bits).
-   * In general, it is a a mutator method due to caching: this function modifies
-   * the internal state of the bitmap.
    */
+  @Override
   public boolean isEmpty() {
-    return getLongCardinality() == 0L;
+    for (BitmapDataProvider bitmap : highToBitmap.values()) {
+      if (!bitmap.isEmpty()) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Override


### PR DESCRIPTION
### SUMMARY
make isEmpty simpler and non mutating
related to https://github.com/RoaringBitmap/RoaringBitmap/issues/773

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.


There was one broken test broken before I chnaged, and its unaffected ([TestSerializationViaByteBuffer](https://github.com/RoaringBitmap/RoaringBitmap/compare/classes/org.roaringbitmap.buffer.TestSerializationViaByteBuffer.html). [[14] 8, LITTLE_ENDIAN, true](https://github.com/RoaringBitmap/RoaringBitmap/compare/classes/org.roaringbitmap.buffer.TestSerializationViaByteBuffer.html#testDeserializeFromMappedFile(int,%20ByteOrder,%20boolean)[14]). I am running on windows