### PR TITLE
improve 64 bit clone

### DIFF
--- a/jmh/src/jmh/java/org/roaringbitmap/longlong/CloneBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/longlong/CloneBenchmark.java
@@ -1,0 +1,38 @@
+package org.roaringbitmap.longlong;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 2, warmups = 0, jvmArgs = {"-Xms32g", "-Xmx32g"})
+@Warmup(iterations = 2, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+public class CloneBenchmark {
+
+  @State(Scope.Benchmark)
+  public static class BenchmarkState {
+
+    @Param({"10", "100", "1000", "10000", "100000", "1000000"})
+    public int size = 0;
+
+    Roaring64Bitmap source;
+
+    @Setup()
+    public void setup() {
+      Random r = new Random(0L);
+      source = new Roaring64Bitmap();
+      Set<Long> indexSet = new HashSet<>();
+      while (indexSet.size() < size) {
+        indexSet.add(r.nextLong());
+      }
+      source = Roaring64Bitmap.bitmapOf(indexSet.stream().mapToLong(Long::longValue).toArray());
+    }
+  }
+  @Benchmark()
+  public Roaring64Bitmap clone(BenchmarkState state) {
+    return state.source.clone();
+  }
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Art.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Art.java
@@ -24,6 +24,15 @@ public class Art {
   public Art() {
     root = null;
   }
+  @Override
+  public Art clone() {
+    Art art = new Art();
+    art.keySize = this.keySize;
+    if (this.root != null) {
+      art.root = this.root.clone();
+    }
+    return art;
+  }
 
   public boolean isEmpty() {
     return root == null;

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/BranchNode.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/BranchNode.java
@@ -3,6 +3,7 @@ package org.roaringbitmap.art;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 public abstract class BranchNode extends Node {
 
@@ -22,6 +23,18 @@ public abstract class BranchNode extends Node {
         super();
         prefix = compressedPrefixSize == 0 ? Art.EMPTY_BYTES : new byte[compressedPrefixSize];
         count = 0;
+    }
+    public void postClone(BranchNode newlyCloned, Node[] oldChildren, Node[] newChildren) {
+        newlyCloned.count = this.count;
+        //we could potentially share the prefix, but it fragile and would safe so little
+        if (this.prefix.length > 0) {
+            newlyCloned.prefix = Arrays.copyOf(this.prefix, this.prefix.length);
+        }
+        for (int i = 0; i < oldChildren.length; i++) {
+            if (oldChildren[i] != null) {
+                newChildren[i] = oldChildren[i].clone();;
+            }
+        }
     }
     protected abstract NodeType nodeType();
     // length of compressed path(prefix)

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Containers.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Containers.java
@@ -37,6 +37,25 @@ public class Containers {
     reset();
   }
 
+  @Override
+  public Containers clone() {
+    Containers containers = new Containers();
+    containers.containerArrays = new ArrayList<>(this.containerArrays.size());
+    for (Container[] array : this.containerArrays) {
+      Container[] values = Arrays.copyOf(array, array.length);
+      containers.containerArrays.add(values);
+      for (int i = 0; i < values.length; i++) {
+        if (values[i] != null) {
+          values[i] = values[i].clone();
+        }
+      }
+    }
+    containers.containerSize = this.containerSize;
+    containers.firstLevelIdx = this.firstLevelIdx;
+    containers.secondLevelIdx = this.secondLevelIdx;
+    return containers;
+  }
+
   private void reset() {
     containerSize = 0;
     firstLevelIdx = -1;

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/LeafNode.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/LeafNode.java
@@ -43,6 +43,11 @@ public class LeafNode extends Node {
   }
 
   @Override
+  protected LeafNode clone() {
+    return new LeafNode(getKey(), containerIdx);
+  }
+
+  @Override
   public void serializeNodeBody(DataOutput dataOutput) throws IOException {
     dataOutput.writeInt(keyHigh);
     dataOutput.writeShort(keyLow);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node.java
@@ -10,6 +10,9 @@ public abstract class Node {
   public Node() {
   }
 
+  @Override
+  protected abstract Node clone();
+
   /**
    * sort the small arrays through the insertion sort alg.
    */

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node16.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node16.java
@@ -17,6 +17,14 @@ public class Node16 extends BranchNode {
   public Node16(int compressionLength) {
     super(compressionLength);
   }
+  @Override
+  protected Node16 clone() {
+    Node16 clone = new Node16(this.prefixLength());
+    clone.firstV = this.firstV;
+    clone.secondV = this.secondV;
+    postClone(clone, this.children, clone.children);
+    return clone;
+  }
 
   @Override
   protected NodeType nodeType() {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node256.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node256.java
@@ -20,6 +20,14 @@ public class Node256 extends BranchNode {
   }
 
   @Override
+  protected Node256 clone() {
+    Node256 clone = new Node256(this.prefixLength());
+    System.arraycopy(this.bitmapMask,0,clone.bitmapMask,0,bitmapMask.length);
+    postClone(clone, this.children, clone.children);
+    return clone;
+  }
+
+  @Override
   protected NodeType nodeType() {
     return NodeType.NODE256;
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node4.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node4.java
@@ -18,6 +18,14 @@ public class Node4 extends BranchNode {
   }
 
   @Override
+  protected Node4 clone() {
+    Node4 clone = new Node4(this.prefixLength());
+    clone.key = this.key;
+    postClone(clone, this.children, clone.children);
+    return clone;
+  }
+
+  @Override
   protected NodeType nodeType() {
     return NodeType.NODE4;
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/Node48.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/Node48.java
@@ -25,6 +25,14 @@ public class Node48 extends BranchNode {
     super(compressedPrefixSize);
     Arrays.fill(childIndex, INIT_LONG_VALUE);
   }
+  @Override
+  protected Node48 clone() {
+    Node48 clone = new Node48(this.prefixLength());
+    System.arraycopy(this.childIndex,0,clone.childIndex,0,LONGS_USED);
+    postClone(clone, this.children, clone.children);
+    return clone;
+  }
+
 
   @Override
   protected NodeType nodeType() {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/longlong/HighLowContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/longlong/HighLowContainer.java
@@ -28,6 +28,13 @@ public class HighLowContainer {
     art = new Art();
     containers = new Containers();
   }
+  @Override
+  public HighLowContainer clone() {
+    HighLowContainer cloned = new HighLowContainer();
+    cloned.art = this.art.clone();
+    cloned.containers = this.containers.clone();
+    return cloned;
+  }
 
   public Container getContainer(long containerIdx) {
     return containers.getContainer(containerIdx);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64Bitmap.java
@@ -1182,21 +1182,9 @@ public class Roaring64Bitmap implements Externalizable, LongBitmapDataProvider {
   // mainly used for benchmark
   @Override
   public Roaring64Bitmap clone() {
-    long sizeInBytesL = this.serializedSizeInBytes();
-    if (sizeInBytesL >= Integer.MAX_VALUE) {
-      throw new UnsupportedOperationException();
-    }
-    int sizeInBytesInt = (int) sizeInBytesL;
-    ByteBuffer byteBuffer = ByteBuffer.allocate(sizeInBytesInt).order(ByteOrder.LITTLE_ENDIAN);
-    try {
-      this.serialize(byteBuffer);
-      byteBuffer.flip();
-      Roaring64Bitmap freshOne = new Roaring64Bitmap();
-      freshOne.deserialize(byteBuffer);
-      return freshOne;
-    } catch (Exception e) {
-      throw new RuntimeException("fail to clone thorough the ser/deser", e);
-    }
+    Roaring64Bitmap result = new Roaring64Bitmap();
+    result.highLowContainer = this.highLowContainer.clone();
+    return result;
   }
 
   private abstract class PeekableIterator implements PeekableLongIterator {


### PR DESCRIPTION
Improve clone implementation for Roaring64Bitmap
Add benchmark

I was seeing GC stats in non allocating code which was skewing some benchmarks on local code,. This noise was caused by the preceding `clone` in `setup`

I am unsure if additional unit tests are needed to ensure that clone is doing the right thing (i.e. no sharing of mutable structures etc

### SUMMARY
Perform a clone from the memory structure, rather than hydration

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.

Summary comparison 
`clone` relates to the old implementation, `cloneNew` relates to the implementation in this PR

In all cases the new implementation used less CPU and produces less allocation. Full jmh table output in a comment below

```text
Benchmark                                          size)  Mode  Cnt          Score          Error   Units
CloneBenchmark.clone                                  10  avgt    5        625.095 ┬▒       69.718   ns/op
CloneBenchmark.cloneNew                               10  avgt    5        210.615 ┬▒       39.083   ns/op
CloneBenchmark.clone:┬Àgc.alloc.rate.norm             10  avgt    5       2840.022 ┬▒        0.032    B/op
CloneBenchmark.cloneNew:┬Àgc.alloc.rate.norm          10  avgt    5       1568.007 ┬▒        0.011    B/op

CloneBenchmark.clone                                 100  avgt    5       5584.360 ┬▒      921.576   ns/op
CloneBenchmark.cloneNew                              100  avgt    5       1970.138 ┬▒      828.473   ns/op
CloneBenchmark.clone:┬Àgc.alloc.rate.norm            100  avgt    5      21632.180 ┬▒        0.350    B/op
CloneBenchmark.cloneNew:┬Àgc.alloc.rate.norm         100  avgt    5      15008.076 ┬▒        0.084    B/op

CloneBenchmark.clone                                1000  avgt    5      85887.355 ┬▒     9144.499   ns/op
CloneBenchmark.cloneNew                             1000  avgt    5      16343.272 ┬▒     1200.606   ns/op
CloneBenchmark.clone:┬Àgc.alloc.rate.norm           1000  avgt    5     225114.476 ┬▒        5.656    B/op
CloneBenchmark.cloneNew:┬Àgc.alloc.rate.norm        1000  avgt    5     123560.637 ┬▒        0.591    B/op

CloneBenchmark.clone                               10000  avgt    5    1241723.049 ┬▒   155992.370   ns/op
CloneBenchmark.cloneNew                            10000  avgt    5     181841.805 ┬▒    24764.820   ns/op
CloneBenchmark.clone:┬Àgc.alloc.rate.norm          10000  avgt    5    2026425.839 ┬▒       37.780    B/op
CloneBenchmark.cloneNew:┬Àgc.alloc.rate.norm       10000  avgt    5    1224454.353 ┬▒        8.496    B/op

CloneBenchmark.clone                              100000  avgt    5   14939194.016 ┬▒  1575918.366   ns/op
CloneBenchmark.cloneNew                           100000  avgt    5    2687041.109 ┬▒   539254.022   ns/op
CloneBenchmark.clone:┬Àgc.alloc.rate.norm         100000  avgt    5   22158801.841 ┬▒      720.266    B/op
CloneBenchmark.cloneNew:┬Àgc.alloc.rate.norm      100000  avgt    5   12951499.006 ┬▒      149.454    B/op

CloneBenchmark.clone                             1000000  avgt    5  275947512.500 ┬▒   7922621.325   ns/op
CloneBenchmark.cloneNew                          1000000  avgt    5   49577044.159 ┬▒  31849076.491   ns/op
CloneBenchmark.clone:┬Àgc.alloc.rate.norm        1000000  avgt    5  213738697.400 ┬▒     61712.986    B/op
CloneBenchmark.cloneNew:┬Àgc.alloc.rate.norm     1000000  avgt    5  120851247.997 ┬▒      6252.456    B/op
```