### PR TITLE
Implement copy on write roaring bitmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ RoaringBitmap
 - [Kryo](#kryo)
 - [64-bit integers (long)](#64-bit-integers-long)
 - [Range Bitmaps](#range-bitmaps)
+- [COW Roaring Bitmaps](#copy-on-write-roaringbitmaps)
 - [Prerequisites](#prerequisites)
 - [Usage for RoaringBitmap Developers](#usage-for-roaringbitmap-developers)
 - [IntelliJ and Eclipse](#intellij-and-eclipse)
@@ -652,9 +653,21 @@ ByteBuffer buffer = mapBuffer(appender.serializedSizeInBytes());
 appender.serialize(buffer);
 RangeBitmap bitmap = RangeBitmap.map(buffer);
 ```
-
 The serialization format uses little endian byte order.
 
+
+## Copy-on-Write RoaringBitmaps
+
+Enable memory-efficient bitmap modifications with `toMutableRoaringBitmapCopyOnWrite()`. Only copies containers when actually modified, reducing memory usage compared to traditional approaches while maintaining full mutability.
+```java
+// Convert ImmutableRoaringBitmap to mutable with minimal copying
+ImmutableRoaringBitmap immutable = new ImmutableRoaringBitmap(byteBuffer);
+CopyOnWriteRoaringBitmap cowBitmap = immutable.toMutableRoaringBitmapCopyOnWrite();
+
+// Modifications only copy containers when needed
+cowBitmap.add(newValue);    // Only copies affected containers
+cowBitmap.remove(oldValue); // Shares unchanged containers
+```
 Prerequisites
 -------------
 

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/CopyOnWriteRoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/CopyOnWriteRoaringBitmap.java
@@ -1,0 +1,169 @@
+package org.roaringbitmap.buffer;
+
+/*
+ * (c) the authors Licensed under the Apache License, Version 2.0.
+ */
+
+
+
+import java.util.Arrays;
+
+/**
+ * A MutableRoaringBitmap that implements copy-on-write semantics for containers.
+ * This allows efficient sharing of memory-mapped containers until they need to be modified.
+ */
+public class CopyOnWriteRoaringBitmap extends MutableRoaringBitmap {
+  private boolean[] needsCopy;
+  private boolean copyOnWrite = true;
+
+  /**
+   * Create a new copy-on-write bitmap.
+   */
+  public CopyOnWriteRoaringBitmap() {
+    super();
+    needsCopy = new boolean[4]; // Initial capacity
+  }
+
+  /**
+   * Create a copy-on-write bitmap from an immutable bitmap.
+   */
+  public static CopyOnWriteRoaringBitmap fromImmutable(ImmutableRoaringBitmap immutable) {
+    CopyOnWriteRoaringBitmap result = new CopyOnWriteRoaringBitmap();
+    MappeableContainerPointer mcp = immutable.highLowContainer.getContainerPointer();
+    while (mcp.hasContainer()) {
+      result.getMappeableRoaringArray().appendCopyOnWrite(mcp.key(), mcp.getContainer());
+      mcp.advance();
+    }
+    result.needsCopy = new boolean[result.getMappeableRoaringArray().size];
+    Arrays.fill(result.needsCopy, true);
+    return result;
+  }
+
+  /**
+   * Ensure the container at the given index is copied if needed.
+   */
+  private void ensureContainerCopied(int index) {
+    if (copyOnWrite && index < needsCopy.length && needsCopy[index]) {
+      MutableRoaringArray array = getMappeableRoaringArray();
+      array.setContainerAtIndex(index, array.getContainerAtIndex(index).clone());
+      needsCopy[index] = false;
+    }
+  }
+
+  /**
+   * Ensure all containers are copied if needed.
+   */
+  private void ensureAllContainersCopied() {
+    if (copyOnWrite) {
+      MutableRoaringArray array = getMappeableRoaringArray();
+      for (int i = 0; i < array.size && i < needsCopy.length; i++) {
+        if (needsCopy[i]) {
+          array.setContainerAtIndex(i, array.getContainerAtIndex(i).clone());
+          needsCopy[i] = false;
+        }
+      }
+    }
+  }
+
+  /**
+   * Extend the needsCopy array if necessary.
+   */
+  private void extendNeedsCopyArray(int minSize) {
+    if (needsCopy.length < minSize) {
+      boolean[] newArray = new boolean[Math.max(minSize, needsCopy.length * 2)];
+      System.arraycopy(needsCopy, 0, newArray, 0, needsCopy.length);
+      needsCopy = newArray;
+    }
+  }
+
+  @Override
+  public void add(int x) {
+    if (copyOnWrite) {
+      char hb = (char) (x >>> 16);
+      MutableRoaringArray array = getMappeableRoaringArray();
+      int index = array.getIndex(hb);
+      if (index >= 0) {
+        ensureContainerCopied(index);
+      }
+    }
+    super.add(x);
+  }
+
+  @Override
+  public void remove(int x) {
+    if (copyOnWrite) {
+      char hb = (char) (x >>> 16);
+      MutableRoaringArray array = getMappeableRoaringArray();
+      int index = array.getIndex(hb);
+      if (index >= 0) {
+        ensureContainerCopied(index);
+      }
+    }
+    super.remove(x);
+  }
+
+  @Override
+  public void flip(int x) {
+    if (copyOnWrite) {
+      char hb = (char) (x >>> 16);
+      MutableRoaringArray array = getMappeableRoaringArray();
+      int index = array.getIndex(hb);
+      if (index >= 0) {
+        ensureContainerCopied(index);
+      }
+    }
+    super.flip(x);
+  }
+
+  @Override
+  public void or(ImmutableRoaringBitmap x2) {
+    if (copyOnWrite) {
+      ensureAllContainersCopied();
+      copyOnWrite = false;
+    }
+    super.or(x2);
+  }
+
+  @Override
+  public void and(ImmutableRoaringBitmap x2) {
+    if (copyOnWrite) {
+      ensureAllContainersCopied();
+      copyOnWrite = false;
+    }
+    super.and(x2);
+  }
+
+  @Override
+  public void xor(ImmutableRoaringBitmap x2) {
+    if (copyOnWrite) {
+      ensureAllContainersCopied();
+      copyOnWrite = false;
+    }
+    super.xor(x2);
+  }
+
+  @Override
+  public void andNot(ImmutableRoaringBitmap x2) {
+    if (copyOnWrite) {
+      ensureAllContainersCopied();
+      copyOnWrite = false;
+    }
+    super.andNot(x2);
+  }
+
+  @Override
+  public CopyOnWriteRoaringBitmap clone() {
+    CopyOnWriteRoaringBitmap result = new CopyOnWriteRoaringBitmap();
+    result.copyOnWrite = this.copyOnWrite;
+    if (copyOnWrite) {
+      // Share containers
+      result.highLowContainer = this.highLowContainer.clone();
+      result.needsCopy = this.needsCopy.clone();
+    } else {
+      // Deep copy
+      result.highLowContainer = this.highLowContainer.clone();
+      result.copyOnWrite = false;
+    }
+    return result;
+  }
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -2042,6 +2042,18 @@ public class ImmutableRoaringBitmap
   }
 
   /**
+   * Creates a mutable bitmap using copy-on-write semantics.
+   * Containers from this bitmap will only be copied when they need to be modified.
+   * This provides better performance for memory-mapped bitmaps that are used mostly
+   * for read operations with occasional modifications.
+   *
+   * @return a mutable bitmap with copy-on-write semantics.
+   */
+  public CopyOnWriteRoaringBitmap toMutableRoaringBitmapCopyOnWrite() {
+    return CopyOnWriteRoaringBitmap.fromImmutable(this);
+  }
+
+  /**
    * Copies this bitmap to a mutable RoaringBitmap.
    *
    * @return a copy of this bitmap as a RoaringBitmap.

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
@@ -219,6 +219,40 @@ public final class MutableRoaringArray
     this.size++;
   }
 
+  /**
+   * Append a container with copy-on-write semantics.
+   * The container will only be copied when it needs to be modified.
+   *
+   * @param key the key
+   * @param value the container
+   */
+  protected void appendCopyOnWrite(char key, MappeableContainer value) {
+    extendArray(1);
+    this.keys[this.size] = key;
+    // Store the original container directly - we'll handle copy-on-write at the bitmap level
+    this.values[this.size] = value;
+    this.size++;
+  }
+
+  /**
+   * Append containers with copy-on-write semantics from a range of another array.
+   * The containers will only be copied when they need to be modified.
+   *
+   * @param highLowContainer the source array
+   * @param startingIndex the starting index (inclusive)
+   * @param end the ending index (exclusive)
+   */
+  protected void appendCopyOnWrite(
+      PointableRoaringArray highLowContainer, int startingIndex, int end) {
+    extendArray(end - startingIndex);
+    for (int i = startingIndex; i < end; ++i) {
+      this.keys[this.size] = highLowContainer.getKeyAtIndex(i);
+      // Store the original container directly - we'll handle copy-on-write at the bitmap level
+      this.values[this.size] = highLowContainer.getContainerAtIndex(i);
+      this.size++;
+    }
+  }
+
   private int binarySearch(int begin, int end, char key) {
     return Util.unsignedBinarySearch(keys, begin, end, key);
   }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestCopyOnWrite.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestCopyOnWrite.java
@@ -1,0 +1,103 @@
+package org.roaringbitmap.buffer;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Test the copy-on-write functionality for memory-mapped bitmaps.
+ */
+public class TestCopyOnWrite {
+
+  @Test
+  public void testCopyOnWriteBasic() throws IOException {
+    // Create a memory-mapped bitmap
+    MutableRoaringBitmap original = new MutableRoaringBitmap();
+    for (int i = 1; i < 1000; i++) {
+      original.add(i);
+    }
+    for (int i = 2000; i < 3000; i++) {
+      original.add(i);
+    }
+    for (int i = 5000; i < 6000; i++) {
+      original.add(i);
+    }
+
+    // Serialize to ByteBuffer
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    original.serialize(dos);
+    dos.close();
+
+    ByteBuffer bb = ByteBuffer.wrap(bos.toByteArray());
+    ImmutableRoaringBitmap immutable = new ImmutableRoaringBitmap(bb);
+
+    // Test that normal conversion still works
+    MutableRoaringBitmap copy = immutable.toMutableRoaringBitmap();
+    assertEquals(original.getCardinality(), copy.getCardinality());
+    assertEquals(original, copy);
+
+    // Test copy-on-write conversion
+    CopyOnWriteRoaringBitmap cowCopy = immutable.toMutableRoaringBitmapCopyOnWrite();
+    assertEquals(original.getCardinality(), cowCopy.getCardinality());
+    assertEquals(original, cowCopy);
+
+    // Verify both copies are functionally equivalent
+    assertEquals(copy, cowCopy);
+
+    // Test that modifications work correctly with copy-on-write
+    cowCopy.add(10000);
+    assertTrue(cowCopy.contains(10000));
+    assertFalse(immutable.contains(10000));
+    assertFalse(copy.contains(10000));
+
+    // Test that operations on copy-on-write bitmap work
+    cowCopy.remove(500);
+    assertFalse(cowCopy.contains(500));
+    assertTrue(immutable.contains(500));
+    assertTrue(copy.contains(500));
+  }
+
+  @Test
+  public void testCopyOnWritePerformance() throws IOException {
+    // Create a large bitmap
+    MutableRoaringBitmap large = new MutableRoaringBitmap();
+    for (int i = 0; i < 100000; i += 10) {
+      large.add(i);
+    }
+
+    // Serialize to ByteBuffer
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    large.serialize(dos);
+    dos.close();
+
+    ByteBuffer bb = ByteBuffer.wrap(bos.toByteArray());
+    ImmutableRoaringBitmap immutable = new ImmutableRoaringBitmap(bb);
+
+    // Time the copy-on-write conversion (should be fast)
+    long startTime = System.nanoTime();
+    CopyOnWriteRoaringBitmap cow = immutable.toMutableRoaringBitmapCopyOnWrite();
+    long cowTime = System.nanoTime() - startTime;
+
+    // Time the regular conversion (should be slower)
+    startTime = System.nanoTime();
+    MutableRoaringBitmap copy = immutable.toMutableRoaringBitmap();
+    long copyTime = System.nanoTime() - startTime;
+
+    // Copy-on-write should be significantly faster (though small bitmaps may have overhead)
+    // Just verify both approaches work and produce the same result
+    System.out.println("Copy-on-write time: " + cowTime + "ns, Full copy time: " + copyTime + "ns");
+
+    // But both should be functionally equivalent
+    assertEquals(copy, cow);
+  }
+}

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestCopyOnWrite.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestCopyOnWrite.java
@@ -94,7 +94,6 @@ public class TestCopyOnWrite {
     long copyTime = System.nanoTime() - startTime;
 
     // Copy-on-write should be significantly faster (though small bitmaps may have overhead)
-    // Just verify both approaches work and produce the same result
     System.out.println("Copy-on-write time: " + cowTime + "ns, Full copy time: " + copyTime + "ns");
 
     // But both should be functionally equivalent

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestCopyOnWriteEdgeCases.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestCopyOnWriteEdgeCases.java
@@ -1,0 +1,370 @@
+package org.roaringbitmap.buffer;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Test edge cases and error conditions for copy-on-write functionality.
+ */
+public class TestCopyOnWriteEdgeCases {
+
+  @Test
+  public void testEmptyBitmap() throws IOException {
+    // Test with empty bitmap
+    MutableRoaringBitmap empty = new MutableRoaringBitmap();
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    empty.serialize(dos);
+    dos.close();
+
+    ByteBuffer bb = ByteBuffer.wrap(bos.toByteArray());
+    ImmutableRoaringBitmap immutable = new ImmutableRoaringBitmap(bb);
+
+    // Test copy-on-write with empty bitmap
+    CopyOnWriteRoaringBitmap cow = immutable.toMutableRoaringBitmapCopyOnWrite();
+
+    assertEquals(0, cow.getCardinality());
+    assertTrue(cow.isEmpty());
+
+    // Adding to empty bitmap should work
+    cow.add(1);
+    assertEquals(1, cow.getCardinality());
+    assertTrue(cow.contains(1));
+
+    // Original should still be empty
+    assertEquals(0, immutable.getCardinality());
+    assertTrue(immutable.isEmpty());
+  }
+
+  @Test
+  public void testSingleElementBitmap() throws IOException {
+    // Test with single element
+    MutableRoaringBitmap single = new MutableRoaringBitmap();
+    single.add(42);
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    single.serialize(dos);
+    dos.close();
+
+    ByteBuffer bb = ByteBuffer.wrap(bos.toByteArray());
+    ImmutableRoaringBitmap immutable = new ImmutableRoaringBitmap(bb);
+
+    CopyOnWriteRoaringBitmap cow = immutable.toMutableRoaringBitmapCopyOnWrite();
+
+    assertEquals(1, cow.getCardinality());
+    assertTrue(cow.contains(42));
+
+    // Remove the only element
+    cow.remove(42);
+    assertEquals(0, cow.getCardinality());
+    assertFalse(cow.contains(42));
+
+    // Original should still have the element
+    assertEquals(1, immutable.getCardinality());
+    assertTrue(immutable.contains(42));
+  }
+
+  @Test
+  public void testFullRangeContainer() throws IOException {
+    // Test with a full range (bitmap container)
+    MutableRoaringBitmap full = new MutableRoaringBitmap();
+    for (int i = 0; i < 65536; i++) {
+      full.add(i);
+    }
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    full.serialize(dos);
+    dos.close();
+
+    ByteBuffer bb = ByteBuffer.wrap(bos.toByteArray());
+    ImmutableRoaringBitmap immutable = new ImmutableRoaringBitmap(bb);
+
+    CopyOnWriteRoaringBitmap cow = immutable.toMutableRoaringBitmapCopyOnWrite();
+
+    assertEquals(65536, cow.getCardinality());
+    assertTrue(cow.contains(0));
+    assertTrue(cow.contains(32768));
+    assertTrue(cow.contains(65535));
+
+    // Modify the full container
+    cow.remove(32768);
+    assertEquals(65535, cow.getCardinality());
+    assertFalse(cow.contains(32768));
+
+    // Original should still be full
+    assertEquals(65536, immutable.getCardinality());
+    assertTrue(immutable.contains(32768));
+  }
+
+  @Test
+  public void testSparseDistribution() throws IOException {
+    // Test with sparse distribution across many containers
+    MutableRoaringBitmap sparse = new MutableRoaringBitmap();
+    for (int i = 0; i < 1000; i++) {
+      sparse.add(i * 100000); // Spread across many containers
+    }
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    sparse.serialize(dos);
+    dos.close();
+
+    ByteBuffer bb = ByteBuffer.wrap(bos.toByteArray());
+    ImmutableRoaringBitmap immutable = new ImmutableRoaringBitmap(bb);
+
+    CopyOnWriteRoaringBitmap cow = immutable.toMutableRoaringBitmapCopyOnWrite();
+
+    assertEquals(1000, cow.getCardinality());
+
+    // Modify elements in different containers
+    cow.add(50000); // Container 0
+    cow.add(150000); // Container 1
+    cow.add(250000); // Container 2
+
+    assertEquals(1003, cow.getCardinality());
+    assertTrue(cow.contains(50000));
+    assertTrue(cow.contains(150000));
+    assertTrue(cow.contains(250000));
+
+    // Original should be unchanged
+    assertEquals(1000, immutable.getCardinality());
+    assertFalse(immutable.contains(50000));
+    assertFalse(immutable.contains(150000));
+    assertFalse(immutable.contains(250000));
+  }
+
+  @Test
+  public void testMultipleModificationsSameContainer() throws IOException {
+    // Test multiple modifications to the same container
+    MutableRoaringBitmap original = new MutableRoaringBitmap();
+    original.add(1);
+    original.add(2);
+    original.add(3);
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    original.serialize(dos);
+    dos.close();
+
+    ByteBuffer bb = ByteBuffer.wrap(bos.toByteArray());
+    ImmutableRoaringBitmap immutable = new ImmutableRoaringBitmap(bb);
+
+    CopyOnWriteRoaringBitmap cow = immutable.toMutableRoaringBitmapCopyOnWrite();
+
+    // Multiple modifications to the same container
+    cow.add(4);
+    cow.add(5);
+    cow.remove(2);
+    cow.flip(6);
+
+    assertEquals(5, cow.getCardinality()); // 1,3,4,5,6
+    assertTrue(cow.contains(1));
+    assertFalse(cow.contains(2));
+    assertTrue(cow.contains(3));
+    assertTrue(cow.contains(4));
+    assertTrue(cow.contains(5));
+    assertTrue(cow.contains(6));
+
+    // Original should be unchanged
+    assertEquals(3, immutable.getCardinality());
+    assertTrue(immutable.contains(1));
+    assertTrue(immutable.contains(2));
+    assertTrue(immutable.contains(3));
+  }
+
+  @Test
+  public void testCloneOfCopyOnWrite() throws IOException {
+    // Test cloning copy-on-write bitmaps
+    MutableRoaringBitmap original = new MutableRoaringBitmap();
+    original.add(1);
+    original.add(2);
+    original.add(3);
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    original.serialize(dos);
+    dos.close();
+
+    ByteBuffer bb = ByteBuffer.wrap(bos.toByteArray());
+    ImmutableRoaringBitmap immutable = new ImmutableRoaringBitmap(bb);
+
+    CopyOnWriteRoaringBitmap cow1 = immutable.toMutableRoaringBitmapCopyOnWrite();
+    CopyOnWriteRoaringBitmap cow2 = cow1.clone();
+
+    assertEquals(cow1.getCardinality(), cow2.getCardinality());
+    assertEquals(cow1, cow2);
+
+    // Modify one clone
+    cow1.add(4);
+
+    // Should not affect the other clone
+    assertTrue(cow1.contains(4));
+    assertFalse(cow2.contains(4));
+    assertEquals(4, cow1.getCardinality());
+    assertEquals(3, cow2.getCardinality());
+  }
+
+  @Test
+  public void testOperationsOnCopyOnWrite() throws IOException {
+    // Test set operations on copy-on-write bitmaps
+    MutableRoaringBitmap original1 = new MutableRoaringBitmap();
+    original1.add(1);
+    original1.add(2);
+    original1.add(3);
+
+    MutableRoaringBitmap original2 = new MutableRoaringBitmap();
+    original2.add(2);
+    original2.add(3);
+    original2.add(4);
+
+    // Create copy-on-write bitmaps
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    original1.serialize(dos);
+    dos.close();
+
+    ByteBuffer bb = ByteBuffer.wrap(bos.toByteArray());
+    ImmutableRoaringBitmap immutable = new ImmutableRoaringBitmap(bb);
+
+    CopyOnWriteRoaringBitmap cow = immutable.toMutableRoaringBitmapCopyOnWrite();
+
+    // Test operations
+    cow.or(original2);
+    assertEquals(4, cow.getCardinality());
+    assertTrue(cow.contains(1));
+    assertTrue(cow.contains(2));
+    assertTrue(cow.contains(3));
+    assertTrue(cow.contains(4));
+
+    // Original should be unchanged
+    assertEquals(3, immutable.getCardinality());
+    assertTrue(immutable.contains(1));
+    assertTrue(immutable.contains(2));
+    assertTrue(immutable.contains(3));
+    assertFalse(immutable.contains(4));
+  }
+
+  @Test
+  public void testIterationAfterCopyOnWrite() throws IOException {
+    // Test iteration after copy-on-write modifications
+    MutableRoaringBitmap original = new MutableRoaringBitmap();
+    for (int i = 0; i < 100; i++) {
+      original.add(i);
+    }
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    original.serialize(dos);
+    dos.close();
+
+    ByteBuffer bb = ByteBuffer.wrap(bos.toByteArray());
+    ImmutableRoaringBitmap immutable = new ImmutableRoaringBitmap(bb);
+
+    CopyOnWriteRoaringBitmap cow = immutable.toMutableRoaringBitmapCopyOnWrite();
+
+    // Modify the bitmap
+    cow.add(200);
+    cow.remove(50);
+
+    // Test iteration
+    int count = 0;
+    for (int value : cow) {
+      count++;
+    }
+
+    assertEquals(100, count); // 100 original - 1 removed + 1 added
+    assertTrue(cow.contains(200));
+    assertFalse(cow.contains(50));
+
+    // Original should still have 100 elements
+    int originalCount = 0;
+    for (int value : immutable) {
+      originalCount++;
+    }
+    assertEquals(100, originalCount);
+  }
+
+  @Test
+  public void testSerializationAfterCopyOnWrite() throws IOException {
+    // Test serialization after copy-on-write modifications
+    MutableRoaringBitmap original = new MutableRoaringBitmap();
+    original.add(1);
+    original.add(2);
+    original.add(3);
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    original.serialize(dos);
+    dos.close();
+
+    ByteBuffer bb = ByteBuffer.wrap(bos.toByteArray());
+    ImmutableRoaringBitmap immutable = new ImmutableRoaringBitmap(bb);
+
+    CopyOnWriteRoaringBitmap cow = immutable.toMutableRoaringBitmapCopyOnWrite();
+
+    // Modify the bitmap
+    cow.add(4);
+    cow.remove(2);
+
+    // Serialize the modified bitmap
+    ByteArrayOutputStream bos2 = new ByteArrayOutputStream();
+    DataOutputStream dos2 = new DataOutputStream(bos2);
+    cow.serialize(dos2);
+    dos2.close();
+
+    // Deserialize and check
+    ByteBuffer bb2 = ByteBuffer.wrap(bos2.toByteArray());
+    ImmutableRoaringBitmap deserialized = new ImmutableRoaringBitmap(bb2);
+
+    assertEquals(3, deserialized.getCardinality());
+    assertTrue(deserialized.contains(1));
+    assertFalse(deserialized.contains(2));
+    assertTrue(deserialized.contains(3));
+    assertTrue(deserialized.contains(4));
+  }
+
+  @Test
+  public void testCopyOnWriteWithRunOptimization() throws IOException {
+    // Test copy-on-write with run optimization
+    MutableRoaringBitmap original = new MutableRoaringBitmap();
+    for (int i = 0; i < 10000; i++) {
+      original.add(i);
+    }
+    original.runOptimize();
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    original.serialize(dos);
+    dos.close();
+
+    ByteBuffer bb = ByteBuffer.wrap(bos.toByteArray());
+    ImmutableRoaringBitmap immutable = new ImmutableRoaringBitmap(bb);
+
+    CopyOnWriteRoaringBitmap cow = immutable.toMutableRoaringBitmapCopyOnWrite();
+
+    assertEquals(10000, cow.getCardinality());
+
+    // Modify to break the run
+    cow.remove(5000);
+
+    assertEquals(9999, cow.getCardinality());
+    assertFalse(cow.contains(5000));
+
+    // Original should still have the run
+    assertEquals(10000, immutable.getCardinality());
+    assertTrue(immutable.contains(5000));
+  }
+}
+


### PR DESCRIPTION
**Copy-on-Write Implementation for Roaring Bitmap** 
 
 
**Overview** 
 
This document provides a comprehensive explanation of the copy-on-write (CoW) implementation for Roaring Bitmap, specifically addressing GitHub [issue #193.](https://github.com/RoaringBitmap/RoaringBitmap/issues/193) The implementation enables efficient conversion of memory-mapped Roaring Bitmaps to mutable bitmaps by sharing containers until modification is required. 
 
**What is Copy-on-Write?** 
Copy-on-Write is a resource management technique where multiple copies of data can share the same underlying storage until one of them needs to modify the data. At that point, a private copy is created for the modifier, while other references continue to share the original data. 
 
**Benefits** 
 
Memory Efficiency: Shared containers reduce memory usage 
Lazy Evaluation: Containers are only copied when modified. 
 
**High-Level Design 
 
ImmutableRoaringBitmap 
     	↓ 
toMutableRoaringBitmapCopyOnWrite() 
     	↓ 
CopyOnWriteRoaringBitmap 
     	↓ 
[Shared Containers] → [Private Copy on Modify]** 
 
 
**Key Components** 
**CopyOnWriteRoaringBitmap**: Main class extending MutableRoaringBitmap 
**needsCopy Array**: Tracks which containers require copying 
**appendCopyOnWrite Methods**: Enable container sharing in MutableRoaringArray 
**Lazy Copying Logic**: Defers container duplication until modification