### PR TITLE
calculate the Node at a key in a single step

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Art.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Art.java
@@ -128,12 +128,7 @@ public class Art {
           // common prefix is the same ,then increase the depth
           depth += branchNodePrefixLength;
         }
-        //TODO - expose an API that avoids this double dipping
-        int pos = branchNode.getChildPos(LongUtils.getByte(key, depth));
-        if (pos == BranchNode.ILLEGAL_IDX) {
-          return null;
-        }
-        node = branchNode.getChild(pos);
+        node = branchNode.getChildAtKey(LongUtils.getByte(key, depth));
         depth++;
       } else {
         LeafNode leafNode = (LeafNode) node;

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/BranchNode.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/BranchNode.java
@@ -145,6 +145,18 @@ public abstract class BranchNode extends Node {
      * @return a Node corresponding to the input position
      */
     public abstract Node getChild(int pos);
+    /**
+     * get the child at the specified key in the node.
+     * the behavior is equivalent to {@code
+     *     int pos = getChildPos(key);
+     *     return (pos != ILLEGAL_IDX) ? getChild(pos) : null;
+     * }
+     * but subclasses may be able to provide a more efficient implementation
+     *
+     * @param key the position
+     * @return a Node corresponding to the input position, or null if not found
+     */
+    public abstract Node getChildAtKey(byte key);
 
     /**
      * replace the position child to the fresh one

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node16.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node16.java
@@ -45,6 +45,12 @@ public class Node16 extends BranchNode {
   }
 
   @Override
+  public Node getChildAtKey(byte key) {
+    int pos = getChildPos(key);
+    return (pos != ILLEGAL_IDX) ? children[pos] : null;
+  }
+
+  @Override
   public SearchResult getNearestChildPos(byte k) {
     byte[] firstBytes = LongUtils.toBDBytes(firstV);
     if (count <= 8) {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node256.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node256.java
@@ -34,6 +34,11 @@ public class Node256 extends BranchNode {
   }
 
   @Override
+  public Node getChildAtKey(byte key) {
+    return children[Byte.toUnsignedInt(key)];
+  }
+
+  @Override
   public SearchResult getNearestChildPos(byte k) {
     int pos = Byte.toUnsignedInt(k);
     if (children[pos] != null) {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node4.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node4.java
@@ -53,6 +53,12 @@ public class Node4 extends BranchNode {
   }
 
   @Override
+  public Node getChildAtKey(byte key) {
+    int pos = getChildPos(key);
+    return (pos != ILLEGAL_IDX) ? children[pos] : null;
+  }
+
+  @Override
   public void replaceNode(int pos, Node freshOne) {
     children[pos] = freshOne;
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node48.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node48.java
@@ -64,6 +64,13 @@ public class Node48 extends BranchNode {
   }
 
   @Override
+  public Node getChildAtKey(byte key) {
+    int unsignedIdx = Byte.toUnsignedInt(key);
+    int childIdx = childrenIdx(unsignedIdx, childIndex);
+    return (childIdx != EMPTY_VALUE) ? children[childIdx] : null;
+  }
+
+  @Override
   public void replaceNode(int pos, Node freshOne) {
     byte idx = childrenIdx(pos, childIndex);
     children[(int) idx] = freshOne;

--- a/roaringbitmap/src/test/java/org/roaringbitmap/art/Node16Test.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/art/Node16Test.java
@@ -2,6 +2,7 @@ package org.roaringbitmap.art;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import static org.roaringbitmap.art.NodeCommon.checkKeyAndPosAlign;
 
 public class Node16Test {
 
@@ -13,9 +14,12 @@ public class Node16Test {
       LeafNode leafNode = new LeafNode(i, i);
       node4 = (Node4) node4.insert(leafNode, (byte) i);
     }
+    checkKeyAndPosAlign(node4);
+
     // insert the fifth node
     LeafNode leafNode4 = new LeafNode(4, 4);
     Node16 node16 = (Node16) node4.insert(leafNode4, (byte) 4);
+    checkKeyAndPosAlign(node16);
     // remove two nodes to shrink to node4
     node16 = (Node16) node16.remove(4);
     Node degenerativeNode = node16.remove(3);
@@ -35,6 +39,8 @@ public class Node16Test {
       node16 = (Node16) node16.insert(leafNode, key1);
       Assertions.assertEquals(i, node16.getChildPos(key1));
     }
+
+    checkKeyAndPosAlign(node16);
     LeafNode leafNode = new LeafNode(12, 12);
     key = (byte) -2;
     node16 = (Node16) node16.insert(leafNode, key);
@@ -57,6 +63,7 @@ public class Node16Test {
       leafNode = new LeafNode(i, i);
       node16 = (Node16) node16.insert(leafNode, (byte) i);
     }
+    checkKeyAndPosAlign(node16);
     leafNode = new LeafNode(16, 16);
     Node node = node16.insert(leafNode, (byte) 16);
     Assertions.assertTrue(node instanceof Node48);
@@ -65,6 +72,7 @@ public class Node16Test {
     Assertions.assertEquals(16, maxPos);
     int pos = node48.getChildPos((byte) 16);
     Assertions.assertEquals(maxPos, pos);
+    checkKeyAndPosAlign(node48);
   }
 
   @Test

--- a/roaringbitmap/src/test/java/org/roaringbitmap/art/Node256Test.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/art/Node256Test.java
@@ -2,6 +2,8 @@ package org.roaringbitmap.art;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import static org.roaringbitmap.art.NodeCommon.checkKeyAndPosAlign;
+
 
 public class Node256Test {
 
@@ -12,6 +14,7 @@ public class Node256Test {
     for (int i = 0; i < 256; i++) {
       node256 = node256.insert(leafNode, (byte) i);
     }
+    checkKeyAndPosAlign(node256);
     int minPos = node256.getMinPos();
     Assertions.assertEquals(0, minPos);
     int currentPos = minPos;
@@ -20,6 +23,7 @@ public class Node256Test {
       Assertions.assertEquals(i, nextLargerPos);
       currentPos = nextLargerPos;
     }
+    checkKeyAndPosAlign(node256);
     int maxPos = node256.getMaxPos();
     Assertions.assertEquals(255, maxPos);
     currentPos = maxPos;
@@ -36,6 +40,7 @@ public class Node256Test {
     Assertions.assertEquals(121, pos121);
     int nextPos119 = node256.getNextSmallerPos(pos121);
     Assertions.assertEquals(119, nextPos119);
+    checkKeyAndPosAlign(node256);
   }
 
   @Test

--- a/roaringbitmap/src/test/java/org/roaringbitmap/art/Node48Test.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/art/Node48Test.java
@@ -8,6 +8,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import static org.roaringbitmap.art.NodeCommon.checkKeyAndPosAlign;
+
 
 public class Node48Test {
 
@@ -34,6 +36,8 @@ public class Node48Test {
       Assertions.assertEquals(key, node48.getChildKey(childPos));
       currentPos = nextPos;
     }
+    checkKeyAndPosAlign(node48);
+
     int maxPos = node48.getMaxPos();
     Assertions.assertEquals(47, maxPos);
     currentPos = maxPos;
@@ -61,6 +65,7 @@ public class Node48Test {
     node48 = (Node48) node48.remove(minPos);
     int newMinPos = node48.getMinPos();
     Assertions.assertEquals(1, newMinPos);
+    checkKeyAndPosAlign(node48);
   }
 
   @Test

--- a/roaringbitmap/src/test/java/org/roaringbitmap/art/Node4Test.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/art/Node4Test.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.roaringbitmap.art.NodeCommon.checkKeyAndPosAlign;
+
 
 public class Node4Test {
 
@@ -37,6 +39,7 @@ public class Node4Test {
     Node4 node4 = new Node4(0);
     assertKeys(node4);
     assertContent(node4);
+    checkKeyAndPosAlign(node4);
     byte key1 = 2;
     node4.insert(leafNode1, key1);
     Assertions.assertEquals(0, node4.getMaxPos());
@@ -45,16 +48,18 @@ public class Node4Test {
     Assertions.assertEquals(key1, node4.getChildKey(0));
     assertKeys(node4, key1);
     assertContent(node4, leafNode1);
+      checkKeyAndPosAlign(node4);
 
-    byte key2 = 1;
+      byte key2 = 1;
     node4 = (Node4) node4.insert(leafNode2, key2);
     Assertions.assertEquals(0, node4.getChildPos(key2));
     Assertions.assertEquals(1, node4.getChildPos(key1));
     Assertions.assertEquals(key2, node4.getChildKey(0));
     assertKeys(node4, key2, key1);
     assertContent(node4, leafNode2, leafNode1);
+      checkKeyAndPosAlign(node4);
 
-    byte key3 = -1;
+      byte key3 = -1;
     node4 = (Node4) node4.insert(leafNode3, key3);
     Assertions.assertEquals(2, node4.getChildPos(key3));
     Assertions.assertEquals(key3, node4.getChildKey(2));
@@ -65,6 +70,7 @@ public class Node4Test {
     Assertions.assertEquals(BranchNode.ILLEGAL_IDX, node4.getChildPos(key1));
     assertKeys(node4, key2, key3);
     assertContent(node4, leafNode2, leafNode3);
+    checkKeyAndPosAlign(node4);
 
     int bytesSize = node4.serializeSizeInBytes();
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
@@ -78,6 +84,7 @@ public class Node4Test {
     Assertions.assertEquals(0, deserializedNode4.getChildPos(key2));
     Assertions.assertEquals(1, deserializedNode4.getChildPos(key3));
     Assertions.assertEquals(BranchNode.ILLEGAL_IDX, deserializedNode4.getChildPos(key1));
+    checkKeyAndPosAlign(deserializedNode4);
 
     Node node = node4.remove(0);
     Assertions.assertTrue(node instanceof LeafNode);
@@ -105,7 +112,7 @@ public class Node4Test {
 
     assertKeys(node4, keys(1,2,3,4));
     assertContent(node4, nodes(leafNode1, leafNode2, leafNode3, leafNode4));
-
+    checkKeyAndPosAlign(node4);
   }
   @Test
   void testUnorderedInsert() {
@@ -119,7 +126,7 @@ public class Node4Test {
 
     assertKeys(node4, keys(1,2,3,4));
     assertContent(node4, nodes(leafNode1, leafNode2, leafNode3, leafNode4));
-
+    checkKeyAndPosAlign(node4);
   }
   @Test
   void testRemoveFullLast() {

--- a/roaringbitmap/src/test/java/org/roaringbitmap/art/NodeCommon.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/art/NodeCommon.java
@@ -1,0 +1,16 @@
+package org.roaringbitmap.art;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.roaringbitmap.art.BranchNode.ILLEGAL_IDX;
+
+public class NodeCommon {
+    static void checkKeyAndPosAlign(BranchNode node) {
+        for (int i = 0; i < 256; i++) {
+            int pos = node.getChildPos((byte)i);
+            Node n1 = (pos != ILLEGAL_IDX) ? node.getChild(pos) : null;
+            Node n2 = node.getChildAtKey((byte)i);
+            assertSame(n1, n2);
+        }
+
+    }
+}


### PR DESCRIPTION
### SUMMARY
- Describe your changes, including rationale and design decisions
- If your pull request includes new functionality, then you must have corresponding new tests. (TODO)

For the insert flow there are optimisations to be had by combining the `getChidPos` and `getChild` calls
In my (local) test this reduced the CPU usage by 13%

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.


**Draft until we agree the API, and add tests**
