### PR TITLE
[64 bit bitmaps) Split non-leaf - BranchNode from leaf nodes (to reduce memory footprint)

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Art.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Art.java
@@ -51,12 +51,12 @@ public class Art {
       LeafNode leafNode = (LeafNode) node;
       return leafNode.containerIdx;
     }
-    return Node.ILLEGAL_IDX;
+    return BranchNode.ILLEGAL_IDX;
   }
 
   private Node findByKey(Node node, byte[] key, int depth) {
     while (node != null) {
-      if (node.nodeType == NodeType.LEAF_NODE) {
+      if (node instanceof LeafNode) {
         LeafNode leafNode = (LeafNode) node;
         byte[] leafNodeKeyBytes = leafNode.getKeyBytes();
         if (depth == LeafNode.LEAF_NODE_KEY_LENGTH_IN_BYTES) {
@@ -75,20 +75,21 @@ public class Art {
         }
         return leafNode;
       }
-      if (node.prefixLength > 0) {
+      BranchNode branchNode = (BranchNode) node;
+      if (branchNode.prefixLength > 0) {
         int commonLength =
-            commonPrefixLength(key, depth, key.length, node.prefix, 0, node.prefixLength);
-        if (commonLength != node.prefixLength) {
+            commonPrefixLength(key, depth, key.length, branchNode.prefix, 0, branchNode.prefixLength);
+        if (commonLength != branchNode.prefixLength) {
           return null;
         }
         // common prefix is the same ,then increase the depth
-        depth += node.prefixLength;
+        depth += branchNode.prefixLength;
       }
-      int pos = node.getChildPos(key[depth]);
-      if (pos == Node.ILLEGAL_IDX) {
+      int pos = branchNode.getChildPos(key[depth]);
+      if (pos == BranchNode.ILLEGAL_IDX) {
         return null;
       }
-      node = node.getChild(pos);
+      node = branchNode.getChild(pos);
       depth++;
     }
     return null;
@@ -113,19 +114,19 @@ public class Art {
     if (toolkit != null) {
       return toolkit.matchedContainerId;
     }
-    return Node.ILLEGAL_IDX;
+    return BranchNode.ILLEGAL_IDX;
   }
 
   protected Toolkit removeSpecifyKey(Node node, byte[] key, int dep) {
     if (node == null) {
       return null;
     }
-    if (node.nodeType == NodeType.LEAF_NODE) {
+    if (node instanceof LeafNode) {
       // root is null
       LeafNode leafNode = (LeafNode) node;
       if (leafMatch(leafNode, key, dep)) {
         // remove this node
-        if (node == this.root) {
+        if (leafNode == this.root) {
           this.root = null;
         }
         keySize--;
@@ -134,26 +135,27 @@ public class Art {
         return null;
       }
     }
-    if (node.prefixLength > 0) {
+    BranchNode branchNode = (BranchNode) node;
+    if (branchNode.prefixLength > 0) {
       int commonLength =
-          commonPrefixLength(key, dep, key.length, node.prefix, 0, node.prefixLength);
-      if (commonLength != node.prefixLength) {
+          commonPrefixLength(key, dep, key.length, branchNode.prefix, 0, branchNode.prefixLength);
+      if (commonLength != branchNode.prefixLength) {
         return null;
       }
-      dep += node.prefixLength;
+      dep += branchNode.prefixLength;
     }
-    int pos = node.getChildPos(key[dep]);
-    if (pos != Node.ILLEGAL_IDX) {
-      Node child = node.getChild(pos);
-      if (child.nodeType == NodeType.LEAF_NODE && leafMatch((LeafNode) child, key, dep)) {
+    int pos = branchNode.getChildPos(key[dep]);
+    if (pos != BranchNode.ILLEGAL_IDX) {
+      Node child = branchNode.getChild(pos);
+      if (child instanceof LeafNode && leafMatch((LeafNode) child, key, dep)) {
         // found matched leaf node from the current node.
-        Node freshNode = node.remove(pos);
+        Node freshNode = branchNode.remove(pos);
         keySize--;
-        if (node == this.root && freshNode != node) {
+        if (branchNode == this.root && freshNode != branchNode) {
           this.root = freshNode;
         }
         long matchedContainerIdx = ((LeafNode) child).getContainerIdx();
-        Toolkit toolkit = new Toolkit(freshNode, matchedContainerIdx, node);
+        Toolkit toolkit = new Toolkit(freshNode, matchedContainerIdx, branchNode);
         toolkit.needToVerifyReplacing = true;
         return toolkit;
       } else {
@@ -163,7 +165,7 @@ public class Art {
             && toolkit.freshMatchedParentNode != null
             && toolkit.freshMatchedParentNode != toolkit.originalMatchedParentNode) {
           // meaning find the matched key and the shrinking happened
-          node.replaceNode(pos, toolkit.freshMatchedParentNode);
+          branchNode.replaceNode(pos, toolkit.freshMatchedParentNode);
           toolkit.needToVerifyReplacing = false;
           return toolkit;
         }
@@ -215,14 +217,11 @@ public class Art {
       LeafNode leafNode = new LeafNode(key, containerIdx);
       return leafNode;
     }
-    if (node.nodeType == NodeType.LEAF_NODE) {
+    if (node instanceof LeafNode) {
       LeafNode leafNode = (LeafNode) node;
       byte[] prefix = leafNode.getKeyBytes();
       int commonPrefix = commonPrefixLength(prefix, depth, prefix.length, key, depth, key.length);
-      // The leaf node maybe was shrunk from some other node type before and
-      // contained an old prefixLength,so we reset it to 0 here.
-      leafNode.prefixLength = 0;
-      leafNode.prefix = EMPTY_BYTES;
+
       Node4 node4 = new Node4(commonPrefix);
       // copy common prefix
       node4.prefixLength = (byte) commonPrefix;
@@ -234,47 +233,48 @@ public class Art {
       // replace the current node with this internal node4
       return node4;
     }
+    BranchNode branchNode = (BranchNode) node;
     // to a inner node case
-    if (node.prefixLength > 0) {
+    if (branchNode.prefixLength > 0) {
       // find the mismatch position
       int mismatchPos =
-          ArraysShim.mismatch(node.prefix, 0, node.prefixLength, key, depth, key.length);
-      if (mismatchPos != node.prefixLength) {
+          ArraysShim.mismatch(branchNode.prefix, 0, branchNode.prefixLength, key, depth, key.length);
+      if (mismatchPos != branchNode.prefixLength) {
         Node4 node4 = new Node4(mismatchPos);
         // copy prefix
         node4.prefixLength = (byte) mismatchPos;
-        System.arraycopy(node.prefix, 0, node4.prefix, 0, mismatchPos);
+        System.arraycopy(branchNode.prefix, 0, node4.prefix, 0, mismatchPos);
         // split the current internal node, spawn a fresh node4 and let the
         // current internal node as its children.
-        Node4.insert(node4, node, node.prefix[mismatchPos]);
-        int nodeOriginalPrefixLength = node.prefixLength;
-        node.prefixLength = (byte) (nodeOriginalPrefixLength - (mismatchPos + (byte) 1));
+        Node4.insert(node4, branchNode, branchNode.prefix[mismatchPos]);
+        int nodeOriginalPrefixLength = branchNode.prefixLength;
+        branchNode.prefixLength = (byte) (nodeOriginalPrefixLength - (mismatchPos + (byte) 1));
         // move the remained common prefix of the initial internal node
-        if (node.prefixLength > 0) {
-          System.arraycopy(node.prefix, mismatchPos + 1, node.prefix, 0, node.prefixLength);
+        if (branchNode.prefixLength > 0) {
+          System.arraycopy(branchNode.prefix, mismatchPos + 1, branchNode.prefix, 0, branchNode.prefixLength);
         } else {
           // TODO:to reduce the 0 prefix memory space,we could mark the prefix as null
-          node.prefix = new byte[0];
+          branchNode.prefix = new byte[0];
         }
         LeafNode leafNode = new LeafNode(key, containerIdx);
         Node4.insert(node4, leafNode, key[mismatchPos + depth]);
         return node4;
       }
-      depth += node.prefixLength;
+      depth += branchNode.prefixLength;
     }
-    int pos = node.getChildPos(key[depth]);
-    if (pos != Node.ILLEGAL_IDX) {
+    int pos = branchNode.getChildPos(key[depth]);
+    if (pos != BranchNode.ILLEGAL_IDX) {
       // insert the key as current internal node's children's child node.
-      Node child = node.getChild(pos);
+      Node child = branchNode.getChild(pos);
       Node freshOne = insert(child, key, depth + 1, containerIdx);
       if (freshOne != child) {
-        node.replaceNode(pos, freshOne);
+        branchNode.replaceNode(pos, freshOne);
       }
-      return node;
+      return branchNode;
     }
     // insert the key as a child leaf node of the current internal node
     LeafNode leafNode = new LeafNode(key, containerIdx);
-    Node freshOne = Node.insertLeaf(node, leafNode, key[depth]);
+    Node freshOne = BranchNode.insertLeaf(branchNode, leafNode, key[depth]);
     return freshOne;
   }
 
@@ -299,12 +299,11 @@ public class Art {
   private LeafNode getExtremeLeaf(boolean reverse) {
     Node parent = getRoot();
     for (int depth = 0; depth < AbstractShuttle.MAX_DEPTH; depth++) {
-      if (parent.nodeType == NodeType.LEAF_NODE) {
-        break;
+      if (parent instanceof BranchNode) {
+        BranchNode branchNode = (BranchNode) parent;
+        int childIndex = reverse ? branchNode.getMaxPos() : branchNode.getMinPos();
+        parent = branchNode.getChild(childIndex);
       }
-
-      int childIndex = reverse ? parent.getMaxPos() : parent.getMinPos();
-      parent = parent.getChild(childIndex);
     }
     return (LeafNode) parent;
   }
@@ -346,16 +345,17 @@ public class Art {
   }
 
   private void serialize(Node node, DataOutput dataOutput) throws IOException {
-    if (node.nodeType != NodeType.LEAF_NODE) {
+    if (node instanceof BranchNode) {
+      BranchNode branchNode = (BranchNode)node;
       // serialize the internal node itself first
-      node.serialize(dataOutput);
+      branchNode.serialize(dataOutput);
       // then all the internal node's children
-      int nexPos = node.getNextLargerPos(Node.ILLEGAL_IDX);
-      while (nexPos != Node.ILLEGAL_IDX) {
+      int nexPos = branchNode.getNextLargerPos(BranchNode.ILLEGAL_IDX);
+      while (nexPos != BranchNode.ILLEGAL_IDX) {
         // serialize all the not null child node
-        Node child = node.getChild(nexPos);
+        Node child = branchNode.getChild(nexPos);
         serialize(child, dataOutput);
-        nexPos = node.getNextLargerPos(nexPos);
+        nexPos = branchNode.getNextLargerPos(nexPos);
       }
     } else {
       // serialize the leaf node
@@ -364,16 +364,17 @@ public class Art {
   }
 
   private void serialize(Node node, ByteBuffer byteBuffer) throws IOException {
-    if (node.nodeType != NodeType.LEAF_NODE) {
+    if (node instanceof BranchNode) {
+      BranchNode branchNode = (BranchNode)node;
       // serialize the internal node itself first
-      node.serialize(byteBuffer);
+      branchNode.serialize(byteBuffer);
       // then all the internal node's children
-      int nexPos = node.getNextLargerPos(Node.ILLEGAL_IDX);
-      while (nexPos != Node.ILLEGAL_IDX) {
+      int nexPos = branchNode.getNextLargerPos(BranchNode.ILLEGAL_IDX);
+      while (nexPos != BranchNode.ILLEGAL_IDX) {
         // serialize all the not null child node
-        Node child = node.getChild(nexPos);
+        Node child = branchNode.getChild(nexPos);
         serialize(child, byteBuffer);
-        nexPos = node.getNextLargerPos(nexPos);
+        nexPos = branchNode.getNextLargerPos(nexPos);
       }
     } else {
       // serialize the leaf node
@@ -386,19 +387,20 @@ public class Art {
     if (oneNode == null) {
       return null;
     }
-    if (oneNode.nodeType == NodeType.LEAF_NODE) {
+    if (oneNode instanceof LeafNode) {
       return oneNode;
     } else {
+      BranchNode branch = (BranchNode) oneNode;
       // internal node
-      int count = oneNode.count;
+      int count = branch.count;
       // all the not null child nodes
       Node[] children = new Node[count];
       for (int i = 0; i < count; i++) {
         Node child = deserialize(dataInput);
         children[i] = child;
       }
-      oneNode.replaceChildren(children);
-      return oneNode;
+      branch.replaceChildren(children);
+      return branch;
     }
   }
 
@@ -407,19 +409,20 @@ public class Art {
     if (oneNode == null) {
       return null;
     }
-    if (oneNode.nodeType == NodeType.LEAF_NODE) {
+    if (oneNode instanceof LeafNode) {
       return oneNode;
     } else {
+      BranchNode branchNode = (BranchNode) oneNode;
       // internal node
-      int count = oneNode.count;
+      int count = branchNode.count;
       // all the not null child nodes
       Node[] children = new Node[count];
       for (int i = 0; i < count; i++) {
         Node child = deserialize(byteBuffer);
         children[i] = child;
       }
-      oneNode.replaceChildren(children);
-      return oneNode;
+      branchNode.replaceChildren(children);
+      return branchNode;
     }
   }
 
@@ -432,17 +435,18 @@ public class Art {
   }
 
   private long serializeSizeInBytes(Node node) {
-    if (node.nodeType != NodeType.LEAF_NODE) {
+    if (node instanceof BranchNode) {
+      BranchNode branchNode = (BranchNode) node;
       // serialize the internal node itself first
-      int currentNodeSize = node.serializeSizeInBytes();
+      int currentNodeSize = branchNode.serializeSizeInBytes();
       // then all the internal node's children
       long childrenTotalSize = 0L;
-      int nexPos = node.getNextLargerPos(Node.ILLEGAL_IDX);
-      while (nexPos != Node.ILLEGAL_IDX) {
+      int nexPos = branchNode.getNextLargerPos(BranchNode.ILLEGAL_IDX);
+      while (nexPos != BranchNode.ILLEGAL_IDX) {
         // serialize all the not null child node
-        Node child = node.getChild(nexPos);
+        Node child = branchNode.getChild(nexPos);
         long childSize = serializeSizeInBytes(child);
-        nexPos = node.getNextLargerPos(nexPos);
+        nexPos = branchNode.getNextLargerPos(nexPos);
         childrenTotalSize += childSize;
       }
       return currentNodeSize + childrenTotalSize;

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/BackwardShuttle.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/BackwardShuttle.java
@@ -15,12 +15,12 @@ public class BackwardShuttle extends AbstractShuttle {
   }
 
   @Override
-  protected int visitedNodeNextPosition(Node node, int pos) {
+  protected int visitedNodeNextPosition(BranchNode node, int pos) {
     return node.getNextSmallerPos(pos);
   }
 
   @Override
-  protected int boundaryNodePosition(Node node, boolean inRunDirection) {
+  protected int boundaryNodePosition(BranchNode node, boolean inRunDirection) {
     if (inRunDirection) {
       return node.getMinPos();
     } else {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/BranchNode.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/BranchNode.java
@@ -1,0 +1,238 @@
+package org.roaringbitmap.art;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public abstract class BranchNode extends Node {
+
+    // node type
+    protected NodeType nodeType;
+    // length of compressed path(prefix)
+    protected byte prefixLength;
+    // the compressed path path (prefix)
+    protected byte[] prefix;
+    // number of non-null children, the largest value will not beyond 255
+    // to benefit calculation,we keep the value as a short type
+    protected short count;
+    public static final int ILLEGAL_IDX = -1;
+
+    /**
+     * constructor
+     *
+     * @param nodeType             the node type
+     * @param compressedPrefixSize the prefix byte array size,less than or equal to 6
+     */
+    public BranchNode(NodeType nodeType, int compressedPrefixSize) {
+        super();
+        this.nodeType = nodeType;
+        this.prefixLength = (byte) compressedPrefixSize;
+        prefix = new byte[prefixLength];
+        count = 0;
+    }
+
+    /**
+     * search the position of the input byte key in the node's key byte array part
+     *
+     * @param key the input key byte array
+     * @param fromIndex inclusive
+     * @param toIndex exclusive
+     * @param k the target key byte value
+     * @return the array offset of the target input key 'k' or -1 to not found
+     */
+    public static int binarySearch(byte[] key, int fromIndex, int toIndex, byte k) {
+        int inputUnsignedByte = Byte.toUnsignedInt(k);
+        int low = fromIndex;
+        int high = toIndex - 1;
+
+        while (low <= high) {
+            int mid = (low + high) >>> 1;
+            int midVal = Byte.toUnsignedInt(key[mid]);
+
+            if (midVal < inputUnsignedByte) {
+                low = mid + 1;
+            } else if (midVal > inputUnsignedByte) {
+                high = mid - 1;
+            } else {
+                return mid; // key found
+            }
+        }
+        // key not found.
+        return ILLEGAL_IDX;
+    }
+
+    static SearchResult binarySearchWithResult(byte[] key, int fromIndex, int toIndex, byte k) {
+        int inputUnsignedByte = Byte.toUnsignedInt(k);
+        int low = fromIndex;
+        int high = toIndex - 1;
+
+        while (low != high) {
+            int mid = (low + high + 1) >>> 1; // ceil
+            int midVal = Byte.toUnsignedInt(key[mid]);
+
+            if (midVal > inputUnsignedByte) {
+                high = mid - 1;
+            } else {
+                low = mid;
+            }
+        }
+        int val = Byte.toUnsignedInt(key[low]);
+        if (val == inputUnsignedByte) {
+            return SearchResult.found(low);
+        } else if (val < inputUnsignedByte) {
+            int highIndex = low + 1;
+            return SearchResult.notFound(low, highIndex < toIndex ? highIndex : BranchNode.ILLEGAL_IDX);
+        } else {
+            return SearchResult.notFound(low - 1, low); // low - 1 == ILLEGAL_IDX if low == 0
+        }
+    }
+
+    /**
+     * insert the LeafNode as a child of the current internal node
+     *
+     * @param current   current internal node
+     * @param childNode the leaf node
+     * @param key       the key byte reference to the child leaf node
+     * @return an adaptive changed node of the input 'current' node
+     */
+    public static BranchNode insertLeaf(BranchNode current, Node childNode, byte key) {
+        switch (current.nodeType) {
+            case NODE4:
+                return Node4.insert(current, childNode, key);
+            case NODE16:
+                return Node16.insert(current, childNode, key);
+            case NODE48:
+                return Node48.insert(current, childNode, key);
+            case NODE256:
+                return Node256.insert(current, childNode, key);
+            default:
+                throw new IllegalArgumentException("Not supported node type!");
+        }
+    }
+
+    /**
+     * copy the prefix between two nodes
+     *
+     * @param src the source node
+     * @param dst the destination node
+     */
+    public static void copyPrefix(BranchNode src, BranchNode dst) {
+        dst.prefixLength = src.prefixLength;
+        System.arraycopy(src.prefix, 0, dst.prefix, 0, src.prefixLength);
+    }
+
+    /**
+     * replace the node's children according to the given children parameter while doing the
+     * deserialization phase.
+     *
+     * @param children all the not null children nodes in key byte ascending order,no null element
+     */
+    abstract void replaceChildren(Node[] children);
+
+    /**
+     * get the position of a child corresponding to the input key 'k'
+     *
+     * @param k a key value of the byte range
+     * @return the child position corresponding to the key 'k'
+     */
+    public abstract int getChildPos(byte k);
+
+    /**
+     * get the position of a child corresponding to the input key 'k' if present
+     * <p>
+     * if 'k' is not in the child, return the positions of the neighbouring nodes instead
+     *
+     * @param key a key value of the byte range
+     * @return a result indicating whether or not the key was found and the positions of the
+     * child corresponding to it or its neighbours
+     */
+    public abstract SearchResult getNearestChildPos(byte key);
+
+    /**
+     * get the corresponding key byte of the requested position
+     *
+     * @param pos the position
+     * @return the corresponding key byte
+     */
+    public abstract byte getChildKey(int pos);
+
+    /**
+     * get the child at the specified position in the node, the 'pos' range from 0 to count
+     *
+     * @param pos the position
+     * @return a Node corresponding to the input position
+     */
+    public abstract Node getChild(int pos);
+
+    /**
+     * replace the position child to the fresh one
+     *
+     * @param pos      the position
+     * @param freshOne the fresh node to replace the old one
+     */
+    public abstract void replaceNode(int pos, Node freshOne);
+
+    /**
+     * get the position of the min element in current node.
+     *
+     * @return the minimum key's position
+     */
+    public abstract int getMinPos();
+
+    /**
+     * get the next position in the node
+     *
+     * @param pos current position,-1 to start from the min one
+     * @return the next larger byte key's position which is close to 'pos' position,-1 for end
+     */
+    public abstract int getNextLargerPos(int pos);
+
+    /**
+     * get the max child's position
+     *
+     * @return the max byte key's position
+     */
+    public abstract int getMaxPos();
+
+    /**
+     * get the next smaller element's position
+     *
+     * @param pos the position,-1 to start from the largest one
+     * @return the next smaller key's position which is close to input 'pos' position,-1 for end
+     */
+    public abstract int getNextSmallerPos(int pos);
+
+    /**
+     * remove the specified position child
+     *
+     * @param pos the position to remove
+     * @return an adaptive changed fresh node of the current node
+     */
+    public abstract Node remove(int pos);
+
+    protected void serializeHeader(DataOutput dataOutput) throws IOException {
+        // first byte: node type
+        dataOutput.writeByte((byte) this.nodeType.ordinal());
+        // non null object count
+        dataOutput.writeShort(Short.reverseBytes(this.count));
+        dataOutput.writeByte(this.prefixLength);
+        if (prefixLength > 0) {
+            dataOutput.write(this.prefix, 0, this.prefixLength);
+        }
+    }
+
+    protected void serializeHeader(ByteBuffer byteBuffer) throws IOException {
+        byteBuffer.put((byte) this.nodeType.ordinal());
+        byteBuffer.putShort(this.count);
+        byteBuffer.put(this.prefixLength);
+        if (prefixLength > 0) {
+            byteBuffer.put(this.prefix, 0, prefixLength);
+        }
+    }
+
+    protected int serializeHeaderSizeInBytes() {
+        return super.serializeHeaderSizeInBytes() + prefixLength;
+    }
+
+
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/ForwardShuttle.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/ForwardShuttle.java
@@ -15,12 +15,12 @@ public class ForwardShuttle extends AbstractShuttle {
   }
 
   @Override
-  protected int visitedNodeNextPosition(Node node, int pos) {
+  protected int visitedNodeNextPosition(BranchNode node, int pos) {
     return node.getNextLargerPos(pos);
   }
 
   @Override
-  protected int boundaryNodePosition(Node node, boolean inRunDirection) {
+  protected int boundaryNodePosition(BranchNode node, boolean inRunDirection) {
     if (inRunDirection) {
       return node.getMaxPos();
     } else {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/LeafNode.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/LeafNode.java
@@ -22,7 +22,7 @@ public class LeafNode extends Node {
    * @param containerIdx the corresponding container index
    */
   public LeafNode(byte[] key, long containerIdx) {
-    super(NodeType.LEAF_NODE, 0);
+    super();
     byte[] bytes = new byte[8];
     System.arraycopy(key, 0, bytes, 0, LEAF_NODE_KEY_LENGTH_IN_BYTES);
     this.key = LongUtils.fromBDBytes(bytes);
@@ -35,7 +35,7 @@ public class LeafNode extends Node {
    * @param containerIdx the corresponding container index
    */
   public LeafNode(long key, long containerIdx) {
-    super(NodeType.LEAF_NODE, 0);
+    super();
     this.key = key;
     this.containerIdx = containerIdx;
   }
@@ -75,61 +75,6 @@ public class LeafNode extends Node {
     return LEAF_NODE_KEY_LENGTH_IN_BYTES + 8;
   }
 
-  @Override
-  public int getChildPos(byte k) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public SearchResult getNearestChildPos(byte key) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public byte getChildKey(int pos) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public Node getChild(int pos) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void replaceNode(int pos, Node freshOne) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public int getMinPos() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public int getNextLargerPos(int pos) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public int getMaxPos() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public int getNextSmallerPos(int pos) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public Node remove(int pos) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void replaceChildren(Node[] children) {
-    throw new UnsupportedOperationException();
-  }
-
   public long getContainerIdx() {
     return containerIdx;
   }
@@ -141,4 +86,19 @@ public class LeafNode extends Node {
   public long getKey() {
     return key >>> 16;
   }
+
+  protected void serializeHeader(DataOutput dataOutput) throws IOException {
+    // first byte: node type
+    dataOutput.writeByte((byte) NodeType.LEAF_NODE.ordinal());
+    // non null object count
+    dataOutput.writeShort(0);
+    dataOutput.writeByte(0);
+  }
+
+  protected void serializeHeader(ByteBuffer byteBuffer) throws IOException {
+    byteBuffer.put((byte) NodeType.LEAF_NODE.ordinal());
+    byteBuffer.putShort((short)0);
+    byteBuffer.put((byte)0);
+  }
+
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node.java
@@ -7,28 +7,7 @@ import java.nio.ByteBuffer;
 
 public abstract class Node {
 
-  // node type
-  protected NodeType nodeType;
-  // length of compressed path(prefix)
-  protected byte prefixLength;
-  // the compressed path path (prefix)
-  protected byte[] prefix;
-  // number of non-null children, the largest value will not beyond 255
-  // to benefit calculation,we keep the value as a short type
-  protected short count;
-  public static final int ILLEGAL_IDX = -1;
-
-  /**
-   * constructor
-   *
-   * @param nodeType the node type
-   * @param compressedPrefixSize the prefix byte array size,less than or equal to 6
-   */
-  public Node(NodeType nodeType, int compressedPrefixSize) {
-    this.nodeType = nodeType;
-    this.prefixLength = (byte) compressedPrefixSize;
-    prefix = new byte[prefixLength];
-    count = 0;
+  public Node() {
   }
 
   /**
@@ -52,79 +31,6 @@ public abstract class Node {
     }
     return key;
   }
-
-  /**
-   * get the position of a child corresponding to the input key 'k'
-   * @param k a key value of the byte range
-   * @return the child position corresponding to the key 'k'
-   */
-  public abstract int getChildPos(byte k);
-
-  /**
-   * get the position of a child corresponding to the input key 'k' if present
-   *
-   * if 'k' is not in the child, return the positions of the neighbouring nodes instead
-   *
-   * @param key a key value of the byte range
-   * @return a result indicating whether or not the key was found and the positions of the
-   *     child corresponding to it or its neighbours
-   */
-  public abstract SearchResult getNearestChildPos(byte key);
-
-  /**
-   * get the corresponding key byte of the requested position
-   * @param pos the position
-   * @return the corresponding key byte
-   */
-  public abstract byte getChildKey(int pos);
-
-  /**
-   * get the child at the specified position in the node, the 'pos' range from 0 to count
-   * @param pos the position
-   * @return a Node corresponding to the input position
-   */
-  public abstract Node getChild(int pos);
-
-  /**
-   * replace the position child to the fresh one
-   * @param pos the position
-   * @param freshOne the fresh node to replace the old one
-   */
-  public abstract void replaceNode(int pos, Node freshOne);
-
-  /**
-   * get the position of the min element in current node.
-   * @return the minimum key's position
-   */
-  public abstract int getMinPos();
-
-  /**
-   * get the next position in the node
-   *
-   * @param pos current position,-1 to start from the min one
-   * @return the next larger byte key's position which is close to 'pos' position,-1 for end
-   */
-  public abstract int getNextLargerPos(int pos);
-
-  /**
-   * get the max child's position
-   * @return the max byte key's position
-   */
-  public abstract int getMaxPos();
-
-  /**
-   * get the next smaller element's position
-   * @param pos the position,-1 to start from the largest one
-   * @return the next smaller key's position which is close to input 'pos' position,-1 for end
-   */
-  public abstract int getNextSmallerPos(int pos);
-
-  /**
-   * remove the specified position child
-   * @param pos the position to remove
-   * @return an adaptive changed fresh node of the current node
-   */
-  public abstract Node remove(int pos);
 
   /**
    * serialize
@@ -192,13 +98,6 @@ public abstract class Node {
   }
 
   /**
-   * replace the node's children according to the given children parameter while doing the
-   * deserialization phase.
-   * @param children all the not null children nodes in key byte ascending order,no null element
-   */
-  abstract void replaceChildren(Node[] children);
-
-  /**
    * serialize the node's body content
    * @param dataOutput the DataOutput
    * @throws IOException exception indicates serialization errors
@@ -233,121 +132,12 @@ public abstract class Node {
    */
   public abstract int serializeNodeBodySizeInBytes();
 
-  /**
-   * insert the LeafNode as a child of the current internal node
-   *
-   * @param current current internal node
-   * @param childNode the leaf node
-   * @param key the key byte reference to the child leaf node
-   * @return an adaptive changed node of the input 'current' node
-   */
-  public static Node insertLeaf(Node current, LeafNode childNode, byte key) {
-    switch (current.nodeType) {
-      case NODE4:
-        return Node4.insert(current, childNode, key);
-      case NODE16:
-        return Node16.insert(current, childNode, key);
-      case NODE48:
-        return Node48.insert(current, childNode, key);
-      case NODE256:
-        return Node256.insert(current, childNode, key);
-      default:
-        throw new IllegalArgumentException("Not supported node type!");
-    }
-  }
+  protected abstract void serializeHeader(DataOutput dataOutput) throws IOException ;
 
-  /**
-   * copy the prefix between two nodes
-   * @param src the source node
-   * @param dst the destination node
-   */
-  public static void copyPrefix(Node src, Node dst) {
-    dst.prefixLength = src.prefixLength;
-    System.arraycopy(src.prefix, 0, dst.prefix, 0, src.prefixLength);
-  }
+  protected abstract void serializeHeader(ByteBuffer byteBuffer) throws IOException ;
 
-  /**
-   * search the position of the input byte key in the node's key byte array part
-   *
-   * @param key the input key byte array
-   * @param fromIndex inclusive
-   * @param toIndex exclusive
-   * @param k the target key byte value
-   * @return the array offset of the target input key 'k' or -1 to not found
-   */
-  public static int binarySearch(byte[] key, int fromIndex, int toIndex, byte k) {
-    int inputUnsignedByte = Byte.toUnsignedInt(k);
-    int low = fromIndex;
-    int high = toIndex - 1;
-
-    while (low <= high) {
-      int mid = (low + high) >>> 1;
-      int midVal = Byte.toUnsignedInt(key[mid]);
-
-      if (midVal < inputUnsignedByte) {
-        low = mid + 1;
-      } else if (midVal > inputUnsignedByte) {
-        high = mid - 1;
-      } else {
-        return mid; // key found
-      }
-    }
-    // key not found.
-    return ILLEGAL_IDX;
-  }
-
-  static SearchResult binarySearchWithResult(byte[] key, int fromIndex, int toIndex, byte k) {
-    int inputUnsignedByte = Byte.toUnsignedInt(k);
-    int low = fromIndex;
-    int high = toIndex - 1;
-
-    while (low != high) {
-      int mid = (low + high + 1) >>> 1; // ceil
-      int midVal = Byte.toUnsignedInt(key[mid]);
-
-      if (midVal > inputUnsignedByte) {
-        high = mid - 1;
-      } else {
-        low = mid;
-      }
-    }
-    int val = Byte.toUnsignedInt(key[low]);
-    if (val == inputUnsignedByte) {
-      return SearchResult.found(low);
-    } else if (val < inputUnsignedByte) {
-      int highIndex = low + 1;
-      return SearchResult.notFound(low, highIndex < toIndex ? highIndex : Node.ILLEGAL_IDX);
-    } else {
-      return SearchResult.notFound(low - 1, low); // low - 1 == ILLEGAL_IDX if low == 0
-    }
-  }
-
-  private void serializeHeader(DataOutput dataOutput) throws IOException {
-    // first byte: node type
-    dataOutput.writeByte((byte) this.nodeType.ordinal());
-    // non null object count
-    dataOutput.writeShort(Short.reverseBytes(this.count));
-    dataOutput.writeByte(this.prefixLength);
-    if (prefixLength > 0) {
-      dataOutput.write(this.prefix, 0, this.prefixLength);
-    }
-  }
-
-  private void serializeHeader(ByteBuffer byteBuffer) throws IOException {
-    byteBuffer.put((byte) this.nodeType.ordinal());
-    byteBuffer.putShort(this.count);
-    byteBuffer.put(this.prefixLength);
-    if (prefixLength > 0) {
-      byteBuffer.put(this.prefix, 0, prefixLength);
-    }
-  }
-
-  private int serializeHeaderSizeInBytes() {
-    int size = 1 + 2 + 1;
-    if (prefixLength > 0) {
-      size = size + prefixLength;
-    }
-    return size;
+  protected int serializeHeaderSizeInBytes() {
+    return 1 + 2 + 1;
   }
 
   private static Node deserializeHeader(DataInput dataInput) throws IOException {
@@ -388,11 +178,7 @@ public abstract class Node {
       return node256;
     }
     if (nodeTypeOrdinal == NodeType.LEAF_NODE.ordinal()) {
-      LeafNode leafNode = new LeafNode(0L, 0);
-      leafNode.prefixLength = prefixLength;
-      leafNode.prefix = prefix;
-      leafNode.count = count;
-      return leafNode;
+      return new LeafNode(0L, 0);
     }
     return null;
   }
@@ -435,11 +221,7 @@ public abstract class Node {
       return node256;
     }
     if (nodeTypeOrdinal == NodeType.LEAF_NODE.ordinal()) {
-      LeafNode leafNode = new LeafNode(0L, 0);
-      leafNode.prefixLength = prefixLength;
-      leafNode.prefix = prefix;
-      leafNode.count = count;
-      return leafNode;
+      return new LeafNode(0L, 0);
     }
     return null;
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node16.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node16.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-public class Node16 extends Node {
+public class Node16 extends BranchNode {
 
   long firstV = 0L;
   long secondV = 0L;
@@ -22,14 +22,14 @@ public class Node16 extends Node {
   public int getChildPos(byte k) {
     byte[] firstBytes = LongUtils.toBDBytes(firstV);
     if (count <= 8) {
-      return Node.binarySearch(firstBytes, 0, count, k);
+      return binarySearch(firstBytes, 0, count, k);
     } else {
-      int pos = Node.binarySearch(firstBytes, 0, 8, k);
+      int pos = binarySearch(firstBytes, 0, 8, k);
       if (pos != ILLEGAL_IDX) {
         return pos;
       } else {
         byte[] secondBytes = LongUtils.toBDBytes(secondV);
-        pos = Node.binarySearch(secondBytes, 0, (count - 8), k);
+        pos = binarySearch(secondBytes, 0, (count - 8), k);
         if (pos != ILLEGAL_IDX) {
           return 8 + pos;
         } else {
@@ -43,16 +43,16 @@ public class Node16 extends Node {
   public SearchResult getNearestChildPos(byte k) {
     byte[] firstBytes = LongUtils.toBDBytes(firstV);
     if (count <= 8) {
-      return Node.binarySearchWithResult(firstBytes, 0, count, k);
+      return binarySearchWithResult(firstBytes, 0, count, k);
     } else {
-      SearchResult firstResult = Node.binarySearchWithResult(firstBytes, 0, 8, k);
+      SearchResult firstResult = binarySearchWithResult(firstBytes, 0, 8, k);
       // given the values are "in order" if we found a match or a value larger than
       // the target we are done.
       if (firstResult.outcome == SearchResult.Outcome.FOUND || firstResult.hasNextLargerPos()) {
         return firstResult;
       } else {
         byte[] secondBytes = LongUtils.toBDBytes(secondV);
-        SearchResult secondResult = Node.binarySearchWithResult(secondBytes, 0, (count - 8), k);
+        SearchResult secondResult = binarySearchWithResult(secondBytes, 0, (count - 8), k);
 
         switch (secondResult.outcome) {
           case FOUND:
@@ -144,7 +144,7 @@ public class Node16 extends Node {
    * @param key the key byte
    * @return the adaptive changed node of the parent node16
    */
-  public static Node insert(Node node, Node child, byte key) {
+  public static BranchNode insert(BranchNode node, Node child, byte key) {
     Node16 currentNode16 = (Node16) node;
     if (currentNode16.count < 8) {
       // first
@@ -185,7 +185,7 @@ public class Node16 extends Node {
       }
       copyPrefix(currentNode16, node48);
       node48.count = currentNode16.count;
-      Node freshOne = Node48.insert(node48, child, key);
+      BranchNode freshOne = Node48.insert(node48, child, key);
       return freshOne;
     }
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node256.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node256.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 
-public class Node256 extends Node {
+public class Node256 extends BranchNode {
 
   Node[] children = new Node[256];
   // a helper utility field

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node48.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node48.java
@@ -8,7 +8,7 @@ import java.nio.ByteOrder;
 import java.nio.LongBuffer;
 import java.util.Arrays;
 
-public class Node48 extends Node {
+public class Node48 extends BranchNode {
 
   // the actual byte value of childIndex content won't be beyond 48
   // 256 bytes packed into longs
@@ -173,7 +173,7 @@ public class Node48 extends Node {
    * @param key the key byte
    * @return the node48 or an adaptive generated node256
    */
-  public static Node insert(Node currentNode, Node child, byte key) {
+  public static BranchNode insert(BranchNode currentNode, Node child, byte key) {
     Node48 node48 = (Node48) currentNode;
     if (node48.count < 48) {
       // insert leaf node into current node
@@ -200,7 +200,7 @@ public class Node48 extends Node {
       }
       node256.count = node48.count;
       copyPrefix(node48, node256);
-      Node freshOne = Node256.insert(node256, child, key);
+      BranchNode freshOne = Node256.insert(node256, child, key);
       return freshOne;
     }
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/SearchResult.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/SearchResult.java
@@ -24,7 +24,7 @@ class SearchResult {
   }
 
   static SearchResult found(int keyPos) {
-    return new SearchResult(Outcome.FOUND, keyPos, Node.ILLEGAL_IDX);
+    return new SearchResult(Outcome.FOUND, keyPos, BranchNode.ILLEGAL_IDX);
   }
 
   static SearchResult notFound(int lowerPos, int higherPos) {
@@ -34,7 +34,7 @@ class SearchResult {
   boolean hasKeyPos() {
     if (outcome == Outcome.FOUND) {
       // this would be an illegal state
-      assert lessOrEqualPos != Node.ILLEGAL_IDX;
+      assert lessOrEqualPos != BranchNode.ILLEGAL_IDX;
       return true;
     }
     return false;
@@ -48,7 +48,7 @@ class SearchResult {
   }
 
   boolean hasNextSmallerPos() {
-    return outcome == Outcome.NOT_FOUND && lessOrEqualPos != Node.ILLEGAL_IDX;
+    return outcome == Outcome.NOT_FOUND && lessOrEqualPos != BranchNode.ILLEGAL_IDX;
   }
 
   int getNextSmallerPos() {
@@ -59,7 +59,7 @@ class SearchResult {
   }
 
   boolean hasNextLargerPos() {
-    return outcome == Outcome.NOT_FOUND && greaterPos != Node.ILLEGAL_IDX;
+    return outcome == Outcome.NOT_FOUND && greaterPos != BranchNode.ILLEGAL_IDX;
   }
 
   int getNextLargerPos() {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/longlong/HighLowContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/longlong/HighLowContainer.java
@@ -4,12 +4,12 @@ import static java.nio.ByteOrder.LITTLE_ENDIAN;
 
 import org.roaringbitmap.Container;
 import org.roaringbitmap.art.Art;
+import org.roaringbitmap.art.BranchNode;
 import org.roaringbitmap.art.ContainerIterator;
 import org.roaringbitmap.art.Containers;
 import org.roaringbitmap.art.KeyIterator;
 import org.roaringbitmap.art.LeafNode;
 import org.roaringbitmap.art.LeafNodeIterator;
-import org.roaringbitmap.art.Node;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -64,7 +64,7 @@ public class HighLowContainer {
    */
   public void remove(byte[] highPart) {
     long containerIdx = art.remove(highPart);
-    if (containerIdx != Node.ILLEGAL_IDX) {
+    if (containerIdx != BranchNode.ILLEGAL_IDX) {
       containers.remove(containerIdx);
     }
   }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/art/Node16Test.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/art/Node16Test.java
@@ -22,7 +22,7 @@ public class Node16Test {
     Assertions.assertTrue(degenerativeNode instanceof Node4);
     // recover to node16 by re-insert two nodes
     Node4 degenerativeNode4 = (Node4) degenerativeNode;
-    Node node = Node4.insert(degenerativeNode4, leafNode4, (byte) 4);
+    BranchNode node = Node4.insert(degenerativeNode4, leafNode4, (byte) 4);
     LeafNode leafNode3 = new LeafNode(3, 3);
     node16 = (Node16) Node4.insert(node, leafNode3, (byte) 3);
 
@@ -97,12 +97,12 @@ public class Node16Test {
       Assertions.assertEquals(i - 1, leafNode.getContainerIdx());
     }
     // there is no illegal_idx valid prior to the first
-    Assertions.assertEquals(Node.ILLEGAL_IDX, node16.getNextSmallerPos(0));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, node16.getNextSmallerPos(0));
   }
 
   @Test
   public void testDenseNonZeroBasedKeysSearch() {
-    Node nodes = new Node16(0);
+    BranchNode nodes = new Node16(0);
     final int insertCount = 15;
     final int lastValue = insertCount - 1;
     final int keyOffset = 0x20;
@@ -132,18 +132,18 @@ public class Node16Test {
     SearchResult sr = nodes.getNearestChildPos((byte) (keyOffset - 1));
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextSmallerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextSmallerPos());
 
     // search after the last value aka "insertCount", and surprise, nothing will be found
     sr = nodes.getNearestChildPos((byte) (keyOffset + insertCount));
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextLargerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextLargerPos());
   }
 
   @Test
   public void testSparseNonZeroBasedKeysSearch() {
-    Node nodes = new Node16(0);
+    BranchNode nodes = new Node16(0);
     final int insertCount = 15;
     final int lastValue = insertCount - 1;
 
@@ -180,7 +180,7 @@ public class Node16Test {
 
         // the value smaller than the first should be INVALID, and the rest should be the prior key
         if (i == 0) {
-          Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextSmallerPos());
+          Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextSmallerPos());
         } else {
           int expect = Byte.toUnsignedInt(key) - step;
           int result = Byte.toUnsignedInt(nodes.getChildKey(sr.getNextSmallerPos()));
@@ -205,7 +205,7 @@ public class Node16Test {
 
         // the value larger than the last should be INVALID and the rest should be the next key
         if (i == lastValue) {
-          Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextLargerPos());
+          Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextLargerPos());
         } else {
           int expect = Byte.toUnsignedInt(key) + step;
           int result = Byte.toUnsignedInt(nodes.getChildKey(sr.getNextLargerPos()));
@@ -218,18 +218,18 @@ public class Node16Test {
     SearchResult sr = nodes.getNearestChildPos((byte) (keyOffset - 1));
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextSmallerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextSmallerPos());
 
     // search after the last value aka "insertCount", and surprise, nothing will be found
     sr = nodes.getNearestChildPos((byte) (keyOffset + (insertCount * step)));
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextLargerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextLargerPos());
   }
 
   @Test
   public void testWithOffsetBeforeBytes() {
-    Node nodes = new Node16(0);
+    BranchNode nodes = new Node16(0);
     LeafNode leafNode = new LeafNode(0, 0);
     int insertCount = 16;
     int offset = 40;
@@ -242,10 +242,10 @@ public class Node16Test {
     Assertions.assertTrue(nodes instanceof Node16);
 
     // The position of a value before the "first" value dose not exist thus ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextSmallerPos(nodes.getMinPos()));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextSmallerPos(nodes.getMinPos()));
 
     // The position of a value after the "last" value dose not exist thus ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextLargerPos(nodes.getMaxPos()));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextLargerPos(nodes.getMaxPos()));
 
     // so for each value in the inserted range the next of the prior should be the same as
     // the location of found current.
@@ -268,7 +268,7 @@ public class Node16Test {
 
   @Test
   public void testWithOffsetAndGapsBytes() {
-    Node nodes = new Node16(0);
+    BranchNode nodes = new Node16(0);
     LeafNode leafNode = new LeafNode(0, 0);
     int insertCount = 16;
     int step = 2;
@@ -282,10 +282,10 @@ public class Node16Test {
     Assertions.assertTrue(nodes instanceof Node16);
 
     // The position of a value before the "first" value dose not exist thus ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextSmallerPos(nodes.getMinPos()));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextSmallerPos(nodes.getMinPos()));
 
     // The position of a value after the "last" value dose not exist thus ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextLargerPos(nodes.getMaxPos()));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextLargerPos(nodes.getMaxPos()));
 
     // so for each value in the inserted range the next of the prior should be the same as
     // the location of found current.

--- a/roaringbitmap/src/test/java/org/roaringbitmap/art/Node256Test.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/art/Node256Test.java
@@ -56,7 +56,7 @@ public class Node256Test {
 
   @Test
   public void testWithOffsetBeforeBytes() {
-    Node nodes = new Node256(0);
+    Node256 nodes = new Node256(0);
     LeafNode leafNode = new LeafNode(0, 0);
     int insertCount = 75;
     int offset = 40;
@@ -74,10 +74,10 @@ public class Node256Test {
     Assertions.assertEquals(offset, nodes.getMinPos());
 
     // The position of a value before the "first" value dose not exist thus ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextSmallerPos(nodes.getMinPos()));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextSmallerPos(nodes.getMinPos()));
 
     // The position of a value after the "last" value dose not exist thus ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextLargerPos(nodes.getMaxPos()));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextLargerPos(nodes.getMaxPos()));
 
     // so for each value in the inserted range the next of the prior should be the same as
     // the location of found current.
@@ -100,7 +100,7 @@ public class Node256Test {
 
   @Test
   public void testWithOffsetAndGapsBytes() {
-    Node nodes = new Node256(0);
+    Node256 nodes = new Node256(0);
     LeafNode leafNode = new LeafNode(0, 0);
     int insertCount = 75;
     int step = 2;
@@ -119,10 +119,10 @@ public class Node256Test {
     Assertions.assertEquals(offset, nodes.getMinPos());
 
     // The position of a value before the "first" value dose not exist thus ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextSmallerPos(nodes.getMinPos()));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextSmallerPos(nodes.getMinPos()));
 
     // The position of a value after the "last" value dose not exist thus ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextLargerPos(nodes.getMaxPos()));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextLargerPos(nodes.getMaxPos()));
 
     // so for each value in the inserted range the next of the prior should be the same as
     // the location of found current.
@@ -147,7 +147,7 @@ public class Node256Test {
 
   @Test
   public void testDenseNonZeroBasedKeysSearch() {
-    Node nodes = new Node256(0);
+    Node256 nodes = new Node256(0);
     final int insertCount = 75;
     final int keyOffset = 0x20;
 
@@ -174,18 +174,18 @@ public class Node256Test {
     SearchResult sr = nodes.getNearestChildPos((byte) (keyOffset - 1));
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextSmallerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextSmallerPos());
 
     // search after the last value aka "insertCount", and surprise, nothing will be found
     sr = nodes.getNearestChildPos((byte) (keyOffset + insertCount));
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextLargerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextLargerPos());
   }
 
   @Test
   public void testSparseNonZeroBasedKeysSearch() {
-    Node nodes = new Node256(0);
+    Node256 nodes = new Node256(0);
     final int insertCount = 75;
     final int lastValue = insertCount - 1;
     final int step = 3;
@@ -219,7 +219,7 @@ public class Node256Test {
 
         // the value smaller than the first should be INVALID, and the rest should be the prior key
         if (i == 0) {
-          Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextSmallerPos());
+          Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextSmallerPos());
         } else {
           int expected = Byte.toUnsignedInt(key) - step;
           int result = Byte.toUnsignedInt(nodes.getChildKey(sr.getNextSmallerPos()));
@@ -244,7 +244,7 @@ public class Node256Test {
 
         // the value larger than the last should be INVALID and the rest should be the next key
         if (i == lastValue) {
-          Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextLargerPos());
+          Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextLargerPos());
         } else {
           int expected = Byte.toUnsignedInt(key) + step;
           int result = Byte.toUnsignedInt(nodes.getChildKey(sr.getNextLargerPos()));
@@ -257,12 +257,12 @@ public class Node256Test {
     SearchResult sr = nodes.getNearestChildPos((byte) (keyOffset - 1));
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextSmallerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextSmallerPos());
 
     // search after the last value aka "insertCount", and surprise, nothing will be found
     sr = nodes.getNearestChildPos((byte) (keyOffset + (insertCount * step)));
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextLargerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextLargerPos());
   }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/art/Node48Test.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/art/Node48Test.java
@@ -65,7 +65,7 @@ public class Node48Test {
 
   @Test
   public void testWithOffsetBeforeBytes() {
-    Node nodes = new Node48(0);
+    BranchNode nodes = new Node48(0);
     LeafNode leafNode = new LeafNode(0, 0);
     int insertCount = 48;
     int offset = 40;
@@ -83,10 +83,10 @@ public class Node48Test {
     Assertions.assertEquals(offset, nodes.getMinPos());
 
     // The position of a value before the "first" value dose not exist thus ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextSmallerPos(nodes.getMinPos()));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextSmallerPos(nodes.getMinPos()));
 
     // The position of a value after the "last" value dose not exist thus ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextLargerPos(nodes.getMaxPos()));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextLargerPos(nodes.getMaxPos()));
 
     // so for each value in the inserted range the next of the prior should be the same as
     // the location of found current.
@@ -109,7 +109,7 @@ public class Node48Test {
 
   @Test
   public void testWithOffsetAndGapsBytes() {
-    Node nodes = new Node48(0);
+    BranchNode nodes = new Node48(0);
     LeafNode leafNode = new LeafNode(0, 0);
     int insertCount = 48;
     int step = 2;
@@ -128,10 +128,10 @@ public class Node48Test {
     Assertions.assertEquals(offset, nodes.getMinPos());
 
     // The position of a value before the "first" value dose not exist thus ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextSmallerPos(nodes.getMinPos()));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextSmallerPos(nodes.getMinPos()));
 
     // The position of a value after the "last" value dose not exist thus ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextLargerPos(nodes.getMaxPos()));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextLargerPos(nodes.getMaxPos()));
 
     // so for each value in the inserted range the next of the prior should be the same as
     // the location of found current.
@@ -189,7 +189,7 @@ public class Node48Test {
     int pos = node16.getChildPos((byte) 0);
     Assertions.assertEquals(0, pos);
     pos = node16.getChildPos((byte) 12);
-    Assertions.assertEquals(Node.ILLEGAL_IDX, pos);
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, pos);
     pos = node16.getChildPos((byte) 11);
     Assertions.assertEquals(11, pos);
   }
@@ -234,7 +234,7 @@ public class Node48Test {
 
   @Test
   public void testDenseNonZeroBasedKeysSearch() {
-    Node nodes = new Node48(0);
+    BranchNode nodes = new Node48(0);
     final int insertCount = 47;
     final int keyOffset = 0x20;
 
@@ -261,18 +261,18 @@ public class Node48Test {
     SearchResult sr = nodes.getNearestChildPos((byte) (keyOffset - 1));
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextSmallerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextSmallerPos());
 
     // search after the last value aka "insertCount", and surprise, nothing will be found
     sr = nodes.getNearestChildPos((byte) (keyOffset + insertCount));
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextLargerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextLargerPos());
   }
 
   @Test
   public void testSparseNonZeroBasedKeysSearch() {
-    Node nodes = new Node48(0);
+    BranchNode nodes = new Node48(0);
     final int insertCount = 47;
     final int lastValue = insertCount - 1;
     final int step = 3;
@@ -306,7 +306,7 @@ public class Node48Test {
 
         // the value smaller than the first should be INVALID, and the rest should be the prior key
         if (i == 0) {
-          Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextSmallerPos());
+          Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextSmallerPos());
         } else {
           int expect = Byte.toUnsignedInt(key) - step;
           int result = Byte.toUnsignedInt(nodes.getChildKey(sr.getNextSmallerPos()));
@@ -331,7 +331,7 @@ public class Node48Test {
 
         // the value larger than the last should be INVALID and the rest should be the next key
         if (i == lastValue) {
-          Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextLargerPos());
+          Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextLargerPos());
         } else {
           int expected = Byte.toUnsignedInt(key) + step;
           int result = Byte.toUnsignedInt(nodes.getChildKey(sr.getNextLargerPos()));
@@ -344,39 +344,39 @@ public class Node48Test {
     SearchResult sr = nodes.getNearestChildPos((byte) (keyOffset - 1));
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextSmallerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextSmallerPos());
 
     // search after the last value aka "insertCount", and surprise, nothing will be found
     sr = nodes.getNearestChildPos((byte) (keyOffset + (insertCount * step)));
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextLargerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextLargerPos());
   }
 
   @Test
   public void testGetNextSmallerPosEdgeCase() {
-    Node nodes = new Node48(0);
+    BranchNode nodes = new Node48(0);
     LeafNode leafNode = new LeafNode(0, 0);
 
     nodes = Node48.insert(nodes, leafNode, (byte) 67);
     // check we are testing the correct thing
     Assertions.assertTrue(nodes instanceof Node48);
 
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextSmallerPos(66));
-    Assertions.assertNotEquals(Node.ILLEGAL_IDX, nodes.getNextSmallerPos(74));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextSmallerPos(66));
+    Assertions.assertNotEquals(BranchNode.ILLEGAL_IDX, nodes.getNextSmallerPos(74));
     Assertions.assertEquals(67, nodes.getChildKey(nodes.getNextSmallerPos(74)));
 
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextLargerPos(68));
-    Assertions.assertNotEquals(Node.ILLEGAL_IDX, nodes.getNextLargerPos(60));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextLargerPos(68));
+    Assertions.assertNotEquals(BranchNode.ILLEGAL_IDX, nodes.getNextLargerPos(60));
     Assertions.assertEquals(67, nodes.getChildKey(nodes.getNextLargerPos(60)));
   }
 
   @Test
   public void testGetNextPosShouldNotThrowOnLegalInputs() {
-    Node node = new Node48(0);
+    Node48 node = new Node48(0);
     for (int key = 0; key < 256; key++) {
-      Assertions.assertEquals(Node.ILLEGAL_IDX, node.getNextSmallerPos(key));
-      Assertions.assertEquals(Node.ILLEGAL_IDX, node.getNextLargerPos(key));
+      Assertions.assertEquals(BranchNode.ILLEGAL_IDX, node.getNextSmallerPos(key));
+      Assertions.assertEquals(BranchNode.ILLEGAL_IDX, node.getNextLargerPos(key));
     }
   }
 

--- a/roaringbitmap/src/test/java/org/roaringbitmap/art/Node4Test.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/art/Node4Test.java
@@ -38,7 +38,7 @@ public class Node4Test {
     Assertions.assertTrue(node4.getChildPos(key2) == 0);
     Assertions.assertTrue(node4.getChildPos(key3) == 1);
     Assertions.assertTrue(node4.getChildKey(1) == key3);
-    Assertions.assertTrue(node4.getChildPos(key1) == Node.ILLEGAL_IDX);
+    Assertions.assertTrue(node4.getChildPos(key1) == BranchNode.ILLEGAL_IDX);
 
     int bytesSize = node4.serializeSizeInBytes();
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
@@ -51,7 +51,7 @@ public class Node4Test {
     Node4 deserializedNode4 = (Node4) Node.deserialize(dataInputStream);
     Assertions.assertEquals(0, deserializedNode4.getChildPos(key2));
     Assertions.assertEquals(1, deserializedNode4.getChildPos(key3));
-    Assertions.assertEquals(Node.ILLEGAL_IDX, deserializedNode4.getChildPos(key1));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, deserializedNode4.getChildPos(key1));
 
     Node node = node4.remove(0);
     Assertions.assertTrue(node instanceof LeafNode);
@@ -84,7 +84,7 @@ public class Node4Test {
     // given we are beyond the key1, the "smaller" should be that position
     Assertions.assertEquals(key1Pos, sr.getNextSmallerPos());
     // and the "larger" should be ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextLargerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextLargerPos());
 
     // search key - 1
     sr = node.getNearestChildPos((byte) (key1 - 1));
@@ -92,7 +92,7 @@ public class Node4Test {
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
     // given we are before the key1, the "smaller" should be ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextSmallerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextSmallerPos());
     // and the "larger" should be position of key1
     Assertions.assertEquals(key1Pos, sr.getNextLargerPos());
   }
@@ -141,7 +141,7 @@ public class Node4Test {
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
     // given we are before the key1, the "smaller" should be ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextSmallerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextSmallerPos());
     // and the "larger" should be key2pos
     Assertions.assertEquals(key1Pos, sr.getNextLargerPos());
 
@@ -163,12 +163,12 @@ public class Node4Test {
     // given we are beyond the key2, the "smaller" should be key2pos
     Assertions.assertEquals(key2Pos, sr.getNextSmallerPos());
     // and the "larger" should be ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextLargerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextLargerPos());
   }
 
   @Test
   public void testDenseNonZeroBasedKeysSearch() {
-    Node nodes = new Node4(0);
+    BranchNode nodes = new Node4(0);
     final int insertCount = 3;
     final int keyOffset = 0x20;
 
@@ -197,18 +197,18 @@ public class Node4Test {
     SearchResult sr = nodes.getNearestChildPos((byte) (keyOffset - 1));
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextSmallerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextSmallerPos());
 
     // search after the last value aka "insertCount", and surprise, nothing will be found
     sr = nodes.getNearestChildPos((byte) (keyOffset + insertCount));
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextLargerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextLargerPos());
   }
 
   @Test
   public void testSparseNonZeroBasedKeysSearch() {
-    Node nodes = new Node4(0);
+    BranchNode nodes = new Node4(0);
     final int insertCount = 3;
     final int lastValue = insertCount - 1;
 
@@ -245,7 +245,7 @@ public class Node4Test {
 
         // the value smaller than the first should be INVALID, and the rest should be the prior key
         if (i == 0) {
-          Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextSmallerPos());
+          Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextSmallerPos());
         } else {
           int expected = Byte.toUnsignedInt(key) - step;
           int result = Byte.toUnsignedInt(nodes.getChildKey(sr.getNextSmallerPos()));
@@ -270,7 +270,7 @@ public class Node4Test {
 
         // the value larger than the last should be INVALID and the rest should be the next key
         if (i == lastValue) {
-          Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextLargerPos());
+          Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextLargerPos());
         } else {
           int expected = Byte.toUnsignedInt(key) + step;
           int result = Byte.toUnsignedInt(nodes.getChildKey(sr.getNextLargerPos()));
@@ -283,18 +283,18 @@ public class Node4Test {
     SearchResult sr = nodes.getNearestChildPos((byte) (keyOffset - 1));
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextSmallerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextSmallerPos());
 
     // search after the last value aka "insertCount", and surprise, nothing will be found
     sr = nodes.getNearestChildPos((byte) (keyOffset + (insertCount * step)));
     Assertions.assertEquals(SearchResult.Outcome.NOT_FOUND, sr.outcome);
     Assertions.assertFalse(sr.hasKeyPos());
-    Assertions.assertEquals(Node.ILLEGAL_IDX, sr.getNextLargerPos());
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, sr.getNextLargerPos());
   }
 
   @Test
   public void testWithOffsetBeforeBytes() {
-    Node nodes = new Node4(0);
+    BranchNode nodes = new Node4(0);
     LeafNode leafNode = new LeafNode(0, 0);
     int insertCount = 4;
     int offset = 40;
@@ -307,10 +307,10 @@ public class Node4Test {
     Assertions.assertTrue(nodes instanceof Node4);
 
     // The position of a value before the "first" value dose not exist thus ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextSmallerPos(nodes.getMinPos()));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextSmallerPos(nodes.getMinPos()));
 
     // The position of a value after the "last" value dose not exist thus ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextLargerPos(nodes.getMaxPos()));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextLargerPos(nodes.getMaxPos()));
 
     // so for each value in the inserted range the next of the prior should be the same as
     // the location of found current.
@@ -333,7 +333,7 @@ public class Node4Test {
 
   @Test
   public void testWithOffsetAndGapsBytes() {
-    Node nodes = new Node4(0);
+    BranchNode nodes = new Node4(0);
     LeafNode leafNode = new LeafNode(0, 0);
     int insertCount = 4;
     int step = 2;
@@ -347,10 +347,10 @@ public class Node4Test {
     Assertions.assertTrue(nodes instanceof Node4);
 
     // The position of a value before the "first" value dose not exist thus ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextSmallerPos(nodes.getMinPos()));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextSmallerPos(nodes.getMinPos()));
 
     // The position of a value after the "last" value dose not exist thus ILLEGAL_IDX
-    Assertions.assertEquals(Node.ILLEGAL_IDX, nodes.getNextLargerPos(nodes.getMaxPos()));
+    Assertions.assertEquals(BranchNode.ILLEGAL_IDX, nodes.getNextLargerPos(nodes.getMaxPos()));
 
     // so for each value in the inserted range the next of the prior should be the same as
     // the location of found current.

--- a/roaringbitmap/src/test/java/org/roaringbitmap/longlong/ArtTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/longlong/ArtTest.java
@@ -1,9 +1,6 @@
 package org.roaringbitmap.longlong;
 
-import org.roaringbitmap.art.Art;
-import org.roaringbitmap.art.LeafNode;
-import org.roaringbitmap.art.LeafNodeIterator;
-import org.roaringbitmap.art.Node;
+import org.roaringbitmap.art.*;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -33,7 +30,7 @@ public class ArtTest {
     hasNext = leafNodeIterator.hasNext();
     Assertions.assertTrue(!hasNext);
     art.remove(key1);
-    Assertions.assertTrue(art.findByKey(key1) == Node.ILLEGAL_IDX);
+    Assertions.assertTrue(art.findByKey(key1) == BranchNode.ILLEGAL_IDX);
   }
 
   // one node4 with two leaf nodes
@@ -177,7 +174,7 @@ public class ArtTest {
     Assertions.assertTrue(containerIdx == 36);
     key = new byte[] {1, 2, 3, 4, 5, 51};
     containerIdx = art.findByKey(key);
-    Assertions.assertTrue(containerIdx == Node.ILLEGAL_IDX);
+    Assertions.assertTrue(containerIdx == BranchNode.ILLEGAL_IDX);
     long sizeInBytesL = art.serializeSizeInBytes();
     int sizeInBytesI = (int) sizeInBytesL;
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(sizeInBytesI);


### PR DESCRIPTION

### SUMMARY
- Trim some retained memory fom Node
- Move branch-specific methods to BranchNode
- replace checks for LEAF_NODE with instanceof checks make some leaf-node-specific code conditional

On all nodes - remove NodeType - its hardly used anyway
Leaf nodes comprise > 50% of all Node (I believe), and there are fields that can never be used/are constant, so remove them by add a BranchNode which can have prefixes/size etc

### Automated Checks

- [ ] I have run `./gradlew test` and made sure that my PR does not break any unit test.
