### PR TITLE
Replace consecutive char array filling with copying of a pre-allocated array

### DIFF
--- a/jmh/src/jmh/java/org/roaringbitmap/CharRangeFillerBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/CharRangeFillerBenchmark.java
@@ -1,0 +1,57 @@
+package org.roaringbitmap;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, timeUnit = TimeUnit.MILLISECONDS, time = 200)
+@Measurement(iterations = 10, timeUnit = TimeUnit.MILLISECONDS, time = 200)
+@BenchmarkMode(Mode.Throughput)
+@Fork(
+    value = 1,
+    jvmArgsPrepend = {
+      "-XX:+UseG1GC",
+      "-XX:-TieredCompilation",
+      "-XX:+AlwaysPreTouch",
+      "-ms4G",
+      "-mx4G"
+    })
+public class CharRangeFillerBenchmark {
+
+  @Param({
+    // "11", // set CharRangeFiller.USE_ARRAYCOPY_MIN_SIZE < 12
+    "12",
+    "16",
+    "100",
+    "4096",
+    "16384",
+  })
+  public int length;
+
+  public char[] a;
+
+  private static final int DESTINATION_OFFSET = 100;
+
+  @Setup
+  public void prepare() {
+    CharRangeFiller.allocate(Character.MAX_VALUE);
+    a = new char[length + DESTINATION_OFFSET];
+  }
+
+  @Benchmark
+  public void arraycopy(Blackhole blackhole) {
+    CharRangeFiller.fill(a, DESTINATION_OFFSET, 0, length);
+    blackhole.consume(a);
+  }
+
+  @Benchmark
+  public void iteratively(Blackhole blackhole) {
+    for (int i = 0, j = DESTINATION_OFFSET; i < length; i++, j++) {
+      a[j] = (char) i;
+    }
+    blackhole.consume(a);
+  }
+}

