### PR TITLE
fix memory leak in Node4.remove

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/LeafNode.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/LeafNode.java
@@ -123,4 +123,12 @@ public class LeafNode extends Node {
     byteBuffer.put((byte)0);
   }
 
+  @Override
+  public String toString() {
+    return "LeafNode{" +
+            "key=" + Long.toHexString(getKey()) +
+            ", containerIdx=" + containerIdx +
+            '}';
+  }
+
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node4.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node4.java
@@ -116,12 +116,12 @@ public class Node4 extends BranchNode {
   @Override
   public Node remove(int pos) {
     assert pos < count;
-    children[pos] = null;
     count--;
     key = IntegerUtil.shiftLeftFromSpecifiedPosition(key, pos, (4 - pos - 1));
     for (; pos < count; pos++) {
       children[pos] = children[pos + 1];
     }
+    children[pos] = null;
     if (count == 1) {
       // shrink to the child node
       Node childNode = children[0];

--- a/roaringbitmap/src/test/java/org/roaringbitmap/art/Node4Test.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/art/Node4Test.java
@@ -9,7 +9,25 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 public class Node4Test {
+
+  private void assertContent(Node4 node4, Node ... children) {
+    Assertions.assertEquals(children.length, node4.count);
+    Assertions.assertArrayEquals(Arrays.copyOf(children, 4), node4.children);
+  }
+
+  private void assertKeys(Node4 node4, byte ... keys) {
+    Assertions.assertEquals(keys.length, node4.count);
+    for (int i = 0; i < keys.length; i++) {
+      Assertions.assertEquals(keys[i], (byte)(node4.key >> (24-8*i)), "key at pos " + i);
+    }
+    //it seems that the rest of the key are undefined
+    //not sure if they should be though
+  }
 
   @Test
   public void testTheBasics() throws IOException {
@@ -17,18 +35,24 @@ public class Node4Test {
     LeafNode leafNode2 = new LeafNode(2, 2);
     LeafNode leafNode3 = new LeafNode(3, 3);
     Node4 node4 = new Node4(0);
+    assertKeys(node4);
+    assertContent(node4);
     byte key1 = 2;
     node4.insert(leafNode1, key1);
     Assertions.assertEquals(0, node4.getMaxPos());
     Assertions.assertEquals(0, node4.getMinPos());
     Assertions.assertEquals(0, node4.getChildPos(key1));
     Assertions.assertEquals(key1, node4.getChildKey(0));
+    assertKeys(node4, key1);
+    assertContent(node4, leafNode1);
 
     byte key2 = 1;
     node4 = (Node4) node4.insert(leafNode2, key2);
     Assertions.assertEquals(0, node4.getChildPos(key2));
     Assertions.assertEquals(1, node4.getChildPos(key1));
     Assertions.assertEquals(key2, node4.getChildKey(0));
+    assertKeys(node4, key2, key1);
+    assertContent(node4, leafNode2, leafNode1);
 
     byte key3 = -1;
     node4 = (Node4) node4.insert(leafNode3, key3);
@@ -39,6 +63,8 @@ public class Node4Test {
     Assertions.assertEquals(1, node4.getChildPos(key3));
     Assertions.assertEquals(key3, node4.getChildKey(1));
     Assertions.assertEquals(BranchNode.ILLEGAL_IDX, node4.getChildPos(key1));
+    assertKeys(node4, key2, key3);
+    assertContent(node4, leafNode2, leafNode3);
 
     int bytesSize = node4.serializeSizeInBytes();
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
@@ -55,6 +81,143 @@ public class Node4Test {
 
     Node node = node4.remove(0);
     Assertions.assertTrue(node instanceof LeafNode);
+  }
+  byte[] keys(int... keys) {
+    byte[] result = new byte[keys.length];
+    for (int i = 0; i < keys.length; i++) {
+      result[i] = (byte) keys[i];
+    }
+    return result;
+  }
+    Node[] nodes(Node... nodes) {
+        return nodes;
+    }
+
+  @Test
+  void testOrderedInsert() {
+    LeafNode leafNode1 = new LeafNode(1, 1);
+    LeafNode leafNode2 = new LeafNode(2, 2);
+    LeafNode leafNode3 = new LeafNode(3, 3);
+    LeafNode leafNode4 = new LeafNode(4, 4);
+
+    Node4 node4 = new Node4(0);
+    addEachNode(node4, nodes(leafNode1, leafNode2, leafNode3, leafNode4), keys(1, 2, 3, 4));
+
+    assertKeys(node4, keys(1,2,3,4));
+    assertContent(node4, nodes(leafNode1, leafNode2, leafNode3, leafNode4));
+
+  }
+  @Test
+  void testUnorderedInsert() {
+    LeafNode leafNode1 = new LeafNode(1, 1);
+    LeafNode leafNode2 = new LeafNode(2, 2);
+    LeafNode leafNode3 = new LeafNode(3, 3);
+    LeafNode leafNode4 = new LeafNode(4, 4);
+
+    Node4 node4 = new Node4(0);
+    addEachNode(node4, nodes(leafNode2, leafNode4, leafNode3, leafNode1), keys(2,4,3,1));
+
+    assertKeys(node4, keys(1,2,3,4));
+    assertContent(node4, nodes(leafNode1, leafNode2, leafNode3, leafNode4));
+
+  }
+  @Test
+  void testRemoveFullLast() {
+    LeafNode leafNode1 = new LeafNode(1, 1);
+    LeafNode leafNode2 = new LeafNode(2, 2);
+    LeafNode leafNode3 = new LeafNode(3, 3);
+    LeafNode leafNode4 = new LeafNode(4, 4);
+
+    Node4 node4 = new Node4(0);
+    addEachNode(node4, nodes(leafNode1, leafNode2, leafNode3, leafNode4), keys(1,2,3,4));
+
+    node4.remove(3);
+    assertKeys(node4, keys(1,2,3));
+    assertContent(node4, nodes(leafNode1, leafNode2, leafNode3));
+
+  }
+  @Test
+  void testRemoveFullMiddle() {
+    LeafNode leafNode1 = new LeafNode(1, 1);
+    LeafNode leafNode2 = new LeafNode(2, 2);
+    LeafNode leafNode3 = new LeafNode(3, 3);
+    LeafNode leafNode4 = new LeafNode(4, 4);
+
+    Node4 node4 = new Node4(0);
+    addEachNode(node4, nodes(leafNode1, leafNode2, leafNode3, leafNode4), keys(1,2,3,4));
+
+    node4.remove(1);
+    assertKeys(node4, keys(1,3,4));
+    assertContent(node4, nodes(leafNode1, leafNode3, leafNode4));
+
+  }
+  @Test
+  void testRemoveFullFirst() {
+    LeafNode leafNode1 = new LeafNode(1, 1);
+    LeafNode leafNode2 = new LeafNode(2, 2);
+    LeafNode leafNode3 = new LeafNode(3, 3);
+    LeafNode leafNode4 = new LeafNode(4, 4);
+
+    Node4 node4 = new Node4(0);
+    addEachNode(node4, nodes(leafNode1, leafNode2, leafNode3, leafNode4), keys(1,2,3,4));
+
+    node4.remove(0);
+    assertKeys(node4, keys(2,3,4));
+    assertContent(node4, nodes(leafNode2, leafNode3, leafNode4));
+
+  }
+  @Test
+  void testRemoveNotFullLast() {
+    LeafNode leafNode1 = new LeafNode(1, 1);
+    LeafNode leafNode2 = new LeafNode(2, 2);
+    LeafNode leafNode3 = new LeafNode(3, 3);
+
+    Node4 node4 = new Node4(0);
+    addEachNode(node4, nodes(leafNode1, leafNode2, leafNode3), keys(1,2,3));
+
+    node4.remove(2);
+    assertKeys(node4, keys(1,2));
+    assertContent(node4, nodes(leafNode1, leafNode2));
+
+  }
+  @Test
+  void testRemoveNotFullMiddle() {
+    LeafNode leafNode1 = new LeafNode(1, 1);
+    LeafNode leafNode2 = new LeafNode(2, 2);
+    LeafNode leafNode3 = new LeafNode(3, 3);
+
+    Node4 node4 = new Node4(0);
+    addEachNode(node4, nodes(leafNode1, leafNode2, leafNode3), keys(1,2,3));
+
+    node4.remove(1);
+    assertKeys(node4, keys(1,3));
+    assertContent(node4, nodes(leafNode1, leafNode3));
+
+  }
+  @Test
+  void testRemoveNotFullFirst() {
+    LeafNode leafNode1 = new LeafNode(1, 1);
+    LeafNode leafNode2 = new LeafNode(2, 2);
+    LeafNode leafNode3 = new LeafNode(3, 3);
+
+    Node4 node4 = new Node4(0);
+    addEachNode(node4, nodes(leafNode1, leafNode2, leafNode3), keys(1,2,3));
+
+    node4.remove(0);
+    assertKeys(node4, keys(2,3));
+    assertContent(node4, nodes(leafNode2, leafNode3));
+
+  }
+
+  private void addEachNode(Node4 node4, Node[] nodes, byte[] keys) {
+    Assertions.assertEquals(nodes.length, keys.length, "Nodes and keys should have the same length");
+    for (int i = 0; i < nodes.length; i++) {
+      Node node = nodes[i];
+      byte key = keys[i];
+      Node result = node4.insert(node, key);
+      assertSame(node4, result, "Inserting node at position " + i + " with key " + key);
+      Assertions.assertEquals(i+1, node4.count);
+    }
   }
 
   @Test


### PR DESCRIPTION
### SUMMARY
Node4 has a memory leak. The last node references is nulled

so if you have a node containing (a,b,c,d)
and then you remove(0), and remove (2)
The leak is caused by the fist remove, but only becomes a leaf on the second one
the node contains ((b,c), but the child array is (b,c,null, d)

I had a quick look at the higher order odes and they look OK, but need tests
I dont have time to write these now, and cant be sure of not similar leaf being there (or creeping in later), so I think there should be some tests to confirm this

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
