### PR TITLE
remove nodeType from Branch nodes (its hardly used)

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Art.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Art.java
@@ -227,9 +227,9 @@ public class Art {
       node4.prefixLength = (byte) commonPrefix;
       System.arraycopy(key, depth, node4.prefix, 0, commonPrefix);
       // generate two leaf nodes as the children of the fresh node4
-      Node4.insert(node4, leafNode, prefix[depth + commonPrefix]);
+      node4.insert(leafNode, prefix[depth + commonPrefix]);
       LeafNode anotherLeaf = new LeafNode(key, containerIdx);
-      Node4.insert(node4, anotherLeaf, key[depth + commonPrefix]);
+      node4.insert(anotherLeaf, key[depth + commonPrefix]);
       // replace the current node with this internal node4
       return node4;
     }
@@ -246,7 +246,7 @@ public class Art {
         System.arraycopy(branchNode.prefix, 0, node4.prefix, 0, mismatchPos);
         // split the current internal node, spawn a fresh node4 and let the
         // current internal node as its children.
-        Node4.insert(node4, branchNode, branchNode.prefix[mismatchPos]);
+        node4.insert(branchNode, branchNode.prefix[mismatchPos]);
         int nodeOriginalPrefixLength = branchNode.prefixLength;
         branchNode.prefixLength = (byte) (nodeOriginalPrefixLength - (mismatchPos + (byte) 1));
         // move the remained common prefix of the initial internal node
@@ -256,7 +256,7 @@ public class Art {
           branchNode.prefix = EMPTY_BYTES;
         }
         LeafNode leafNode = new LeafNode(key, containerIdx);
-        Node4.insert(node4, leafNode, key[mismatchPos + depth]);
+        node4.insert(leafNode, key[mismatchPos + depth]);
         return node4;
       }
       depth += branchNode.prefixLength;
@@ -273,8 +273,7 @@ public class Art {
     }
     // insert the key as a child leaf node of the current internal node
     LeafNode leafNode = new LeafNode(key, containerIdx);
