### PR TITLE
share empty arrays

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Art.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Art.java
@@ -254,7 +254,7 @@ public class Art {
           System.arraycopy(node.prefix, mismatchPos + 1, node.prefix, 0, node.prefixLength);
         } else {
           // TODO:to reduce the 0 prefix memory space,we could mark the prefix as null
-          node.prefix = new byte[0];
+          node.prefix = EMPTY_BYTES;
         }
         LeafNode leafNode = new LeafNode(key, containerIdx);
         Node4.insert(node4, leafNode, key[mismatchPos + depth]);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node.java
@@ -17,6 +17,7 @@ public abstract class Node {
   // to benefit calculation,we keep the value as a short type
   protected short count;
   public static final int ILLEGAL_IDX = -1;
+  private static final byte[] EMPTY_BYTES = new byte[0];
 
   /**
    * constructor
@@ -27,7 +28,7 @@ public abstract class Node {
   public Node(NodeType nodeType, int compressedPrefixSize) {
     this.nodeType = nodeType;
     this.prefixLength = (byte) compressedPrefixSize;
-    prefix = new byte[prefixLength];
+    prefix = compressedPrefixSize == 0 ? EMPTY_BYTES : new byte[prefixLength];
     count = 0;
   }
 
@@ -351,11 +352,13 @@ public abstract class Node {
   }
 
   private static Node deserializeHeader(DataInput dataInput) throws IOException {
-    int nodeTypeOrdinal = dataInput.readByte();
-    short count = Short.reverseBytes(dataInput.readShort());
-    byte prefixLength = dataInput.readByte();
-    byte[] prefix = new byte[0];
-    if (prefixLength > 0) {
+    final int nodeTypeOrdinal = dataInput.readByte();
+    final short count = Short.reverseBytes(dataInput.readShort());
+    final byte prefixLength = dataInput.readByte();
+    final byte[] prefix;
+    if (prefixLength == 0) {
+      prefix = EMPTY_BYTES;
+    } else {
       prefix = new byte[prefixLength];
       dataInput.readFully(prefix);
     }
@@ -398,11 +401,13 @@ public abstract class Node {
   }
 
   private static Node deserializeHeader(ByteBuffer byteBuffer) throws IOException {
-    int nodeTypeOrdinal = byteBuffer.get();
-    short count = byteBuffer.getShort();
-    byte prefixLength = byteBuffer.get();
-    byte[] prefix = new byte[0];
-    if (prefixLength > 0) {
+    final int nodeTypeOrdinal = byteBuffer.get();
+    final short count = byteBuffer.getShort();
+    final byte prefixLength = byteBuffer.get();
+    final byte[] prefix;
+    if (prefixLength == 0) {
+      prefix = EMPTY_BYTES;
+    } else {
       prefix = new byte[prefixLength];
       byteBuffer.get(prefix);
     }


### PR DESCRIPTION
### SUMMARY
dont create empty arrays, use a shared empty array

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.


There was one broken test broken before I chnaged, and its unaffected ([TestSerializationViaByteBuffer](https://github.com/RoaringBitmap/RoaringBitmap/compare/classes/org.roaringbitmap.buffer.TestSerializationViaByteBuffer.html). [[14] 8, LITTLE_ENDIAN, true](https://github.com/RoaringBitmap/RoaringBitmap/compare/classes/org.roaringbitmap.buffer.TestSerializationViaByteBuffer.html#testDeserializeFromMappedFile(int,%20ByteOrder,%20boolean)%5B14%5D). I am running on windows

part of https://github.com/RoaringBitmap/RoaringBitmap/issues/776