### PR TITLE
make isEmpty faster

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -841,7 +841,17 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
 
   @Override
   public boolean isEmpty() {
-    return getLongCardinality() == 0L;
+
+    if (highLowContainer.isEmpty()) {
+      return true;
+    }
+    Iterator<Container> containerIterator = highLowContainer.containerIterator();
+    while (containerIterator.hasNext()) {
+      Container container = containerIterator.next();
+      if (!container.isEmpty())
+        return false;
+    }
+    return true;
   }
 
   @Override

--- a/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -910,6 +910,7 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
   public void deserialize(DataInput in) throws IOException {
     this.clear();
     highLowContainer.deserialize(in);
+    removeEmpty();
   }
 
   /**
@@ -926,6 +927,26 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
   public void deserialize(ByteBuffer in) throws IOException {
     this.clear();
     highLowContainer.deserialize(in);
+    removeEmpty();
+  }
+
+  /**
+   * Remove empty containers. It's an invariant that there should be no empty containers in the current implementation.
+   * However, it is possible that the serialized form may have come from another codebase (previous implementation or
+   * different language), so it is prudent to enforce.
+   */
+  private void removeEmpty() {
+    if (!highLowContainer.isEmpty()) {
+      KeyIterator keyIterator = highLowContainer.highKeyIterator();
+      while (keyIterator.hasNext()) {
+        keyIterator.next();
+        long containerIdx = keyIterator.currentContainerIdx();
+        Container container = highLowContainer.getContainer(containerIdx);
+        if (container.isEmpty()) {
+          keyIterator.remove();
+        }
+      }
+    }
   }
 
   @Override

--- a/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -841,17 +841,7 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
 
   @Override
   public boolean isEmpty() {
-
-    if (highLowContainer.isEmpty()) {
-      return true;
-    }
-    Iterator<Container> containerIterator = highLowContainer.containerIterator();
-    while (containerIterator.hasNext()) {
-      Container container = containerIterator.next();
-      if (!container.isEmpty())
-        return false;
-    }
-    return true;
+    return highLowContainer.isEmpty();
   }
 
   @Override


### PR DESCRIPTION
### SUMMARY
dont count and compare with 0
just see if any of the registers are non empty

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
There was one broken test broken before I changed, and its unaffected ([TestSerializationViaByteBuffer](https://github.com/RoaringBitmap/RoaringBitmap/compare/classes/org.roaringbitmap.buffer.TestSerializationViaByteBuffer.html). [[14] 8, LITTLE_ENDIAN, true](https://github.com/RoaringBitmap/RoaringBitmap/compare/classes/org.roaringbitmap.buffer.TestSerializationViaByteBuffer.html#testDeserializeFromMappedFile(int,%20ByteOrder,%20boolean)%5B14%5D). I am running on windows

Part of https://github.com/RoaringBitmap/RoaringBitmap/issues/776