-    Node freshOne = BranchNode.insertLeaf(branchNode, leafNode, key[depth]);
-    return freshOne;
+    return branchNode.insert(leafNode, key[depth]);
   }
 
   // find common prefix length

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node256.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node256.java
@@ -16,7 +16,12 @@ public class Node256 extends BranchNode {
   private static final long LONG_MASK = 0xffffffffffffffffL;
 
   public Node256(int compressedPrefixSize) {
-    super(NodeType.NODE256, compressedPrefixSize);
+    super(compressedPrefixSize);
+  }
+
+  @Override
+  protected NodeType nodeType() {
+    return NodeType.NODE256;
   }
 
   @Override
@@ -126,18 +131,17 @@ public class Node256 extends BranchNode {
   /**
    * insert the child node into the node256 node with the key byte
    *
-   * @param currentNode the node256
    * @param child the child node
    * @param key the key byte
    * @return the node256 node
    */
-  public static Node256 insert(Node currentNode, Node child, byte key) {
-    Node256 node256 = (Node256) currentNode;
-    node256.count++;
+  @Override
+  protected Node256 insert(Node child, byte key) {
+    this.count++;
     int i = Byte.toUnsignedInt(key);
-    node256.children[i] = child;
-    setBit(key, node256.bitmapMask);
-    return node256;
+    this.children[i] = child;
+    setBit(key, this.bitmapMask);
+    return this;
   }
 
   static void setBit(byte key, long[] bitmapMask) {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node4.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node4.java
@@ -14,7 +14,12 @@ public class Node4 extends BranchNode {
   Node[] children = new Node[4];
 
   public Node4(int compressedPrefixSize) {
-    super(NodeType.NODE4, compressedPrefixSize);
+    super(compressedPrefixSize);
+  }
+
+  @Override
+  protected NodeType nodeType() {
+    return NodeType.NODE4;
   }
 
   @Override
@@ -81,30 +86,29 @@ public class Node4 extends BranchNode {
   }
 
   /**
-   * insert the child node into the node4 with the key byte
+   * insert the child node into this with the key byte
    *
-   * @param node the node4 to insert into
    * @param childNode the child node
    * @param key the key byte
    * @return the input node4 or an adaptive generated node16
    */
-  public static BranchNode insert(BranchNode node, Node childNode, byte key) {
-    Node4 current = (Node4) node;
-    if (current.count < 4) {
+  @Override
+  protected BranchNode insert(Node childNode, byte key) {
+    if (this.count < 4) {
       // insert leaf into current node
-      current.key = IntegerUtil.setByte(current.key, key, current.count);
-      current.children[current.count] = childNode;
-      current.count++;
-      insertionSort(current);
-      return current;
+      this.key = IntegerUtil.setByte(this.key, key, this.count);
+      this.children[this.count] = childNode;
+      this.count++;
+      insertionSort(this);
+      return this;
     } else {
       // grow to Node16
-      Node16 node16 = new Node16(current.prefixLength);
+      Node16 node16 = new Node16(this.prefixLength);
       node16.count = 4;
-      node16.firstV = LongUtils.initWithFirst4Byte(current.key);
-      System.arraycopy(current.children, 0, node16.children, 0, 4);
-      copyPrefix(current, node16);
-      BranchNode freshOne = Node16.insert(node16, childNode, key);
+      node16.firstV = LongUtils.initWithFirst4Byte(this.key);
+      System.arraycopy(children, 0, node16.children, 0, 4);
+      copyPrefix(this, node16);
+      BranchNode freshOne = node16.insert(childNode, key);
       return freshOne;
     }
   }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/art/Node16Test.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/art/Node16Test.java
@@ -11,38 +11,38 @@ public class Node16Test {
     // insert 4 nodes
     for (int i = 0; i < 4; i++) {
       LeafNode leafNode = new LeafNode(i, i);
-      node4 = (Node4) Node4.insert(node4, leafNode, (byte) i);
+      node4 = (Node4) node4.insert(leafNode, (byte) i);
     }
     // insert the fifth node
     LeafNode leafNode4 = new LeafNode(4, 4);
-    Node16 node16 = (Node16) Node4.insert(node4, leafNode4, (byte) 4);
+    Node16 node16 = (Node16) node4.insert(leafNode4, (byte) 4);
     // remove two nodes to shrink to node4
     node16 = (Node16) node16.remove(4);
     Node degenerativeNode = node16.remove(3);
     Assertions.assertTrue(degenerativeNode instanceof Node4);
     // recover to node16 by re-insert two nodes
     Node4 degenerativeNode4 = (Node4) degenerativeNode;
-    BranchNode node = Node4.insert(degenerativeNode4, leafNode4, (byte) 4);
+    BranchNode node = degenerativeNode4.insert(leafNode4, (byte) 4);
     LeafNode leafNode3 = new LeafNode(3, 3);
-    node16 = (Node16) Node4.insert(node, leafNode3, (byte) 3);
+    node16 = (Node16) node.insert(leafNode3, (byte) 3);
 
     byte key = 4;
-    Assertions.assertTrue(node16.getChildPos(key) == 4);
-    Assertions.assertTrue(node16.getChildKey(4) == key);
+    Assertions.assertEquals(4, node16.getChildPos(key));
+    Assertions.assertEquals(key, node16.getChildKey(4));
     for (int i = 5; i < 12; i++) {
       byte key1 = (byte) i;
       LeafNode leafNode = new LeafNode(i, i);
-      node16 = (Node16) Node16.insert(node16, leafNode, key1);
+      node16 = (Node16) node16.insert(leafNode, key1);
       Assertions.assertEquals(i, node16.getChildPos(key1));
     }
     LeafNode leafNode = new LeafNode(12, 12);
     key = (byte) -2;
-    node16 = (Node16) Node16.insert(node16, leafNode, key);
+    node16 = (Node16) node16.insert(leafNode, key);
     Assertions.assertEquals(12, node16.getChildPos(key));
     Assertions.assertEquals(key, node16.getChildKey(12));
     leafNode = new LeafNode(13, 13);
     byte key12 = (byte) 12;
-    node16 = (Node16) Node16.insert(node16, leafNode, key12);
+    node16 = (Node16) node16.insert(leafNode, key12);
     Assertions.assertEquals(12, node16.getChildPos(key12));
     Assertions.assertEquals(key12, node16.getChildKey(12));
     Assertions.assertEquals(13, node16.getChildPos(key));
@@ -55,10 +55,10 @@ public class Node16Test {
     LeafNode leafNode;
     for (int i = 0; i < 16; i++) {
       leafNode = new LeafNode(i, i);
-      node16 = (Node16) Node16.insert(node16, leafNode, (byte) i);
+      node16 = (Node16) node16.insert(leafNode, (byte) i);
     }
     leafNode = new LeafNode(16, 16);
-    Node node = Node16.insert(node16, leafNode, (byte) 16);
+    Node node = node16.insert(leafNode, (byte) 16);
     Assertions.assertTrue(node instanceof Node48);
     Node48 node48 = (Node48) node;
     int maxPos = node48.getMaxPos();
@@ -76,7 +76,7 @@ public class Node16Test {
     // create the data
     for (int i = 0; i < insertCount; i++) {
       LeafNode leafNode = new LeafNode(i, i);
-      node16 = (Node16) Node16.insert(node16, leafNode, (byte) i);
+      node16 = (Node16) node16.insert(leafNode, (byte) i);
     }
 
     // check the range is as expected
@@ -111,7 +111,7 @@ public class Node16Test {
     for (int i = 0; i < insertCount; i++) {
       LeafNode leafNode = new LeafNode(i, i);
       byte key = (byte) (i + keyOffset);
-      nodes = Node16.insert(nodes, leafNode, key);
+      nodes = nodes.insert(leafNode, key);
     }
     // check we are testing the correct thing
     Assertions.assertTrue(nodes instanceof Node16);
@@ -154,7 +154,7 @@ public class Node16Test {
     for (int i = 0; i < insertCount; i++) {
       LeafNode leafNode = new LeafNode(i, i);
       byte key = (byte) ((i * step) + keyOffset);
-      nodes = Node16.insert(nodes, leafNode, key);
+      nodes = nodes.insert(leafNode, key);
     }
     // check we are testing the correct thing
     Assertions.assertTrue(nodes instanceof Node16);
@@ -236,7 +236,7 @@ public class Node16Test {
 
     // setup data
     for (int i = 0; i < insertCount; i++) {
-      nodes = Node16.insert(nodes, leafNode, (byte) (offset + i));
+      nodes = nodes.insert(leafNode, (byte) (offset + i));
     }
     // check we are testing the correct data structure
     Assertions.assertTrue(nodes instanceof Node16);
@@ -276,7 +276,7 @@ public class Node16Test {
 
     // setup data
     for (int i = 0; i < insertCount; i++) {
-      nodes = Node16.insert(nodes, leafNode, (byte) (offset + (i * step)));
+      nodes = nodes.insert(leafNode, (byte) (offset + (i * step)));
     }
     // check we are testing the correct data structure
     Assertions.assertTrue(nodes instanceof Node16);

--- a/roaringbitmap/src/test/java/org/roaringbitmap/art/Node256Test.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/art/Node256Test.java
@@ -10,7 +10,7 @@ public class Node256Test {
     Node256 node256 = new Node256(0);
     LeafNode leafNode = new LeafNode(0, 0);
     for (int i = 0; i < 256; i++) {
-      node256 = Node256.insert(node256, leafNode, (byte) i);
+      node256 = node256.insert(leafNode, (byte) i);
     }
     int minPos = node256.getMinPos();
     Assertions.assertEquals(0, minPos);
@@ -43,7 +43,7 @@ public class Node256Test {
     Node256 node256 = new Node256(0);
     LeafNode leafNode = new LeafNode(0, 0);
     for (int i = 0; i < 37; i++) {
-      node256 = Node256.insert(node256, leafNode, (byte) i);
+      node256 = node256.insert(leafNode, (byte) i);
     }
     int maxPos = node256.getMaxPos();
     Node node = node256.remove(maxPos);
@@ -63,7 +63,7 @@ public class Node256Test {
 
     // setup data
     for (int i = 0; i < insertCount; i++) {
-      nodes = Node256.insert(nodes, leafNode, (byte) (offset + i));
+      nodes = nodes.insert(leafNode, (byte) (offset + i));
     }
     // check we are testing the correct data structure
     Assertions.assertTrue(nodes instanceof Node256);
@@ -108,7 +108,7 @@ public class Node256Test {
 
     // setup data
     for (int i = 0; i < insertCount; i++) {
-      nodes = Node256.insert(nodes, leafNode, (byte) (offset + (i * step)));
+      nodes = nodes.insert(leafNode, (byte) (offset + (i * step)));
     }
     // check we are testing the correct data structure
     Assertions.assertTrue(nodes instanceof Node256);
@@ -155,7 +155,7 @@ public class Node256Test {
     for (int i = 0; i < insertCount; i++) {
       LeafNode leafNode = new LeafNode(i, i);
       byte key = (byte) (i + keyOffset);
-      nodes = Node256.insert(nodes, leafNode, key);
+      nodes = nodes.insert(leafNode, key);
     }
     // check we are testing the correct thing
     Assertions.assertTrue(nodes instanceof Node256);
@@ -195,7 +195,7 @@ public class Node256Test {
     for (int i = 0; i < insertCount; i++) {
       LeafNode leafNode = new LeafNode(i, i);
       byte key = (byte) ((i * step) + keyOffset);
-      nodes = Node256.insert(nodes, leafNode, key);
+      nodes = nodes.insert(leafNode, key);
     }
     // check we are testing the correct thing
     Assertions.assertTrue(nodes instanceof Node256);

--- a/roaringbitmap/src/test/java/org/roaringbitmap/art/Node48Test.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/art/Node48Test.java
@@ -17,7 +17,7 @@ public class Node48Test {
     LeafNode leafNode;
     for (int i = 0; i < 48; i++) {
       leafNode = new LeafNode(i, i);
-      node48 = (Node48) Node48.insert(node48, leafNode, (byte) i);
+      node48 = (Node48) node48.insert(leafNode, (byte) i);
     }
     int minPos = node48.getMinPos();
     Assertions.assertEquals(0, minPos);
@@ -72,7 +72,7 @@ public class Node48Test {
 
     // setup data
     for (int i = 0; i < insertCount; i++) {
-      nodes = Node48.insert(nodes, leafNode, (byte) (offset + i));
+      nodes = nodes.insert(leafNode, (byte) (offset + i));
     }
     // check we are testing the correct data structure
     Assertions.assertTrue(nodes instanceof Node48);
@@ -117,7 +117,7 @@ public class Node48Test {
 
     // setup data
     for (int i = 0; i < insertCount; i++) {
-      nodes = Node48.insert(nodes, leafNode, (byte) (offset + (i * step)));
+      nodes = nodes.insert(leafNode, (byte) (offset + (i * step)));
     }
     // check we are testing the correct data structure
     Assertions.assertTrue(nodes instanceof Node48);
@@ -160,11 +160,11 @@ public class Node48Test {
     LeafNode leafNode;
     for (int i = 0; i < 48; i++) {
       leafNode = new LeafNode(i, i);
-      node48 = (Node48) Node48.insert(node48, leafNode, (byte) i);
+      node48 = (Node48) node48.insert(leafNode, (byte) i);
     }
     int key48 = 48;
     leafNode = new LeafNode(key48, key48);
-    Node node = Node48.insert(node48, leafNode, (byte) key48);
+    Node node = node48.insert(leafNode, (byte) key48);
     Assertions.assertTrue(node instanceof Node256);
     Node256 node256 = (Node256) node;
     int pos48 = node256.getChildPos((byte) key48);
@@ -179,7 +179,7 @@ public class Node48Test {
     LeafNode leafNode;
     for (int i = 0; i < 13; i++) {
       leafNode = new LeafNode(i, i);
-      node48 = (Node48) Node48.insert(node48, leafNode, (byte) i);
+      node48 = (Node48) node48.insert(leafNode, (byte) i);
     }
     int maxPos = node48.getMaxPos();
     Assertions.assertEquals(12, maxPos);
@@ -202,7 +202,7 @@ public class Node48Test {
     for (int i = 0; i < 48; i++) {
       int byteKey = -128 + i;
       leafNode = new LeafNode(i, i);
-      node48 = (Node48) Node48.insert(node48, leafNode, (byte) byteKey);
+      node48 = (Node48) node48.insert(leafNode, (byte) byteKey);
     }
     int minPos = node48.getMinPos();
     Assertions.assertEquals(128, minPos);
@@ -242,7 +242,7 @@ public class Node48Test {
     for (int i = 0; i < insertCount; i++) {
       LeafNode leafNode = new LeafNode(i, i);
       byte key = (byte) (i + keyOffset);
-      nodes = Node48.insert(nodes, leafNode, key);
+      nodes = nodes.insert(leafNode, key);
     }
     // check we are testing the correct thing
     Assertions.assertTrue(nodes instanceof Node48);
@@ -282,7 +282,7 @@ public class Node48Test {
     for (int i = 0; i < insertCount; i++) {
       LeafNode leafNode = new LeafNode(i, i);
       byte key = (byte) ((i * step) + keyOffset);
-      nodes = Node48.insert(nodes, leafNode, key);
+      nodes = nodes.insert(leafNode, key);
     }
     // check we are testing the correct thing
     Assertions.assertTrue(nodes instanceof Node48);
@@ -358,7 +358,7 @@ public class Node48Test {
     BranchNode nodes = new Node48(0);
     LeafNode leafNode = new LeafNode(0, 0);
 
-    nodes = Node48.insert(nodes, leafNode, (byte) 67);
+    nodes = nodes.insert(leafNode, (byte) 67);
     // check we are testing the correct thing
     Assertions.assertTrue(nodes instanceof Node48);
 

--- a/roaringbitmap/src/test/java/org/roaringbitmap/art/Node4Test.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/art/Node4Test.java
@@ -18,20 +18,20 @@ public class Node4Test {
     LeafNode leafNode3 = new LeafNode(3, 3);
     Node4 node4 = new Node4(0);
     byte key1 = 2;
-    Node4.insert(node4, leafNode1, key1);
+    node4.insert(leafNode1, key1);
     Assertions.assertTrue(node4.getMaxPos() == 0);
     Assertions.assertTrue(node4.getMinPos() == 0);
     Assertions.assertTrue(node4.getChildPos(key1) == 0);
     Assertions.assertTrue(node4.getChildKey(0) == key1);
 
     byte key2 = 1;
-    node4 = (Node4) Node4.insert(node4, leafNode2, key2);
+    node4 = (Node4) node4.insert(leafNode2, key2);
     Assertions.assertTrue(node4.getChildPos(key2) == 0);
     Assertions.assertTrue(node4.getChildPos(key1) == 1);
     Assertions.assertTrue(node4.getChildKey(0) == key2);
 
     byte key3 = -1;
-    node4 = (Node4) Node4.insert(node4, leafNode3, key3);
+    node4 = (Node4) node4.insert(leafNode3, key3);
     Assertions.assertTrue(node4.getChildPos(key3) == 2);
     Assertions.assertTrue(node4.getChildKey(2) == key3);
     node4 = (Node4) node4.remove(1);
@@ -65,7 +65,7 @@ public class Node4Test {
 
     Node4 node = new Node4(0);
 
-    Node4.insert(node, ln1, key1);
+    node.insert(ln1, key1);
 
     // search for the key we just added returns the
     SearchResult sr = node.getNearestChildPos(key1);
@@ -108,8 +108,8 @@ public class Node4Test {
 
     Node4 node = new Node4(0);
 
-    Node4.insert(node, ln1, key1);
-    Node4.insert(node, ln2, key2);
+    node.insert(ln1, key1);
+    node.insert(ln2, key2);
 
     // value checks
     Assertions.assertTrue((key1 + 1) < (key2 - 1));
@@ -176,7 +176,7 @@ public class Node4Test {
     for (int i = 0; i < insertCount; i++) {
       LeafNode leafNode = new LeafNode(i, i);
       byte key = (byte) (i + keyOffset);
-      nodes = Node4.insert(nodes, leafNode, key);
+      nodes = nodes.insert(leafNode, key);
     }
     // check we are testing the correct thing
     Assertions.assertTrue(nodes instanceof Node4);
@@ -219,7 +219,7 @@ public class Node4Test {
     for (int i = 0; i < insertCount; i++) {
       LeafNode leafNode = new LeafNode(i, i);
       byte key = (byte) ((i * step) + keyOffset);
-      nodes = Node4.insert(nodes, leafNode, key);
+      nodes = nodes.insert(leafNode, key);
     }
     // check we are testing the correct thing
     Assertions.assertTrue(nodes instanceof Node4);
@@ -301,7 +301,7 @@ public class Node4Test {
 
     // setup data
     for (int i = 0; i < insertCount; i++) {
-      nodes = Node4.insert(nodes, leafNode, (byte) (offset + i));
+      nodes = nodes.insert(leafNode, (byte) (offset + i));
     }
     // check we are testing the correct data structure
     Assertions.assertTrue(nodes instanceof Node4);
@@ -341,7 +341,7 @@ public class Node4Test {
 
     // setup data
     for (int i = 0; i < insertCount; i++) {
-      nodes = Node4.insert(nodes, leafNode, (byte) (offset + (i * step)));
+      nodes = nodes.insert(leafNode, (byte) (offset + (i * step)));
     }
     // check we are testing the correct data structure
     Assertions.assertTrue(nodes instanceof Node4);


### PR DESCRIPTION
this reduces the retained memory of nodes (4 or 8 bytes per Mode)

### SUMMARY
- Describe your changes, including rationale and design decisions
- remove the field, as it can be derived from the class
- make some methods virtual

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
