### PR TITLE
implement combined union and intersection aggregation operation

### DIFF
--- a/jmh/src/jmh/java/org/roaringbitmap/RandomData.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/RandomData.java
@@ -20,8 +20,16 @@ public class RandomData {
     return forKeys(keys, rleLimit, denseLimit);
   }
 
+  public static RoaringBitmap randomContiguousBitmap(int startKey, int numKeys) {
+    return randomContiguousBitmap(startKey, numKeys, 1 / 3d, 1 / 3d);
+  }
+
   public static RoaringBitmap randomBitmap(int maxKeys, double rleLimit, double denseLimit) {
     return forKeys(createSorted16BitInts(maxKeys), rleLimit, denseLimit);
+  }
+
+  public static RoaringBitmap randomBitmap(int maxKeys) {
+    return forKeys(createSorted16BitInts(maxKeys), 1 / 3d, 1 / 3d);
   }
 
   public static IntStream rleRegion() {

--- a/jmh/src/jmh/java/org/roaringbitmap/aggregation/pushdown/IntersectionPushdownBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/aggregation/pushdown/IntersectionPushdownBenchmark.java
@@ -1,0 +1,90 @@
+package org.roaringbitmap.aggregation.pushdown;
+
+import org.roaringbitmap.FastAggregation;
+import org.roaringbitmap.RandomData;
+import org.roaringbitmap.RoaringBitmap;
+
+import org.openjdk.jmh.annotations.*;
+
+/**
+ * Benchmarks queries of the form (x AND (y OR z))
+ */
+@State(Scope.Benchmark)
+public class IntersectionPushdownBenchmark {
+
+  public static class Pair {
+    RoaringBitmap toIntersect;
+    RoaringBitmap[] toUnite;
+
+    Pair(RoaringBitmap toIntersect, RoaringBitmap... toUnite) {
+      this.toIntersect = toIntersect;
+      this.toUnite = toUnite;
+    }
+  }
+
+  public static enum Scenario {
+    EQUAL {
+      @Override
+      Pair create(int keysInIntersection, int unionSize) {
+        RoaringBitmap toIntersect = RandomData.randomBitmap(keysInIntersection);
+        RoaringBitmap[] toUnite = new RoaringBitmap[unionSize];
+        for (int i = 0; i < unionSize; i++) {
+          toUnite[i] = toIntersect.clone();
+        }
+        return new Pair(toIntersect, toUnite);
+      }
+    },
+    STEPS {
+      @Override
+      Pair create(int keysInIntersection, int unionSize) {
+        int startKey = 0;
+        RoaringBitmap toIntersect = RandomData.randomContiguousBitmap(startKey, keysInIntersection);
+        RoaringBitmap[] toUnite = new RoaringBitmap[unionSize];
+        for (int i = 0; i < unionSize; i++) {
+          toUnite[i] = RandomData.randomContiguousBitmap(startKey, keysInIntersection);
+          startKey += keysInIntersection;
+        }
+        return new Pair(toIntersect, toUnite);
+      }
+    };
+
+    abstract Pair create(int keysInIntersection, int unionSize);
+  }
+
+  @Param({"10", "100"})
+  int unionSize;
+
+  @Param({"10", "100", "1000"})
+  int keysInIntersection;
+
+  @Param Scenario scenario;
+
+  private RoaringBitmap toIntersect;
+  private RoaringBitmap[] toUnite;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    Pair pair = scenario.create(keysInIntersection, unionSize);
+    toIntersect = pair.toIntersect;
+    toUnite = pair.toUnite;
+  }
+
+  @Benchmark
+  public RoaringBitmap orThenAnd() {
+    return RoaringBitmap.and(toIntersect, FastAggregation.or(toUnite));
+  }
+
+  @Benchmark
+  public RoaringBitmap andEachThenOr() {
+    RoaringBitmap result = new RoaringBitmap();
+    for (RoaringBitmap bitmap : toUnite) {
+      result.or(RoaringBitmap.and(toIntersect, bitmap));
+    }
+    return result;
+  }
+
+  @Benchmark
+  public RoaringBitmap orWithContext() {
+    return FastAggregation.orWithContext(toIntersect, toUnite);
+  }
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -299,6 +299,14 @@ public final class ArrayContainer extends Container implements Cloneable {
   }
 
   @Override
+  public void orInto(long[] bits) {
+    for (int i = 0; i < this.getCardinality(); ++i) {
+      char value = content[i];
+      bits[value >>> 6] |= (1L << value);
+    }
+  }
+
+  @Override
   public boolean contains(final char x) {
     return Util.unsignedBinarySearch(content, 0, cardinality, x) >= 0;
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -1100,6 +1100,13 @@ public final class BitmapContainer extends Container implements Cloneable {
   }
 
   @Override
+  public void orInto(long[] bits) {
+    for (int i = 0; i < bitmap.length; i++) {
+      bits[i] |= bitmap[i];
+    }
+  }
+
+  @Override
   public Container or(final BitmapContainer value2) {
     BitmapContainer value1 = this.clone();
     return value1.ior(value2);

--- a/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/Container.java
@@ -213,6 +213,13 @@ public abstract class Container
   public abstract boolean isFull();
 
   /**
+   * Computes the union of this container with the bits present in the array,
+   * modifying the array.
+   * @param bits a 1024 element array to be interpreted as a bit set
+   */
+  public abstract void orInto(long[] bits);
+
+  /**
    * Checks whether the contain contains the provided value
    *
    * @param x value to check

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ContainerPointer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ContainerPointer.java
@@ -16,6 +16,12 @@ public interface ContainerPointer extends Comparable<ContainerPointer>, Cloneabl
   void advance();
 
   /**
+   * Advance to the key
+   * @param key the key to advance to
+   */
+  boolean advanceUntil(char key);
+
+  /**
    * Create a copy
    *
    * @return return a clone of this pointer
@@ -58,4 +64,10 @@ public interface ContainerPointer extends Comparable<ContainerPointer>, Cloneabl
    * @return the key
    */
   char key();
+
+  /**
+   * Check whether it safe to advance
+   * @return whether it is safe to advance
+   */
+  boolean hasRemaining();
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/FastAggregation.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/FastAggregation.java
@@ -104,6 +104,44 @@ public final class FastAggregation {
     }
   }
 
+  public static RoaringBitmap orWithContext(RoaringBitmap context, RoaringBitmap... bitmaps) {
+    if (context.isEmpty()) {
+      return new RoaringBitmap();
+    }
+    char[] keys = context.highLowContainer.keys;
+    int numContainers = context.highLowContainer.size;
+    RoaringArray array = new RoaringArray(new char[numContainers], new Container[numContainers], 0);
+    long[] bitset = new long[1024];
+    boolean marked = false;
+    ContainerPointer[] containerPointers = new ContainerPointer[bitmaps.length];
+    for (int i = 0; i < bitmaps.length; i++) {
+      containerPointers[i] = bitmaps[i].getContainerPointer();
+    }
+    for (int i = 0; i < numContainers; i++) {
+      char matchingKey = keys[i];
+      for (ContainerPointer ptr : containerPointers) {
+        if (ptr.advanceUntil(matchingKey)) {
+          if (ptr.hasRemaining() && ptr.key() == matchingKey) {
+            ptr.getContainer().orInto(bitset);
+            marked = true;
+          }
+        }
+      }
+      Container tmp =
+          new BitmapContainer(bitset, -1)
+              .iand(context.highLowContainer.values[i])
+              .repairAfterLazy();
+      if (!tmp.isEmpty()) {
+        array.append(matchingKey, tmp instanceof BitmapContainer ? tmp.clone() : tmp);
+      }
+      if (marked) {
+        Arrays.fill(bitset, 0L);
+        marked = false;
+      }
+    }
+    return new RoaringBitmap(array);
+  }
+
   /**
    * Calls naive_or.
    *

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
@@ -689,6 +689,12 @@ public final class RoaringArray implements Cloneable, Externalizable, Appendable
       }
 
       @Override
+      public boolean advanceUntil(char key) {
+        k = RoaringArray.this.advanceUntil(key, k - 1);
+        return k < size;
+      }
+
+      @Override
       public ContainerPointer clone() {
         try {
           return (ContainerPointer) super.clone();
@@ -712,10 +718,10 @@ public final class RoaringArray implements Cloneable, Externalizable, Appendable
 
       @Override
       public Container getContainer() {
-        if (k >= RoaringArray.this.size) {
+        if (k >= size) {
           return null;
         }
-        return RoaringArray.this.values[k];
+        return values[k];
       }
 
       @Override
@@ -730,7 +736,12 @@ public final class RoaringArray implements Cloneable, Externalizable, Appendable
 
       @Override
       public char key() {
-        return RoaringArray.this.keys[k];
+        return keys[k];
+      }
+
+      @Override
+      public boolean hasRemaining() {
+        return k < size;
       }
     };
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -3,6 +3,8 @@
  */
 package org.roaringbitmap;
 
+import static org.roaringbitmap.Util.setBitmapRange;
+
 import org.roaringbitmap.buffer.MappeableContainer;
 import org.roaringbitmap.buffer.MappeableRunContainer;
 
@@ -1673,6 +1675,15 @@ public final class RunContainer extends Container implements Cloneable {
   @Override
   public boolean isFull() {
     return (this.nbrruns == 1) && (this.getValue(0) == 0) && (this.getLength(0) == 0xFFFF);
+  }
+
+  @Override
+  public void orInto(long[] bits) {
+    for (int r = 0; r < numberOfRuns(); ++r) {
+      int start = this.valueslength[r << 1];
+      int length = this.valueslength[(r << 1) + 1];
+      setBitmapRange(bits, start, start + length + 1);
+    }
   }
 
   public static RunContainer full() {

--- a/roaringbitmap/src/main/java/org/roaringbitmap/Util.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/Util.java
@@ -1244,7 +1244,7 @@ public final class Util {
    * @param bitmaps bitmaps
    * @return keys intersection
    */
-  static char[] intersectKeys(long[] words, RoaringBitmap[] bitmaps) {
+  static char[] intersectKeys(long[] words, RoaringBitmap... bitmaps) {
     RoaringBitmap first = bitmaps[0];
     for (int i = 0; i < first.highLowContainer.size; ++i) {
       char key = first.highLowContainer.keys[i];

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestFastAggregation.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestFastAggregation.java
@@ -278,4 +278,21 @@ public class TestFastAggregation {
       assertEquals(or.getCardinality(), orCardinality);
     }
   }
+
+  @MethodSource("bitmaps")
+  @ParameterizedTest()
+  public void testOrWithContext(List<RoaringBitmap> list) {
+    RoaringBitmap[] toUnite = new RoaringBitmap[list.size() - 1];
+    for (int i = 0; i < list.size(); i++) {
+      RoaringBitmap toIntersect = list.get(i);
+      for (int j = 0, k = 0; j < list.size(); j++) {
+        if (j != i) {
+          toUnite[k++] = list.get(j);
+        }
+      }
+      RoaringBitmap candidate = FastAggregation.orWithContext(toIntersect, toUnite);
+      RoaringBitmap baseline = RoaringBitmap.and(toIntersect, FastAggregation.or(toUnite));
+      assertEquals(baseline.getCardinality(), candidate.getCardinality());
+    }
+  }
 }


### PR DESCRIPTION
### SUMMARY
Adds a new method to `FastAggregation` to allow a large union which will later be intersected with a smaller bitmap to be executed in the context of the intersection to be performed later. The motivation is large IN clauses intersected with other filters within WHERE clauses, e.g.

```sql
select * from table 
where x in (<huge list>)
and <some selective condition>
```

This could be implemented two ways as a user of the library at present:

1. materialise the in clause with `FastAggregation.or`
```java
     RoaringBitmap.and(toIntersect, FastAggregation.or(toUnite))
```

2. avoid materialising the in clause by intersecting the other filter with every single condition specified by the in clause.
```java
    RoaringBitmap result = new RoaringBitmap();
    for (RoaringBitmap bitmap : toUnite) {
      result.or(RoaringBitmap.and(toIntersect, bitmap));
    }
```

I benchmark against each of these. There are some cases in my simplistic benchmarks where the end user code wins by a little, but there are cases where the new approach wins by a lot. The goal is to provide an implementation of this common combined aggregation which would be the one you would pick if you could only pick one by being the quickest on average across scenarios.

```
Benchmark                                    (keysInIntersection)  (scenario)  (unionSize)   Mode  Cnt      Score      Error  Units
IntersectionPushdownBenchmark.andEachThenOr                    10       EQUAL           10  thrpt    5   1202.606 ±  517.195  ops/s
IntersectionPushdownBenchmark.orThenAnd                        10       EQUAL           10  thrpt    5   3257.376 ± 2000.025  ops/s
IntersectionPushdownBenchmark.orWithContext                    10       EQUAL           10  thrpt    5   3240.571 ±  118.866  ops/s

IntersectionPushdownBenchmark.andEachThenOr                    10       EQUAL          100  thrpt    5    120.835 ±    4.270  ops/s
IntersectionPushdownBenchmark.orThenAnd                        10       EQUAL          100  thrpt    5    443.392 ±    4.927  ops/s
IntersectionPushdownBenchmark.orWithContext                    10       EQUAL          100  thrpt    5    447.023 ±   20.983  ops/s

IntersectionPushdownBenchmark.andEachThenOr                    10       STEPS           10  thrpt    5  22426.356 ± 7885.007  ops/s
IntersectionPushdownBenchmark.orThenAnd                        10       STEPS           10  thrpt    5  18181.527 ± 1843.511  ops/s
IntersectionPushdownBenchmark.orWithContext                    10       STEPS           10  thrpt    5  20679.570 ±  775.225  ops/s

IntersectionPushdownBenchmark.andEachThenOr                    10       STEPS          100  thrpt    5  22711.372 ± 7253.271  ops/s
IntersectionPushdownBenchmark.orThenAnd                        10       STEPS          100  thrpt    5   5619.156 ±   71.067  ops/s
IntersectionPushdownBenchmark.orWithContext                    10       STEPS          100  thrpt    5  17813.704 ± 1690.157  ops/s

IntersectionPushdownBenchmark.andEachThenOr                   100       EQUAL           10  thrpt    5    135.118 ±    1.941  ops/s
IntersectionPushdownBenchmark.orThenAnd                       100       EQUAL           10  thrpt    5    359.642 ±    3.402  ops/s
IntersectionPushdownBenchmark.orWithContext                   100       EQUAL           10  thrpt    5    328.085 ±   11.337  ops/s

IntersectionPushdownBenchmark.andEachThenOr                   100       EQUAL          100  thrpt    5     12.512 ±    0.234  ops/s
IntersectionPushdownBenchmark.orThenAnd                       100       EQUAL          100  thrpt    5     48.731 ±    0.164  ops/s
IntersectionPushdownBenchmark.orWithContext                   100       EQUAL          100  thrpt    5     49.631 ±    1.425  ops/s

IntersectionPushdownBenchmark.andEachThenOr                   100       STEPS           10  thrpt    5   1742.549 ±   62.649  ops/s
IntersectionPushdownBenchmark.orThenAnd                       100       STEPS           10  thrpt    5   1583.091 ±   16.104  ops/s
IntersectionPushdownBenchmark.orWithContext                   100       STEPS           10  thrpt    5   1157.314 ±   11.057  ops/s

IntersectionPushdownBenchmark.andEachThenOr                   100       STEPS          100  thrpt    5   1697.878 ±   54.095  ops/s
IntersectionPushdownBenchmark.orThenAnd                       100       STEPS          100  thrpt    5    360.201 ±   14.722  ops/s
IntersectionPushdownBenchmark.orWithContext                   100       STEPS          100  thrpt    5   1133.666 ±   36.484  ops/s

IntersectionPushdownBenchmark.andEachThenOr                  1000       EQUAL           10  thrpt    5     13.444 ±    0.155  ops/s
IntersectionPushdownBenchmark.orThenAnd                      1000       EQUAL           10  thrpt    5     35.400 ±    0.775  ops/s
IntersectionPushdownBenchmark.orWithContext                  1000       EQUAL           10  thrpt    5     33.820 ±    1.003  ops/s

IntersectionPushdownBenchmark.andEachThenOr                  1000       EQUAL          100  thrpt    5      1.245 ±    0.011  ops/s
IntersectionPushdownBenchmark.orThenAnd                      1000       EQUAL          100  thrpt    5      4.879 ±    0.060  ops/s
IntersectionPushdownBenchmark.orWithContext                  1000       EQUAL          100  thrpt    5      4.928 ±    0.153  ops/s

IntersectionPushdownBenchmark.andEachThenOr                  1000       STEPS           10  thrpt    5    182.167 ±    4.351  ops/s
IntersectionPushdownBenchmark.orThenAnd                      1000       STEPS           10  thrpt    5    134.971 ±    1.055  ops/s
IntersectionPushdownBenchmark.orWithContext                  1000       STEPS           10  thrpt    5    118.371 ±    1.635  ops/s

IntersectionPushdownBenchmark.andEachThenOr                  1000       STEPS          100  thrpt    5     82.605 ±   36.085  ops/s
IntersectionPushdownBenchmark.orThenAnd                      1000       STEPS          100  thrpt    5      2.289 ±    1.291  ops/s
IntersectionPushdownBenchmark.orWithContext                  1000       STEPS          100  thrpt    5     86.826 ±    2.106  ops/s
```

The approach is to iterate the keys of the later-intersected bitmap and perform the union of the other bitmaps only for these keys, before intersecting and appending to the result bitmap. This allows to use a controlled amount of memory by doing the union of each container into an 8kB bitset, which avoids allocation of extra storage in array and run containers, as well as avoiding reallocating containers to adaptively choose the best container - this work is delayed until just before appending. 

I benchmarked two main cases: where all the bitmaps are equal, so performance should be similar to or then add, and a contrived case to illustrate the strength of this approach: when the united bitmaps are disjoint with each other (STEPS) and the intersected bitmap only intersects with one of the bitmaps in the IN clause.


### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
