### PR TITLE
update gradle wrapper validation

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/wrapper-validation@v3


### PR DESCRIPTION
### SUMMARY
- The runner `gradle/wrapper-validation-action@v1` is obsolete. Replacing it with `gradle/actions/wrapper-validation@v3`.