### PR TITLE
bitmaps serialized with runs should have runs

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
@@ -293,6 +293,17 @@ public final class RoaringArray implements Cloneable, Externalizable, Appendable
     if (hasrun) {
       bitmapOfRunContainers = new byte[(size + 7) / 8];
       in.readFully(bitmapOfRunContainers);
+      boolean hasNonZero = false;
+      for (byte b : bitmapOfRunContainers) {
+        if (b != 0) {
+          hasNonZero = true;
+          break;
+        }
+      }
+      if (!hasNonZero) {
+        throw new InvalidRoaringFormat(
+            "You indicated the presence of run containers but none were found.");
+      }
     }
 
     final char[] keys = new char[this.size];
@@ -389,6 +400,17 @@ public final class RoaringArray implements Cloneable, Externalizable, Appendable
     if (hasrun) {
       bitmapOfRunContainers = new byte[(size + 7) / 8];
       in.readFully(bitmapOfRunContainers);
+      boolean hasNonZero = false;
+      for (byte b : bitmapOfRunContainers) {
+        if (b != 0) {
+          hasNonZero = true;
+          break;
+        }
+      }
+      if (!hasNonZero) {
+        throw new InvalidRoaringFormat(
+            "You indicated the presence of run containers but none were found.");
+      }
     }
 
     final char[] keys = new char[this.size];
@@ -571,6 +593,17 @@ public final class RoaringArray implements Cloneable, Externalizable, Appendable
     if (hasrun) {
       bitmapOfRunContainers = new byte[(size + 7) / 8];
       buffer.get(bitmapOfRunContainers);
+      boolean hasNonZero = false;
+      for (byte b : bitmapOfRunContainers) {
+        if (b != 0) {
+          hasNonZero = true;
+          break;
+        }
+      }
+      if (!hasNonZero) {
+        throw new InvalidRoaringFormat(
+            "You indicated the presence of run containers but none were found.");
+      }
     }
 
     final char[] keys = new char[this.size];

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
@@ -333,6 +333,17 @@ public final class MutableRoaringArray
     if (hasrun) {
       bitmapOfRunContainers = new byte[(size + 7) / 8];
       in.readFully(bitmapOfRunContainers);
+      boolean hasNonZero = false;
+      for (byte b : bitmapOfRunContainers) {
+        if (b != 0) {
+          hasNonZero = true;
+          break;
+        }
+      }
+      if (!hasNonZero) {
+        throw new InvalidRoaringFormat(
+            "You indicated the presence of run containers but none were found.");
+      }
     }
 
     final char keys[] = new char[this.size];
@@ -422,6 +433,17 @@ public final class MutableRoaringArray
     if (hasrun) {
       bitmapOfRunContainers = new byte[(size + 7) / 8];
       buffer.get(bitmapOfRunContainers);
+      boolean hasNonZero = false;
+      for (byte b : bitmapOfRunContainers) {
+        if (b != 0) {
+          hasNonZero = true;
+          break;
+        }
+      }
+      if (!hasNonZero) {
+        throw new InvalidRoaringFormat(
+            "You indicated the presence of run containers but none were found.");
+      }
     }
 
     final char[] keys = new char[this.size];


### PR DESCRIPTION
Adding a sanity check during deserialization.