### PR TITLE
an few more benchmarks

### DIFF
--- a/jmh/src/jmh/java/org/roaringbitmap/longlong/AddRoaring64.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/longlong/AddRoaring64.java
@@ -1,0 +1,128 @@
+package org.roaringbitmap.longlong;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 2, warmups = 0, jvmArgs = {"-Xms32g", "-Xmx32g"})
+@Warmup(iterations = 2, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+public class AddRoaring64 {
+
+  @State(Scope.Benchmark)
+  public static class BenchmarkState {
+
+    @Param({"10000", "100000", "1000000"})
+    public int initialSize = 0;
+
+    @Param({"10000", "100000", "1000000"})
+    public int addedSize = 0;
+
+    @Param({"true", "false"})
+    public boolean orderedAdd = false;
+
+    long[] addedIndexes;
+    Roaring64Bitmap bitmapInitial;
+    Roaring64Bitmap bitmapTest;
+
+    @Setup(Level.Trial)
+    public void setupTrial() {
+      bitmapTest = bitmapInitial.clone();
+    }
+    public long[] baseSetup() {
+      Random r = new Random(0L);
+      Set<Long> indexSet = new HashSet<>();
+      while (indexSet.size() < initialSize) {
+        indexSet.add(r.nextLong());
+      }
+      long[] values = indexSet.stream().mapToLong(Long::longValue).sorted().toArray();
+      bitmapInitial = Roaring64Bitmap.bitmapOf(values);
+      return values;
+    }
+  }
+  @State(Scope.Benchmark)
+  public static class AddExistingState extends BenchmarkState {
+    @Setup()
+    public void setup() {
+      if (addedSize > initialSize) {
+        throw new IllegalStateException("addedSize must not be greater than initialSize");
+      }
+      long[] values = baseSetup();
+
+      List<Long> list = new ArrayList<>();
+      for (long value : values) {
+        list.add(value);
+      }
+
+      if (addedSize < initialSize) {
+        Collections.shuffle(list, new Random(1L));
+      }
+      addedIndexes = list.stream().mapToLong(Long::longValue).limit(addedSize).toArray();
+      if (!orderedAdd) {
+        Arrays.sort(addedIndexes);
+      }
+
+    }
+
+    @State(Scope.Benchmark)
+    public static class AddMissingState extends BenchmarkState {
+
+      @Setup()
+      public void setup() {
+        long[] values = baseSetup();
+        Random r = new Random(1L);
+
+        Set<Long> indexSet = new HashSet<>();
+        for (long index : values) {
+          indexSet.add(index);
+        }
+
+        Set<Long> missedSet = new HashSet<>();
+        while (missedSet.size() < addedSize) {
+          long value = r.nextLong();
+          if (!indexSet.contains(value))
+            missedSet.add(r.nextLong());
+        }
+
+        if (orderedAdd) {
+          addedIndexes = missedSet.stream().mapToLong(Long::longValue).sorted().toArray();
+        } else {
+          List<Long> list = new ArrayList<>(missedSet);
+          Collections.shuffle(list, r);
+          addedIndexes = list.stream().mapToLong(Long::longValue).toArray();
+        }
+      }
+    }
+
+    @Benchmark()
+    public void addAllExisting(AddExistingState state) {
+      Roaring64Bitmap bitmap = state.bitmapTest;
+      bitmap.add(state.addedIndexes);
+    }
+
+    @Benchmark()
+    public void addEachExisting(AddExistingState state) {
+      Roaring64Bitmap bitmap = state.bitmapTest;
+      for (long index : state.addedIndexes) {
+        bitmap.addLong(index);
+      }
+    }
+
+    @Benchmark()
+    public void addAllMissing(AddMissingState state) {
+      Roaring64Bitmap bitmap = state.bitmapTest;
+      bitmap.add(state.addedIndexes);
+    }
+
+    @Benchmark()
+    public void addEachMissing(AddMissingState state) {
+      Roaring64Bitmap bitmap = state.bitmapTest;
+      for (long index : state.addedIndexes) {
+        bitmap.addLong(index);
+      }
+    }
+  }
+}

--- a/jmh/src/jmh/java/org/roaringbitmap/longlong/BuildFromEmpty.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/longlong/BuildFromEmpty.java
@@ -1,0 +1,51 @@
+package org.roaringbitmap.longlong;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 2, warmups = 0, jvmArgs = {"-Xms32g", "-Xmx32g"})
+@Warmup(iterations = 2, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+public class BuildFromEmpty {
+
+  @State(Scope.Benchmark)
+  public static class BenchmarkState {
+
+    @Param({"10000", "100000", "1000000"})
+    public int size = 0;
+
+    @Param({"true", "false"})
+    public boolean ordered = false;
+
+    long[] indexes;
+
+    @Setup()
+    public void setup() {
+      Random r = new Random(0L);
+      Set<Long> indexSet = new HashSet<>();
+      while (indexSet.size() < size) {
+        indexSet.add(r.nextLong());
+      }
+      if (ordered) {
+        indexes = indexSet.stream().mapToLong(Long::longValue).sorted().toArray();
+      } else {
+        List<Long> list = new ArrayList<>(indexSet);
+        Collections.shuffle(list, r);
+        indexes = list.stream().mapToLong(Long::longValue).toArray();
+      }
+    }
+  }
+  @Benchmark()
+  public Roaring64Bitmap addLong(BenchmarkState state) {
+    Roaring64Bitmap bitmap = new Roaring64Bitmap();
+    for (long index : state.indexes) {
+      bitmap.addLong(index);
+    }
+    return bitmap;
+  }
+
+}

--- a/jmh/src/jmh/java/org/roaringbitmap/longlong/BuildFromEmpty.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/longlong/BuildFromEmpty.java
@@ -47,5 +47,14 @@ public class BuildFromEmpty {
     }
     return bitmap;
   }