--- a/jmh/src/jmh/java/org/roaringbitmap/CharRangeFillerUsedInArrayContainerBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/CharRangeFillerUsedInArrayContainerBenchmark.java
@@ -1,0 +1,57 @@
+package org.roaringbitmap;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, timeUnit = TimeUnit.MILLISECONDS, time = 200)
+@Measurement(iterations = 10, timeUnit = TimeUnit.MILLISECONDS, time = 200)
+@BenchmarkMode(Mode.Throughput)
+@Fork(
+    value = 1,
+    jvmArgsPrepend = {
+      "-XX:+UseG1GC",
+      "-XX:-TieredCompilation",
+      "-XX:+AlwaysPreTouch",
+      "-ms4G",
+      "-mx4G"
+    })
+public class CharRangeFillerUsedInArrayContainerBenchmark {
+
+  @Param({"10", "100", "4096"})
+  public int length;
+
+  public char[] a;
+
+  private static final int DESTINATION_OFFSET = 100;
+
+  @Setup
+  public void prepare() {
+    CharRangeFiller.allocate(Character.MAX_VALUE);
+    a = new char[length + DESTINATION_OFFSET];
+  }
+
+  @Benchmark
+  public void arraycopy(Blackhole blackhole) {
+    blackhole.consume(new ArrayContainer(0, length));
+  }
+
+  @Benchmark
+  public void iteratively(Blackhole blackhole) {
+    blackhole.consume(newArrayContainerOriginal(0, length));
+  }
+
+  public ArrayContainer newArrayContainerOriginal(final int firstOfRun, final int lastOfRun) {
+    ArrayContainer ac = new ArrayContainer(length);
+    final int valuesInRange = lastOfRun - firstOfRun;
+    ac.content = new char[valuesInRange];
+    for (int i = 0; i < valuesInRange; ++i) {
+      ac.content[i] = (char) (firstOfRun + i);
+    }
+    ac.cardinality = valuesInRange;
+    return ac;
+  }
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -68,9 +68,7 @@ public final class ArrayContainer extends Container implements Cloneable {
   public ArrayContainer(final int firstOfRun, final int lastOfRun) {
     final int valuesInRange = lastOfRun - firstOfRun;
     this.content = new char[valuesInRange];
-    for (int i = 0; i < valuesInRange; ++i) {
-      content[i] = (char) (firstOfRun + i);
-    }
+    CharRangeFiller.fill(content, 0, firstOfRun, lastOfRun);
     cardinality = valuesInRange;
   }
 
@@ -128,9 +126,7 @@ public final class ArrayContainer extends Container implements Cloneable {
     ArrayContainer answer = new ArrayContainer(newcardinality, content);
     System.arraycopy(
         content, indexend, answer.content, indexstart + rangelength, cardinality - indexend);
-    for (int k = 0; k < rangelength; ++k) {
-      answer.content[k + indexstart] = (char) (begin + k);
-    }
+    CharRangeFiller.fill(answer.content, indexstart, begin, end);
     answer.cardinality = newcardinality;
     return answer;
   }
@@ -516,9 +512,7 @@ public final class ArrayContainer extends Container implements Cloneable {
       // if b > 0, we copy from 0 to b. Do nothing otherwise.
       System.arraycopy(content, 0, destination, 0, indexstart);
       // set values from b to e
-      for (int k = 0; k < rangelength; ++k) {
-        destination[k + indexstart] = (char) (begin + k);
-      }
+      CharRangeFiller.fill(destination, indexstart, begin, begin + rangelength);
       /*
        * so far cases - 1,2 and 6 are done Now, if e < cardinality, we copy from e to
        * cardinality.Otherwise do noting this covers remaining 3,4 and 5 cases
@@ -529,9 +523,7 @@ public final class ArrayContainer extends Container implements Cloneable {
     } else {
       System.arraycopy(
           content, indexend, content, indexstart + rangelength, cardinality - indexend);
-      for (int k = 0; k < rangelength; ++k) {
-        content[k + indexstart] = (char) (begin + k);
-      }
+      CharRangeFiller.fill(content, indexstart, begin, begin + rangelength);
     }
     cardinality = newcardinality;
     return this;
@@ -888,9 +880,8 @@ public final class ArrayContainer extends Container implements Cloneable {
 
     // if there are extra items (greater than the biggest
     // pre-existing one in range), buffer them
-    for (; valInRange < lastRange; ++valInRange) {
-      buffer[outPos++] = (char) valInRange;
-    }
+    CharRangeFiller.fill(buffer, outPos, valInRange, lastRange);
+    outPos += lastRange - valInRange;
 
     if (outPos != buffer.length) {
       throw new RuntimeException(
@@ -948,14 +939,11 @@ public final class ArrayContainer extends Container implements Cloneable {
       }
     }
 
-    for (; valInRange < lastOfRange; ++valInRange) {
-      answer.content[outPos++] = (char) valInRange;
-    }
+    CharRangeFiller.fill(answer.content, outPos, valInRange, lastOfRange);
+    outPos += lastOfRange - valInRange;
 
-    // content after the active range
-    for (int i = lastIndex + 1; i < cardinality; ++i) {
-      answer.content[outPos++] = content[i];
-    }
+    System.arraycopy(content, lastIndex + 1, answer.content, outPos, cardinality - lastIndex - 1);
+
     answer.cardinality = newCardinality;
     return answer;
   }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/CharRangeFiller.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/CharRangeFiller.java
@@ -1,0 +1,109 @@
+package org.roaringbitmap;
+
+/**
+ * Provides more performant way to fill char array by chars with consecutive codes. It is necessary
+ * to call {@link CharRangeFiller#allocate(char)} before use, otherwise simple (and slow) loop is
+ * used only. Maximum of used memory is 128 kB, when all characters range is used.
+ */
+public class CharRangeFiller {
+  static final int USE_ARRAYCOPY_MIN_SIZE = 12; // determined empirically via benchmarking
+  private static char[] CHARS = new char[0];
+
+  static void fillIteratively(char[] a, int pos, int from, int to) {
+    for (int i = 0; i < to - from; i++) {
+      a[pos + i] = (char) (from + i);
+    }
+  }
+
+  /**
+   * Allocates char array for complete char range.
+   */
+  public static void allocateCompletely() {
+    allocate(Character.MAX_VALUE);
+  }
+
+  /**
+   * Allocates char array from zero to up to given character.
+   *
+   * @param last last allocated character
+   */
+  public static void allocate(char last) {
+    int length = last + 1; // + 1 to have space for null character
+    char[] oldChars = CHARS; // grab reference first to be thread-safe
+    if (length != oldChars.length) {
+      char[] newChars = new char[length];
+      int copied = Math.min(length, oldChars.length);
+      System.arraycopy(oldChars, 0, newChars, 0, copied);
+      fillIteratively(newChars, copied, copied, length);
+      CHARS = newChars;
+    }
+  }
+
+  /**
+   * Deallocates char array.
+   */
+  public static void deallocate() {
+    CHARS = new char[0];
+  }
+
+  /**
+   * Returns length of allocated char array.
+   *
+   * @return array length
+   */
+  public static int length() {
+    return CHARS.length;
+  }
+
+  /**
+   * Fills natural numbers to array effectively using pre-allocated char array. If range to fill is
+   * too small (several characters), it falls back to simple loop iterating on array as it is more
+   * performant for such cases or when pre-allocated array does not contain values from filled
+   * range. The length of copied sequence is {@code to - from}. The array could have length greater
+   * than char range even it is not expected to happen.
+   *
+   * @param a    destination char array
+   * @param pos  start position in destination array
+   * @param from first character code (inclusive)
+   * @param to   last character code (exclusive)
+   * @throws IndexOutOfBoundsException if @{code pos} is negative, any value of given range is
+   *                                   outside char range or filled range does not fit into array
+   */
+  public static void fill(char[] a, int pos, int from, int to) {
+    if (pos < 0) {
+      throw new IndexOutOfBoundsException("target position could not be negative: " + pos);
+    }
+    if (from < 0 || from > Character.MAX_VALUE || to < 0 || to > Character.MAX_VALUE + 1) {
+      throw new IndexOutOfBoundsException(
+          "values range has to be within char range: (" + from + "," + to + ")");
+    }
+    if (from >= to) {
+      return;
+    }
+    if (to - from + pos > a.length) {
+      throw new IndexOutOfBoundsException(
+          "array length "
+              + a.length
+              + " is too small to fill characters from "
+              + from
+              + " to "
+              + to
+              + " from "
+              + pos
+              + ". position");
+    }
+    final char[] naturals = CHARS; // grab reference first to be thread-safe
+    int copyTo = Math.min(to, naturals.length);
+    int iterateFrom;
+    int targetFrom;
+    if (USE_ARRAYCOPY_MIN_SIZE <= copyTo - from) {
+      iterateFrom = copyTo;
+      targetFrom = pos + copyTo - from;
+      System.arraycopy(naturals, from, a, pos, copyTo - from);
+    } else {
+      iterateFrom = from;
+      targetFrom = pos;
+    }
+    fillIteratively(a, targetFrom, iterateFrom, to);
+  }
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RunContainer.java
@@ -2305,7 +2305,6 @@ public final class RunContainer extends Container implements Cloneable {
    * @return new container
    */
   Container toBitmapOrArrayContainer(int card) {
-    // int card = this.getCardinality();
     if (card <= ArrayContainer.DEFAULT_MAX_SIZE) {
       ArrayContainer answer = new ArrayContainer(card);
       answer.cardinality = 0;
@@ -2313,9 +2312,8 @@ public final class RunContainer extends Container implements Cloneable {
         int runStart = (this.getValue(rlepos));
         int runEnd = runStart + (this.getLength(rlepos));
 
-        for (int runValue = runStart; runValue <= runEnd; ++runValue) {
-          answer.content[answer.cardinality++] = (char) runValue;
-        }
+        CharRangeFiller.fill(answer.content, answer.cardinality, runStart, runEnd + 1);
+        answer.cardinality += runEnd + 1 - runStart;
       }
       return answer;
     }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/insights/BitmapStatistics.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/insights/BitmapStatistics.java
@@ -1,28 +1,33 @@
 package org.roaringbitmap.insights;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 public class BitmapStatistics {
   private final long bitmapsCount;
   private final ArrayContainersStats arrayContainersStats;
+  private final RunContainersStats runContainersStats;
   private final long bitmapContainerCount;
   private final long runContainerCount;
 
   BitmapStatistics(
       ArrayContainersStats arrayContainersStats,
+      RunContainersStats runContainersStats,
       long bitmapContainerCount,
       long runContainerCount) {
 
-    this(arrayContainersStats, bitmapContainerCount, runContainerCount, 1);
+    this(arrayContainersStats, runContainersStats, bitmapContainerCount, runContainerCount, 1);
   }
 
   BitmapStatistics(
       ArrayContainersStats arrayContainersStats,
+      RunContainersStats runContainersStats,
       long bitmapContainerCount,
       long runContainerCount,
       long bitmapsCount) {
 
     this.arrayContainersStats = arrayContainersStats;
+    this.runContainersStats = runContainersStats;
     this.bitmapContainerCount = bitmapContainerCount;
     this.runContainerCount = runContainerCount;
     this.bitmapsCount = bitmapsCount;
@@ -45,6 +50,10 @@ public class BitmapStatistics {
     return arrayContainersStats;
   }
 
+  public RunContainersStats getRunContainersStats() {
+    return runContainersStats;
+  }
+
   @Override
   public String toString() {
     return "BitmapStatistics{"
@@ -52,6 +61,8 @@ public class BitmapStatistics {
         + bitmapsCount
         + ", arrayContainersStats="
         + arrayContainersStats
+        + ", runContainersStats="
+        + runContainersStats
         + ", bitmapContainerCount="
         + bitmapContainerCount
         + ", runContainerCount="
@@ -66,13 +77,14 @@ public class BitmapStatistics {
   BitmapStatistics merge(BitmapStatistics other) {
     return new BitmapStatistics(
         arrayContainersStats.merge(other.arrayContainersStats),
+        runContainersStats.merge(other.runContainersStats),
         bitmapContainerCount + other.bitmapContainerCount,
         runContainerCount + other.runContainerCount,
         bitmapsCount + other.bitmapsCount);
   }
 
   public static final BitmapStatistics empty =
-      new BitmapStatistics(ArrayContainersStats.empty, 0, 0, 0);
+      new BitmapStatistics(ArrayContainersStats.empty, RunContainersStats.empty, 0, 0, 0);
 
   @Override
   public boolean equals(Object o) {
@@ -86,7 +98,8 @@ public class BitmapStatistics {
     return bitmapsCount == that.bitmapsCount
         && bitmapContainerCount == that.bitmapContainerCount
         && runContainerCount == that.runContainerCount
-        && Objects.equals(arrayContainersStats, that.arrayContainersStats);
+        && Objects.equals(arrayContainersStats, that.arrayContainersStats)
+        && Objects.equals(runContainersStats, that.runContainersStats);
   }
 
   @Override
@@ -169,5 +182,100 @@ public class BitmapStatistics {
     }
 
     public static final ArrayContainersStats empty = new ArrayContainersStats(0, 0);
+  }
+
+  public static class RunContainersStats {
+    private final long runsCount;
+    private final long cardinalitySum;
+    private final int[] runLengthHistogram; // length is always 16
+
+    public long getRunsCount() {
+      return runsCount;
+    }
+
+    public long getCardinalitySum() {
+      return cardinalitySum;
+    }
+
+    public int[] getRunLengthHistogram() {
+      return runLengthHistogram;
+    }
+
+    RunContainersStats(long runsCount, long cardinalitySum, int[] runLengthHistogram) {
+      this.runsCount = runsCount;
+      this.cardinalitySum = cardinalitySum;
+      this.runLengthHistogram = runLengthHistogram;
+    }
+
+    RunContainersStats merge(RunContainersStats other) {
+      return new RunContainersStats(
+          runsCount + other.runsCount,
+          cardinalitySum + other.cardinalitySum,
+          addArrays(runLengthHistogram, other.runLengthHistogram));
+    }
+
+    private static int[] addArrays(int[] a, int[] b) {
+      int[] c = new int[a.length];
+      for (int i = 0; i < a.length; i++) {
+        c[i] = a[i] + b[i];
+      }
+      return c;
+    }
+
+    /**
+     * Average run length
+     *
+     * @return the average
+     */
+    public long averageRunLength() {
+      if (runsCount == 0) {
+        return Long.MAX_VALUE;
+      } else {
+        return cardinalitySum / runsCount;
+      }
+    }
+
+    // TODO very disputable - at least due to use magic constant 70, above that averageRunLength
+    // should be involved also
+    public boolean hasManyLongRuns() {
+      int sum = 0;
+      for (int i = 0; i < 12; i++) {
+        sum += runLengthHistogram[i] * (12 - i); // linear weighting, not by powers of two
+      }
+      return sum > 70;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      RunContainersStats that = (RunContainersStats) o;
+      return runsCount == that.runsCount
+          && cardinalitySum == that.cardinalitySum
+          && Arrays.equals(runLengthHistogram, that.runLengthHistogram);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(runsCount, cardinalitySum, Arrays.hashCode(runLengthHistogram));
+    }
+
+    @Override
+    public String toString() {
+      return "RunContainersStats{"
+          + "runsCount="
+          + runsCount
+          + ", runLengthHistogram="
+          + Arrays.toString(runLengthHistogram)
+          + ", cardinalitySum="
+          + cardinalitySum
+          + '}';
+    }
+
+    public static final RunContainersStats empty = new RunContainersStats(0, 0, new int[16]);
   }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/CharRangeFillerTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/CharRangeFillerTest.java
@@ -1,0 +1,237 @@
+package org.roaringbitmap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+class CharRangeFillerTest {
+
+  @Test
+  void deallocate() {
+    CharRangeFiller.allocate((char) 12345);
+    CharRangeFiller.deallocate();
+    assertEquals(0, CharRangeFiller.length());
+  }
+
+  @Test
+  void completeRangeAllocated() {
+    CharRangeFiller.deallocate();
+    CharRangeFiller.allocate(Character.MAX_VALUE);
+    assertEquals(Character.MAX_VALUE + 1, CharRangeFiller.length());
+  }
+
+  @Test
+  void allocateCompletely() {
+    CharRangeFiller.deallocate();
+    CharRangeFiller.allocateCompletely();
+    assertEquals(Character.MAX_VALUE + 1, CharRangeFiller.length());
+  }
+
+  @Test
+  void partOfRangeAllocated() {
+    CharRangeFiller.deallocate();
+    CharRangeFiller.allocate((char) 12345);
+    assertEquals(12345 + 1, CharRangeFiller.length());
+  }
+
+  @Test
+  void allocatedNullCharOnly() {
+    CharRangeFiller.deallocate();
+    CharRangeFiller.allocate((char) 0);
+    assertEquals(1, CharRangeFiller.length());
+  }
+
+  @Test
+  void fillFromMoreThanTo() {
+    char[] filled = new char[200];
+    CharRangeFiller.fill(filled, 0, 200, 100);
+    assertArrayEquals(new char[200], filled);
+  }
+
+  @Test
+  void fillMoreThanSizeArray() {
+    assertThrows(
+        IndexOutOfBoundsException.class,
+        () -> {
+          CharRangeFiller.fill(new char[200], 0, 0, 201);
+        });
+  }
+
+  @Test
+  void fillFromNegativeIndex() {
+    assertThrows(
+        IndexOutOfBoundsException.class,
+        () -> {
+          CharRangeFiller.fill(new char[200], -10, 0, 100);
+        });
+  }
+
+  @Test
+  void fillIndexesAroundCharacterRange() {
+    // test included even CharRangeFiller is not used with char array of such length
+    char[] expected = new char[Character.MAX_VALUE + 200];
+    expected[Character.MAX_VALUE] = 1;
+    expected[Character.MAX_VALUE + 1] = 2;
+    expected[Character.MAX_VALUE + 2] = 3;
+    char[] filled = new char[Character.MAX_VALUE + 200];
+    CharRangeFiller.fill(filled, Character.MAX_VALUE, 1, 4);
+    assertArrayEquals(expected, filled);
+  }
+
+  @Test
+  void fillFromIndexOutsideCharacterRange() {
+    // test included even CharRangeFiller is not used with char array of such length
+    char[] expected = new char[Character.MAX_VALUE + 200];
+    expected[Character.MAX_VALUE + 1] = 1;
+    expected[Character.MAX_VALUE + 2] = 2;
+    char[] filled = new char[Character.MAX_VALUE + 200];
+    CharRangeFiller.fill(filled, Character.MAX_VALUE + 1, 1, 3);
+    assertArrayEquals(expected, filled);
+  }
+
+  @Test
+  void fillFromNegativeValue() {
+    assertThrows(
+        IndexOutOfBoundsException.class,
+        () -> {
+          CharRangeFiller.fill(new char[200], 0, -1, 100);
+        });
+  }
+
+  @Test
+  void fillFromValueOutOfCharRange() {
+    assertThrows(
+        IndexOutOfBoundsException.class,
+        () -> {
+          CharRangeFiller.fill(new char[200], 0, Character.MAX_VALUE + 1, 100);
+        });
+  }
+
+  @Test
+  void fillToNegativeValue() {
+    assertThrows(
+        IndexOutOfBoundsException.class,
+        () -> {
+          CharRangeFiller.fill(new char[200], 0, 0, -1);
+        });
+  }
+
+  @Test
+  void fillToValueOutOfCharRange() {
+    assertThrows(
+        IndexOutOfBoundsException.class,
+        () -> {
+          CharRangeFiller.fill(new char[200], 0, Character.MAX_VALUE, Character.MAX_VALUE + 2);
+        });
+  }
+
+  @Test
+  void fillToTooLargeIndex() {
+    assertThrows(
+        IndexOutOfBoundsException.class,
+        () -> {
+          CharRangeFiller.fill(new char[200], 300, 0, 100);
+        });
+  }
+
+  @Test
+  void fillEmptyRange() {
+    CharRangeFiller.allocate((char) (300));
+    char[] filled = new char[300];
+    CharRangeFiller.fill(filled, 0, 200, 200);
+    assertArrayEquals(new char[300], filled);
+  }
+
+  @Test
+  void fillEmptyRangeFromIsGreaterThanTo() {
+    CharRangeFiller.allocate((char) (300));
+    char[] filled = new char[300];
+    CharRangeFiller.fill(filled, 0, 201, 200);
+    assertArrayEquals(new char[300], filled);
+  }
+
+  public static Stream<Arguments> outsideAllocatedRange() {
+    List<Arguments> cases = new ArrayList<>();
+    int[] allocated = new int[] {1000, Character.MAX_VALUE - 1, Character.MAX_VALUE};
+    for (int i = 0; i < allocated.length; i++) {
+      int ALLOCATED = allocated[i];
+      int IN_RANGE = ALLOCATED - 100;
+      int OUT_OF_RANGE = ALLOCATED + 100;
+      int[] pos = new int[] {IN_RANGE, ALLOCATED, OUT_OF_RANGE};
+      for (int j = 0; j < pos.length; j++) {
+        int POS = pos[j];
+        cases.add(Arguments.of(ALLOCATED, POS, IN_RANGE, ALLOCATED - 1));
+        cases.add(Arguments.of(ALLOCATED, POS, IN_RANGE, ALLOCATED));
+        if (ALLOCATED + 1 <= Character.MAX_VALUE) {
+          cases.add(Arguments.of(ALLOCATED, POS, IN_RANGE, ALLOCATED + 1));
+        }
+        if (OUT_OF_RANGE <= Character.MAX_VALUE) {
+          cases.add(Arguments.of(ALLOCATED, POS, ALLOCATED - 1, OUT_OF_RANGE));
+          cases.add(Arguments.of(ALLOCATED, POS, ALLOCATED + 0, OUT_OF_RANGE));
+          cases.add(Arguments.of(ALLOCATED, POS, ALLOCATED + 1, OUT_OF_RANGE));
+          cases.add(Arguments.of((char) ALLOCATED, POS, IN_RANGE, OUT_OF_RANGE));
+        }
+        if (OUT_OF_RANGE + 10 <= Character.MAX_VALUE) {
+          cases.add(Arguments.of(ALLOCATED, POS, OUT_OF_RANGE, OUT_OF_RANGE + 10));
+        }
+      }
+    }
+    for (int pos = 0; pos < 3; pos++) {
+      for (int allocated2 = 0; allocated2 < 3; allocated2++) {
+        for (int from = 0; from < 2; from++) {
+          for (int to = from + 1; to < 3; to++) {
+            cases.add(Arguments.of(allocated2, pos, from, to));
+          }
+        }
+      }
+    }
+    return cases.stream();
+  }
+
+  @ParameterizedTest
+  @MethodSource("outsideAllocatedRange")
+  void fillOutsideAllocatedRange(int allocated, int pos, int from, int to) {
+    CharRangeFiller.allocate((char) allocated);
+    char[] expected = new char[allocated + pos + 10];
+    char[] tested = new char[allocated + pos + 10];
+    CharRangeFiller.fillIteratively(expected, pos, from, to);
+    CharRangeFiller.fill(tested, pos, from, to);
+    assertArrayEquals(expected, tested);
+  }
+
+  @Test
+  void fillIterativelyAndUsingArraycopyComparison() {
+    CharRangeFiller.allocate(Character.MAX_VALUE);
+    for (int offset = 0; offset < 100; offset += 10) {
+      for (int from = 0; from < 10; from += 3) {
+        for (int to = from + CharRangeFiller.USE_ARRAYCOPY_MIN_SIZE; to < from + 100; to += 15) {
+          char[] a = new char[210];
+          char[] b = new char[210];
+          CharRangeFiller.fillIteratively(a, offset, from, to);
+          CharRangeFiller.fill(b, offset, from, to);
+          assertArrayEquals(
+              a,
+              b,
+              "dest offset: "
+                  + offset
+                  + ", range: "
+                  + from
+                  + "-"
+                  + to
+                  + "\r\n"
+                  + Arrays.toString(a)
+                  + "\r\n"
+                  + Arrays.toString(b));
+        }
+      }
+    }
+  }
+}

--- a/roaringbitmap/src/test/java/org/roaringbitmap/insights/BitmapAnalyserTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/insights/BitmapAnalyserTest.java
@@ -25,7 +25,12 @@ public class BitmapAnalyserTest {
     }
     BitmapStatistics result = BitmapAnalyser.analyse(rb);
     BitmapStatistics expected =
-        new BitmapStatistics(new BitmapStatistics.ArrayContainersStats(1, 6), 1, 1);
+        new BitmapStatistics(
+            new BitmapStatistics.ArrayContainersStats(1, 6),
+            new BitmapStatistics.RunContainersStats(
+                1, 10000, new int[] {0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
+            1,
+            1);
     assertEquals(expected, result);
   }
 

--- a/roaringbitmap/src/test/java/org/roaringbitmap/insights/BitmapStatisticsTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/insights/BitmapStatisticsTest.java
@@ -10,7 +10,11 @@ public class BitmapStatisticsTest {
   @Test
   public void toStringWorks() {
     BitmapStatistics statistics =
-        new BitmapStatistics(new BitmapStatistics.ArrayContainersStats(10, 50), 2, 1);
+        new BitmapStatistics(
+            new BitmapStatistics.ArrayContainersStats(10, 50),
+            new BitmapStatistics.RunContainersStats(10, 50, new int[16]),
+            2,
+            1);
 
     String string = statistics.toString();
 

--- a/roaringbitmap/src/test/java/org/roaringbitmap/insights/NaiveWriterRecommenderTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/insights/NaiveWriterRecommenderTest.java
@@ -18,6 +18,7 @@ public class NaiveWriterRecommenderTest {
         new BitmapStatistics(
             new BitmapStatistics.ArrayContainersStats(
                 arrayContainerCount, arrayContainerCount * averagePerArrayContaier),
+            new BitmapStatistics.RunContainersStats(0, 0, new int[16]),
             bitmapContainerCount,
             runContainerCount,
             bitmapsCount);
@@ -41,6 +42,7 @@ public class NaiveWriterRecommenderTest {
         new BitmapStatistics(
             new BitmapStatistics.ArrayContainersStats(
                 arrayContainerCount, arrayContainerCount * denseAveragePerArrayContaier),
+            new BitmapStatistics.RunContainersStats(0, 0, new int[16]),
             bitmapContainerCount,
             runContainerCount,
             bitmapsCount);
@@ -56,17 +58,24 @@ public class NaiveWriterRecommenderTest {
     int averagePerArrayContaier = 10;
     int bitmapContainerCount = 200;
     int runContainerCount = 50000;
+    int runsCount = 50000;
+    int averageRunLength = 16;
     int bitmapsCount = 70;
     BitmapStatistics stats =
         new BitmapStatistics(
             new BitmapStatistics.ArrayContainersStats(
                 arrayContainerCount, arrayContainerCount * averagePerArrayContaier),
+            new BitmapStatistics.RunContainersStats(
+                runsCount,
+                runsCount * averageRunLength,
+                new int[] {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0}),
             bitmapContainerCount,
             runContainerCount,
             bitmapsCount);
 
     String recommendation = NaiveWriterRecommender.recommend(stats);
 
+    assertTrue(recommendation.contains("RangeFiller"));
     assertTrue(recommendation.contains(".initialCapacity(718)"));
     assertTrue(recommendation.contains(".optimiseForRuns()"));
   }
@@ -82,6 +91,7 @@ public class NaiveWriterRecommenderTest {
         new BitmapStatistics(
             new BitmapStatistics.ArrayContainersStats(
                 arrayContainerCount, arrayContainerCount * averagePerArrayContaier),
+            new BitmapStatistics.RunContainersStats(0, 0, new int[16]),
             bitmapContainerCount,
             runContainerCount,
             bitmapsCount);
@@ -103,6 +113,7 @@ public class NaiveWriterRecommenderTest {
         new BitmapStatistics(
             new BitmapStatistics.ArrayContainersStats(
                 arrayContainerCount, arrayContainerCount * averagePerArrayContaier),
+            new BitmapStatistics.RunContainersStats(0, 0, new int[16]),
             bitmapContainerCount,
             runContainerCount,
             bitmapsCount);


### PR DESCRIPTION
### SUMMARY
Filling a char array with consecutive values can be done either using a simple loop or by copying a pre-allocated char array.
The latter approach is up to 5 times more performant, especially for large value ranges. This affects the performance of wide range of routines dealing with consecutive values directly in `ArrayContainer` or `RunContainer`, and indirectly impacts some other routines that call them. The trade-off of this approach is permanently occupied memory due to the pre-allocated char array, which consumes an additional 128 kB of memory at most.

This feature can be enabled by calling `CharRangeFiller.allocate(char)` for partial range allocation, or, for allocating the entire character range, the more suitable `CharRangeFiller.allocateCompletely()`. To free the memory, `CharRangeFiller.deallocate()` could be used.

A bitmap analyzer recommendation was added, although detection of many runs in `RunContainersStats.hasManyLongRuns() `could be implemented in a more comprehensive way.

**Benchmark: Isolated char array filling**

```
CharRangeFillerBenchmark.arraycopy          12  thrpt   10  69133.466 ±  3123.095  ops/ms
CharRangeFillerBenchmark.arraycopy          16  thrpt   10  71981.190 ± 12174.344  ops/ms
CharRangeFillerBenchmark.arraycopy         100  thrpt   10  64071.132 ±  5643.923  ops/ms
CharRangeFillerBenchmark.arraycopy        4096  thrpt   10   5213.053 ±    51.235  ops/ms
CharRangeFillerBenchmark.arraycopy       16384  thrpt   10    863.610 ±     9.211  ops/ms
CharRangeFillerBenchmark.iteratively        12  thrpt   10  86908.744 ±   702.798  ops/ms
CharRangeFillerBenchmark.iteratively        16  thrpt   10  70800.389 ±  1686.227  ops/ms
CharRangeFillerBenchmark.iteratively       100  thrpt   10  22331.669 ±   271.267  ops/ms
CharRangeFillerBenchmark.iteratively      4096  thrpt   10    609.741 ±     5.151  ops/ms
CharRangeFillerBenchmark.iteratively     16384  thrpt   10    150.446 ±     2.023  ops/ms
```

**Benchmark: Char array filling used in ArrayContainer creation by range**

```
Benchmark                                                 (length)   Mode  Cnt      Score      Error   Units
CharRangeFillerUsedInArrayContainerBenchmark.arraycopy          10  thrpt   10  45331.204 ± 1050.502  ops/ms
CharRangeFillerUsedInArrayContainerBenchmark.arraycopy         100  thrpt   10  32752.445 ± 1205.521  ops/ms
CharRangeFillerUsedInArrayContainerBenchmark.arraycopy        4096  thrpt   10   1060.396 ±   20.323  ops/ms
CharRangeFillerUsedInArrayContainerBenchmark.iteratively        10  thrpt   10  39073.542 ± 1183.561  ops/ms
CharRangeFillerUsedInArrayContainerBenchmark.iteratively       100  thrpt   10  13584.141 ±  304.668  ops/ms
CharRangeFillerUsedInArrayContainerBenchmark.iteratively      4096  thrpt   10    309.166 ±    5.933  ops/ms
```
Based on these benchmarks, the minimal array length for switching from a simple loop to copying a pre-allocated char array was determined empirically to be **12**. It is hard to determine this constant as it is varying by the time, Java version and the context of the use.

Comparison benchmarks are included in this PR for potential future reference.

Within this work the code in `MappeableContainer.toEfficientContainer()` was deduplicated at the same time.

### Automated Checks

- [X] I have run `./gradlew test` and made sure that my PR does not break any unit test.