### PR TITLE
remove `prefixLength` to save some memory.

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/AbstractShuttle.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/AbstractShuttle.java
@@ -187,10 +187,11 @@ public abstract class AbstractShuttle implements Shuttle {
 
     BranchNode branchNode = (BranchNode) node;
 
-    if (branchNode.prefixLength > 0) {
+    byte branchNodePrefixLength = branchNode.prefixLength();
+    if (branchNodePrefixLength > 0) {
       int commonLength =
-          Art.commonPrefixLength(high, keyDepth, high.length, branchNode.prefix, 0, branchNode.prefixLength);
-      if (commonLength != branchNode.prefixLength) {
+          Art.commonPrefixLength(high, keyDepth, high.length, branchNode.prefix, 0, branchNodePrefixLength);
+      if (commonLength != branchNodePrefixLength) {
         byte nodeValue = branchNode.prefix[commonLength];
         byte highValue = high[keyDepth + commonLength];
         boolean visitDirection = prefixMismatchIsInRunDirection(nodeValue, highValue);
@@ -199,7 +200,7 @@ public abstract class AbstractShuttle implements Shuttle {
         return;
       }
       // common prefix is the same ,then increase the depth
-      keyDepth += branchNode.prefixLength;
+      keyDepth += branchNode.prefixLength();
     }
     // find next child
     SearchResult result = branchNode.getNearestChildPos(high[keyDepth]);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node.java
@@ -153,28 +153,24 @@ public abstract class Node {
     }
     if (nodeTypeOrdinal == NodeType.NODE4.ordinal()) {
       Node4 node4 = new Node4(prefixLength);
-      node4.prefixLength = prefixLength;
       node4.prefix = prefix;
       node4.count = count;
       return node4;
     }
     if (nodeTypeOrdinal == NodeType.NODE16.ordinal()) {
       Node16 node16 = new Node16(prefixLength);
-      node16.prefixLength = prefixLength;
       node16.prefix = prefix;
       node16.count = count;
       return node16;
     }
     if (nodeTypeOrdinal == NodeType.NODE48.ordinal()) {
       Node48 node48 = new Node48(prefixLength);
-      node48.prefixLength = prefixLength;
       node48.prefix = prefix;
       node48.count = count;
       return node48;
     }
     if (nodeTypeOrdinal == NodeType.NODE256.ordinal()) {
       Node256 node256 = new Node256(prefixLength);
-      node256.prefixLength = prefixLength;
       node256.prefix = prefix;
       node256.count = count;
       return node256;
@@ -198,28 +194,24 @@ public abstract class Node {
     }
     if (nodeTypeOrdinal == NodeType.NODE4.ordinal()) {
       Node4 node4 = new Node4(prefixLength);
-      node4.prefixLength = prefixLength;
       node4.prefix = prefix;
       node4.count = count;
       return node4;
     }
     if (nodeTypeOrdinal == NodeType.NODE16.ordinal()) {
       Node16 node16 = new Node16(prefixLength);
-      node16.prefixLength = prefixLength;
       node16.prefix = prefix;
       node16.count = count;
       return node16;
     }
     if (nodeTypeOrdinal == NodeType.NODE48.ordinal()) {
       Node48 node48 = new Node48(prefixLength);
-      node48.prefixLength = prefixLength;
       node48.prefix = prefix;
       node48.count = count;
       return node48;
     }
     if (nodeTypeOrdinal == NodeType.NODE256.ordinal()) {
       Node256 node256 = new Node256(prefixLength);
-      node256.prefixLength = prefixLength;
       node256.prefix = prefix;
       node256.count = count;
       return node256;

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node16.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node16.java
@@ -172,7 +172,7 @@ public class Node16 extends BranchNode {
       this.secondV = byteBuffer.getLong(8);
       return this;
     } else {
-      Node48 node48 = new Node48(this.prefixLength);
+      Node48 node48 = new Node48(this.prefixLength());
       for (int i = 0; i < 8; i++) {
         int unsignedIdx = Byte.toUnsignedInt((byte) (this.firstV >>> ((7 - i) << 3)));
         // i won't be beyond 48
@@ -206,7 +206,7 @@ public class Node16 extends BranchNode {
     count--;
     if (count <= 3) {
       // shrink to node4
-      Node4 node4 = new Node4(prefixLength);
+      Node4 node4 = new Node4(prefixLength());
       // copy the keys
       node4.key = (int) (firstV >> 32);
       System.arraycopy(children, 0, node4.children, 0, count);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node256.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node256.java
@@ -159,7 +159,7 @@ public class Node256 extends BranchNode {
     bitmapMask[longPos] &= ~(1L << pos);
     this.count--;
     if (this.count <= 36) {
-      Node48 node48 = new Node48(this.prefixLength);
+      Node48 node48 = new Node48(this.prefixLength());
       int j = 0;
       int currentPos = ILLEGAL_IDX;
       while ((currentPos = getNextLargerPos(currentPos)) != ILLEGAL_IDX) {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node4.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node4.java
@@ -103,7 +103,7 @@ public class Node4 extends BranchNode {
       return this;
     } else {
       // grow to Node16
-      Node16 node16 = new Node16(this.prefixLength);
+      Node16 node16 = new Node16(this.prefixLength());
       node16.count = 4;
       node16.firstV = LongUtils.initWithFirst4Byte(this.key);
       System.arraycopy(children, 0, node16.children, 0, 4);
@@ -127,12 +127,13 @@ public class Node4 extends BranchNode {
       Node childNode = children[0];
       if (childNode instanceof BranchNode) {
         BranchNode child = (BranchNode) childNode;
-        byte newLength = (byte) (child.prefixLength + this.prefixLength + 1);
+        byte childPrefixLength = child.prefixLength();
+        byte thisPrefixLength = this.prefixLength();
+        byte newLength = (byte) (childPrefixLength + thisPrefixLength + 1);
         byte[] newPrefix = new byte[newLength];
-        System.arraycopy(this.prefix, 0, newPrefix, 0, this.prefixLength);
-        newPrefix[this.prefixLength] = IntegerUtil.firstByte(key);
-        System.arraycopy(child.prefix, 0, newPrefix, this.prefixLength + 1, child.prefixLength);
-        child.prefixLength = newLength;
+        System.arraycopy(this.prefix, 0, newPrefix, 0,thisPrefixLength);
+        newPrefix[thisPrefixLength] = IntegerUtil.firstByte(key);
+        System.arraycopy(child.prefix, 0, newPrefix, thisPrefixLength + 1, childPrefixLength);
         child.prefix = newPrefix;
       }
       return childNode;

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node48.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node48.java
@@ -195,7 +195,7 @@ public class Node48 extends BranchNode {
       return this;
     } else {
       // grow to Node256
-      Node256 node256 = new Node256(this.prefixLength);
+      Node256 node256 = new Node256(this.prefixLength());
       int currentPos = ILLEGAL_IDX;
       while ((currentPos = this.getNextLargerPos(currentPos)) != ILLEGAL_IDX) {
         Node childNode = this.getChild(currentPos);
@@ -217,7 +217,7 @@ public class Node48 extends BranchNode {
     count--;
     if (count <= 12) {
       // shrink to node16
-      Node16 node16 = new Node16(this.prefixLength);
+      Node16 node16 = new Node16(this.prefixLength());
       int j = 0;
       ByteBuffer byteBuffer = ByteBuffer.allocate(16).order(ByteOrder.BIG_ENDIAN);
       int currentPos = ILLEGAL_IDX;


### PR DESCRIPTION
remove a minor memory leak

### SUMMARY
- Describe your changes, including rationale and design decisions
- remove `prefixLength`, as is should always be `prefix.length`
- expose a methos for the same functionallity
Note 
there was one case where the above wasn't true, (when an array wasn't being resized) which was a very small and bounded memory leak

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