-
+  @Benchmark()
+  public Roaring64Bitmap bitmapOf(BenchmarkState state) {
+    return Roaring64Bitmap.bitmapOf(state.indexes);
+  }
+  @Benchmark()
+  public Roaring64Bitmap addArray(BenchmarkState state) {
+    Roaring64Bitmap bitmap = new Roaring64Bitmap();
+    bitmap.add(state.indexes);
+    return bitmap;
+  }
 }

--- a/jmh/src/jmh/java/org/roaringbitmap/longlong/FindRoaring64.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/longlong/FindRoaring64.java
@@ -1,0 +1,79 @@
+package org.roaringbitmap.longlong;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 2, warmups = 0, jvmArgs = {"-Xms32g", "-Xmx32g"})
+@Warmup(iterations = 2, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+public class FindRoaring64 {
+
+  @State(Scope.Benchmark)
+  public static class BenchmarkState {
+
+    @Param({"10000", "100000", "1000000"})
+    public int size = 0;
+
+    @Param({"true", "false"})
+    public boolean ordered = false;
+
+    long[] indexes;
+    long[] missedIndexes;
+    Roaring64Bitmap bitmap;
+
+    @Setup()
+    public void setup() {
+      Random r = new Random(0L);
+      Set<Long> indexSet = new HashSet<>();
+      while (indexSet.size() < size) {
+        indexSet.add(r.nextLong());
+      }
+
+      Set<Long> missedSet = new HashSet<>();
+      while (missedSet.size() < size) {
+        long value = r.nextLong();
+        if (!indexSet.contains(value))
+          missedSet.add(r.nextLong());
+      }
+
+      if (ordered) {
+        indexes = indexSet.stream().mapToLong(Long::longValue).sorted().toArray();
+        missedIndexes = missedSet.stream().mapToLong(Long::longValue).toArray();
+      } else {
+        List<Long> list = new ArrayList<>(indexSet);
+        Collections.shuffle(list, r);
+        indexes = list.stream().mapToLong(Long::longValue).toArray();
+
+        list = new ArrayList<>(missedSet);
+        Collections.shuffle(list, r);
+        missedIndexes = list.stream().mapToLong(Long::longValue).toArray();
+      }
+
+      bitmap = new Roaring64Bitmap();
+      for (long index : indexes) {
+        bitmap.addLong(index);
+      }
+
+    }
+  }
+  @Benchmark()
+  public void findPresent(BenchmarkState state, Blackhole blackhole) {
+    Roaring64Bitmap bitmap = state.bitmap;
+    for (long index : state.indexes) {
+      blackhole.consume(bitmap.contains(index));
+    }
+  }
+  @Benchmark()
+  public void findMissing(BenchmarkState state, Blackhole blackhole) {
+    Roaring64Bitmap bitmap = state.bitmap;
+    for (long index : state.missedIndexes) {
+      blackhole.consume(bitmap.contains(index));
+    }
+  }
+
+}


### PR DESCRIPTION
### SUMMARY
followup to https://github.com/RoaringBitmap/RoaringBitmap/pull/797

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.

I missed a commit :-(. added comments and then didnt push the updates cos I lost connectivity

from running
`java -jar jmh/build/libs/benchmarks.jar -f 1 -r2 -i 5 -w 2 -wi 2 'org.roaringbitmap.longlong.*' `

the values are not so interesting, but this shows the spread of parameters
```
Benchmark                                          (addedSize)  (count)  (initialSize)  (ordered)  (orderedAdd)  (pos)   (size)   Mode  Cnt          Score           Error  Units
AddRoaring64.AddExistingState.addAllExisting             10000      N/A          10000        N/A          true    N/A      N/A  thrpt    5       3932.510 ┬▒       136.842  ops/s
AddRoaring64.AddExistingState.addAllExisting             10000      N/A          10000        N/A         false    N/A      N/A  thrpt    5       4382.218 ┬▒        28.232  ops/s
AddRoaring64.AddExistingState.addAllExisting             10000      N/A         100000        N/A          true    N/A      N/A  thrpt    5       1435.385 ┬▒       198.959  ops/s
AddRoaring64.AddExistingState.addAllExisting             10000      N/A         100000        N/A         false    N/A      N/A  thrpt    5       2008.613 ┬▒        41.096  ops/s
AddRoaring64.AddExistingState.addAllExisting             10000      N/A        1000000        N/A          true    N/A      N/A  thrpt    5        869.570 ┬▒       132.874  ops/s
AddRoaring64.AddExistingState.addAllExisting             10000      N/A        1000000        N/A         false    N/A      N/A  thrpt    5       1104.556 ┬▒       164.428  ops/s
AddRoaring64.AddExistingState.addAllExisting            100000      N/A         100000        N/A          true    N/A      N/A  thrpt    5        298.022 ┬▒         9.523  ops/s
AddRoaring64.AddExistingState.addAllExisting            100000      N/A         100000        N/A         false    N/A      N/A  thrpt    5        298.597 ┬▒        11.247  ops/s
AddRoaring64.AddExistingState.addAllExisting            100000      N/A        1000000        N/A          true    N/A      N/A  thrpt    5         34.896 ┬▒         2.108  ops/s
AddRoaring64.AddExistingState.addAllExisting            100000      N/A        1000000        N/A         false    N/A      N/A  thrpt    5         72.945 ┬▒         1.874  ops/s
AddRoaring64.AddExistingState.addAllExisting           1000000      N/A        1000000        N/A          true    N/A      N/A  thrpt    5         29.336 ┬▒         0.337  ops/s
AddRoaring64.AddExistingState.addAllExisting           1000000      N/A        1000000        N/A         false    N/A      N/A  thrpt    5         29.817 ┬▒         0.358  ops/s
AddRoaring64.AddExistingState.addAllMissing              10000      N/A          10000        N/A          true    N/A      N/A  thrpt    5       3870.460 ┬▒       103.509  ops/s
AddRoaring64.AddExistingState.addAllMissing              10000      N/A          10000        N/A         false    N/A      N/A  thrpt    5       2813.566 ┬▒        65.400  ops/s
AddRoaring64.AddExistingState.addAllMissing              10000      N/A         100000        N/A          true    N/A      N/A  thrpt    5       2140.889 ┬▒        53.997  ops/s
AddRoaring64.AddExistingState.addAllMissing              10000      N/A         100000        N/A         false    N/A      N/A  thrpt    5       1676.564 ┬▒        15.150  ops/s
AddRoaring64.AddExistingState.addAllMissing              10000      N/A        1000000        N/A          true    N/A      N/A  thrpt    5       1516.801 ┬▒        87.140  ops/s
AddRoaring64.AddExistingState.addAllMissing              10000      N/A        1000000        N/A         false    N/A      N/A  thrpt    5       1154.995 ┬▒       104.063  ops/s
AddRoaring64.AddExistingState.addAllMissing             100000      N/A         100000        N/A          true    N/A      N/A  thrpt    5        216.285 ┬▒         9.701  ops/s
AddRoaring64.AddExistingState.addAllMissing             100000      N/A         100000        N/A         false    N/A      N/A  thrpt    5         99.928 ┬▒        43.609  ops/s
AddRoaring64.AddExistingState.addAllMissing             100000      N/A        1000000        N/A          true    N/A      N/A  thrpt    5        106.731 ┬▒         3.465  ops/s
AddRoaring64.AddExistingState.addAllMissing             100000      N/A        1000000        N/A         false    N/A      N/A  thrpt    5         53.733 ┬▒         3.647  ops/s
AddRoaring64.AddExistingState.addAllMissing            1000000      N/A        1000000        N/A          true    N/A      N/A  thrpt    5         25.739 ┬▒         1.015  ops/s
AddRoaring64.AddExistingState.addAllMissing            1000000      N/A        1000000        N/A         false    N/A      N/A  thrpt    5          3.597 ┬▒         0.135  ops/s
AddRoaring64.AddExistingState.addEachExisting            10000      N/A          10000        N/A          true    N/A      N/A  thrpt    5       3762.726 ┬▒       116.024  ops/s
AddRoaring64.AddExistingState.addEachExisting            10000      N/A          10000        N/A         false    N/A      N/A  thrpt    5       4064.387 ┬▒        66.639  ops/s
AddRoaring64.AddExistingState.addEachExisting            10000      N/A         100000        N/A          true    N/A      N/A  thrpt    5       1471.512 ┬▒        77.324  ops/s
AddRoaring64.AddExistingState.addEachExisting            10000      N/A         100000        N/A         false    N/A      N/A  thrpt    5       2014.650 ┬▒        40.140  ops/s
AddRoaring64.AddExistingState.addEachExisting            10000      N/A        1000000        N/A          true    N/A      N/A  thrpt    5        861.736 ┬▒       237.434  ops/s
AddRoaring64.AddExistingState.addEachExisting            10000      N/A        1000000        N/A         false    N/A      N/A  thrpt    5       1133.587 ┬▒        82.337  ops/s
AddRoaring64.AddExistingState.addEachExisting           100000      N/A         100000        N/A          true    N/A      N/A  thrpt    5        301.677 ┬▒        11.181  ops/s
AddRoaring64.AddExistingState.addEachExisting           100000      N/A         100000        N/A         false    N/A      N/A  thrpt    5        299.001 ┬▒         9.270  ops/s
AddRoaring64.AddExistingState.addEachExisting           100000      N/A        1000000        N/A          true    N/A      N/A  thrpt    5         34.348 ┬▒         2.507  ops/s
AddRoaring64.AddExistingState.addEachExisting           100000      N/A        1000000        N/A         false    N/A      N/A  thrpt    5         72.185 ┬▒         1.149  ops/s
AddRoaring64.AddExistingState.addEachExisting          1000000      N/A        1000000        N/A          true    N/A      N/A  thrpt    5         27.274 ┬▒         1.076  ops/s
AddRoaring64.AddExistingState.addEachExisting          1000000      N/A        1000000        N/A         false    N/A      N/A  thrpt    5         27.984 ┬▒         1.831  ops/s
AddRoaring64.AddExistingState.addEachMissing             10000      N/A          10000        N/A          true    N/A      N/A  thrpt    5       3867.195 ┬▒        51.703  ops/s
AddRoaring64.AddExistingState.addEachMissing             10000      N/A          10000        N/A         false    N/A      N/A  thrpt    5       3102.123 ┬▒        76.003  ops/s
AddRoaring64.AddExistingState.addEachMissing             10000      N/A         100000        N/A          true    N/A      N/A  thrpt    5       2116.688 ┬▒        95.294  ops/s
AddRoaring64.AddExistingState.addEachMissing             10000      N/A         100000        N/A         false    N/A      N/A  thrpt    5       1603.826 ┬▒       392.975  ops/s
AddRoaring64.AddExistingState.addEachMissing             10000      N/A        1000000        N/A          true    N/A      N/A  thrpt    5       1402.647 ┬▒       534.728  ops/s
AddRoaring64.AddExistingState.addEachMissing             10000      N/A        1000000        N/A         false    N/A      N/A  thrpt    5       1268.652 ┬▒        64.677  ops/s
AddRoaring64.AddExistingState.addEachMissing            100000      N/A         100000        N/A          true    N/A      N/A  thrpt    5        219.244 ┬▒        15.140  ops/s
AddRoaring64.AddExistingState.addEachMissing            100000      N/A         100000        N/A         false    N/A      N/A  thrpt    5        107.581 ┬▒        53.497  ops/s
AddRoaring64.AddExistingState.addEachMissing            100000      N/A        1000000        N/A          true    N/A      N/A  thrpt    5        118.859 ┬▒         6.273  ops/s
AddRoaring64.AddExistingState.addEachMissing            100000      N/A        1000000        N/A         false    N/A      N/A  thrpt    5         57.299 ┬▒         9.762  ops/s
AddRoaring64.AddExistingState.addEachMissing           1000000      N/A        1000000        N/A          true    N/A      N/A  thrpt    5         27.273 ┬▒         1.136  ops/s
AddRoaring64.AddExistingState.addEachMissing           1000000      N/A        1000000        N/A         false    N/A      N/A  thrpt    5          3.981 ┬▒         0.672  ops/s
BuildFromEmpty.addArray                                    N/A      N/A            N/A       true           N/A    N/A    10000   avgt    5     507402.801 ┬▒     83357.610  ns/op
BuildFromEmpty.addArray                                    N/A      N/A            N/A       true           N/A    N/A   100000   avgt    5    5488799.490 ┬▒   1307045.514  ns/op
BuildFromEmpty.addArray                                    N/A      N/A            N/A       true           N/A    N/A  1000000   avgt    5  122133122.526 ┬▒ 148422225.810  ns/op
BuildFromEmpty.addArray                                    N/A      N/A            N/A      false           N/A    N/A    10000   avgt    5     651811.911 ┬▒     41143.100  ns/op
BuildFromEmpty.addArray                                    N/A      N/A            N/A      false           N/A    N/A   100000   avgt    5    7956140.614 ┬▒    368207.228  ns/op
BuildFromEmpty.addArray                                    N/A      N/A            N/A      false           N/A    N/A  1000000   avgt    5  265892953.056 ┬▒  55589842.385  ns/op
BuildFromEmpty.addLong                                     N/A      N/A            N/A       true           N/A    N/A    10000   avgt    5     512808.235 ┬▒    125461.685  ns/op
BuildFromEmpty.addLong                                     N/A      N/A            N/A       true           N/A    N/A   100000   avgt    5    5381379.941 ┬▒    494736.458  ns/op
BuildFromEmpty.addLong                                     N/A      N/A            N/A       true           N/A    N/A  1000000   avgt    5  103103234.150 ┬▒  36203470.584  ns/op
BuildFromEmpty.addLong                                     N/A      N/A            N/A      false           N/A    N/A    10000   avgt    5     636411.212 ┬▒     40955.398  ns/op
BuildFromEmpty.addLong                                     N/A      N/A            N/A      false           N/A    N/A   100000   avgt    5    8202295.868 ┬▒    432734.947  ns/op
BuildFromEmpty.addLong                                     N/A      N/A            N/A      false           N/A    N/A  1000000   avgt    5  272096218.333 ┬▒  88844179.670  ns/op
BuildFromEmpty.bitmapOf                                    N/A      N/A            N/A       true           N/A    N/A    10000   avgt    5     495158.857 ┬▒     68549.418  ns/op
BuildFromEmpty.bitmapOf                                    N/A      N/A            N/A       true           N/A    N/A   100000   avgt    5    5250895.964 ┬▒    507784.027  ns/op
BuildFromEmpty.bitmapOf                                    N/A      N/A            N/A       true           N/A    N/A  1000000   avgt    5  102327003.612 ┬▒  27101759.677  ns/op
BuildFromEmpty.bitmapOf                                    N/A      N/A            N/A      false           N/A    N/A    10000   avgt    5     610630.037 ┬▒     99512.415  ns/op
BuildFromEmpty.bitmapOf                                    N/A      N/A            N/A      false           N/A    N/A   100000   avgt    5    8104207.726 ┬▒   1292396.320  ns/op
BuildFromEmpty.bitmapOf                                    N/A      N/A            N/A      false           N/A    N/A  1000000   avgt    5  265362659.008 ┬▒  81693402.750  ns/op
FindRoaring64.findMissing                                  N/A      N/A            N/A       true           N/A    N/A    10000   avgt    5     101929.873 ┬▒      5348.790  ns/op
FindRoaring64.findMissing                                  N/A      N/A            N/A       true           N/A    N/A   100000   avgt    5    3407398.048 ┬▒    143623.943  ns/op
FindRoaring64.findMissing                                  N/A      N/A            N/A       true           N/A    N/A  1000000   avgt    5   73827665.582 ┬▒   4674673.323  ns/op
FindRoaring64.findMissing                                  N/A      N/A            N/A      false           N/A    N/A    10000   avgt    5     100204.215 ┬▒      2444.343  ns/op
FindRoaring64.findMissing                                  N/A      N/A            N/A      false           N/A    N/A   100000   avgt    5    3178257.487 ┬▒    612262.646  ns/op
FindRoaring64.findMissing                                  N/A      N/A            N/A      false           N/A    N/A  1000000   avgt    5   73466042.646 ┬▒   3625955.893  ns/op
FindRoaring64.findPresent                                  N/A      N/A            N/A       true           N/A    N/A    10000   avgt    5     158266.949 ┬▒      1949.514  ns/op
FindRoaring64.findPresent                                  N/A      N/A            N/A       true           N/A    N/A   100000   avgt    5    2562890.936 ┬▒    134693.061  ns/op
FindRoaring64.findPresent                                  N/A      N/A            N/A       true           N/A    N/A  1000000   avgt    5   25334448.940 ┬▒   2119151.595  ns/op
FindRoaring64.findPresent                                  N/A      N/A            N/A      false           N/A    N/A    10000   avgt    5     192587.831 ┬▒      6307.206  ns/op
FindRoaring64.findPresent                                  N/A      N/A            N/A      false           N/A    N/A   100000   avgt    5    5012811.488 ┬▒    421244.096  ns/op
FindRoaring64.findPresent                                  N/A      N/A            N/A      false           N/A    N/A  1000000   avgt    5  138962870.702 ┬▒  16589007.867  ns/op
ShiftLeftFromSpecifiedPositionBenchmark.optimized          N/A        1            N/A        N/A           N/A      0      N/A   avgt    5          1.757 ┬▒         0.017  ns/op
ShiftLeftFromSpecifiedPositionBenchmark.optimized          N/A        1            N/A        N/A           N/A      2      N/A   avgt    5          1.753 ┬▒         0.066  ns/op
ShiftLeftFromSpecifiedPositionBenchmark.optimized          N/A        2            N/A        N/A           N/A      0      N/A   avgt    5          1.761 ┬▒         0.040  ns/op
ShiftLeftFromSpecifiedPositionBenchmark.optimized          N/A        2            N/A        N/A           N/A      2      N/A   avgt    5          1.757 ┬▒         0.030  ns/op
ShiftLeftFromSpecifiedPositionBenchmark.original           N/A        1            N/A        N/A           N/A      0      N/A   avgt    5          5.632 ┬▒         0.229  ns/op
ShiftLeftFromSpecifiedPositionBenchmark.original           N/A        1            N/A        N/A           N/A      2      N/A   avgt    5          5.577 ┬▒         0.148  ns/op
ShiftLeftFromSpecifiedPositionBenchmark.original           N/A        2            N/A        N/A           N/A      0      N/A   avgt    5          7.951 ┬▒         0.421  ns/op
```
