### PR TITLE
Avoid intersecting with containers that are already empty

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/FastAggregation.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/FastAggregation.java
@@ -373,6 +373,7 @@ public final class FastAggregation {
     }
 
     RoaringArray array = new RoaringArray(keys, new Container[numContainers], 0);
+    outer:
     for (int i = 0; i < numContainers; ++i) {
       Container[] slice = containers[i];
       Arrays.fill(words, -1L);
@@ -384,6 +385,9 @@ public final class FastAggregation {
         Container and = tmp.iand(container);
         if (and != tmp) {
           tmp = and;
+        }
+        if (tmp.isEmpty()) {
+          continue outer;
         }
       }
       tmp = tmp.repairAfterLazy();
@@ -402,14 +406,12 @@ public final class FastAggregation {
     }
     int numKeys = keys.length;
     int cardinality = 0;
+    outer:
     for (int i = 0; i < numKeys; i++) {
       Arrays.fill(words, -1L);
       Container tmp = new BitmapContainer(words, -1);
       for (RoaringBitmap bitmap : bitmaps) {
         int index = bitmap.highLowContainer.getIndex(keys[i]);
-        if (index < 0) {
-          continue;
-        }
         Container container = bitmap.highLowContainer.getContainerAtIndex(index);
         // We only assign to 'tmp' when 'tmp != tmp.iand(container)'
         // as a garbage-collection optimization: we want to avoid
@@ -417,6 +419,9 @@ public final class FastAggregation {
         Container and = tmp.iand(container);
         if (and != tmp) {
           tmp = and;
+        }
+        if (tmp.isEmpty()) {
+          continue outer;
         }
       }
       cardinality += tmp.repairAfterLazy().getCardinality();
@@ -483,15 +488,13 @@ public final class FastAggregation {
     int numContainers = keys.length;
 
     RoaringArray array = new RoaringArray(keys, new Container[numContainers], 0);
+    outer:
     for (int i = 0; i < numContainers; ++i) {
       char MatchingKey = keys[i];
       Arrays.fill(words, -1L);
       Container tmp = new BitmapContainer(words, -1);
       for (RoaringBitmap bitmap : bitmaps) {
         int idx = bitmap.highLowContainer.getIndex(MatchingKey);
-        if (idx < 0) {
-          continue;
-        }
         Container container = bitmap.highLowContainer.getContainerAtIndex(idx);
         // We only assign to 'tmp' when 'tmp != tmp.iand(container)'
         // as a garbage-collection optimization: we want to avoid
@@ -499,6 +502,9 @@ public final class FastAggregation {
         Container and = tmp.iand(container);
         if (and != tmp) {
           tmp = and;
+        }
+        if (tmp.isEmpty()) {
+          continue outer;
         }
       }
       tmp = tmp.repairAfterLazy();


### PR DESCRIPTION
### SUMMARY
Avoids intersecting with containers that are already empty and removes an unnecessary check for empty containers.  

This change is inspired by the implementation provided in #815.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
