### PR TITLE
Fix minHigh, add synchronized on cache-writing

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
@@ -82,6 +82,7 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
   // If true, we handle longs a plain java longs: -1 if right before 0
   // If false, we handle longs as unsigned longs: 0 has no predecessor and Long.MAX_VALUE + 1L is
   // expressed as a negative long
+  // Not final to enable initialization in Externalizable.readObject
   private boolean signedLongs = false;
 
   private transient BitmapDataProviderSupplier supplier;
@@ -302,6 +303,16 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
     }
   }
 
+  private int minHigh(int x, int y) {
+    int compareResult = compare(x, y);
+    if (compareResult < 0) {
+      // x is smaller than y
+      return x;
+    } else {
+      return y;
+    }
+  }
+
   private void pushBitmapForHigh(int high, BitmapDataProvider bitmap) {
     // TODO .size is too slow
     // int nbHighBefore = highToBitmap.headMap(high).size();
@@ -381,7 +392,7 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
       return selectNoCache(j);
     }
 
-    // Ensure all cumulatives as we we have straightforward way to know in advance the high of the
+    // Ensure all cumulatives as we have straightforward way to know in advance the high of the
     // j-th value
     int indexOk = ensureCumulatives(highestHigh());
 
@@ -677,7 +688,11 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
     return -(low + 1); // key not found.
   }
 
-  private void ensureOne(Map.Entry<Integer, BitmapDataProvider> e, int currentHigh, int indexOk) {
+  /**
+   * BEWARE This method is synchronized as it is a mutating operation called by read operations
+   * (as it mutates some cached data-structure used to faster read operation).
+   */
+  private synchronized void ensureOne(Map.Entry<Integer, BitmapDataProvider> e, int currentHigh, int indexOk) {
     // sortedHighs are valid only up to some index
     assert indexOk <= sortedHighs.length : indexOk + " is bigger than " + sortedHighs.length;
 
@@ -855,7 +870,7 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
         firstBucket = false;
 
         // Invalidate the lowest high as lowest not valid
-        firstHighNotValid = Math.min(firstHighNotValid, high);
+        firstHighNotValid = minHigh(firstHighNotValid, high);
         allValid = false;
       }
     }
@@ -1007,7 +1022,7 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
         firstBucket = false;
 
         // Invalidate the lowest high as lowest not valid
-        firstHighNotValid = Math.min(firstHighNotValid, high);
+        firstHighNotValid = minHigh(firstHighNotValid, high);
         allValid = false;
       }
     }
@@ -1103,7 +1118,7 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
         firstBucket = false;
 
         // Invalidate the lowest high as lowest not valid
-        firstHighNotValid = Math.min(firstHighNotValid, high);
+        firstHighNotValid = minHigh(firstHighNotValid, high);
         allValid = false;
       }
     }
@@ -1258,7 +1273,7 @@ public class Roaring64NavigableMap implements Externalizable, LongBitmapDataProv
         firstBucket = false;
 
         // Invalidate the lowest high as lowest not valid
-        firstHighNotValid = Math.min(firstHighNotValid, high);
+        firstHighNotValid = minHigh(firstHighNotValid, high);
         allValid = false;
       }
     }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap.java
@@ -2327,4 +2327,23 @@ public class TestRoaring64NavigableMap {
     assertEquals(2, rb.first());
     assertEquals(-32, rb.last());
   }
+
+  // https://github.com/RoaringBitmap/RoaringBitmap/issues/828
+  @Test
+  public void testOr_negativeInt_sortedHighs_signedLongsTrue() {
+      Roaring64NavigableMap a = newDefaultCtor();
+      a.add(-1L);  // upper 32 bits = 0xFFFFFFFF (-1 as signed int)
+
+      Roaring64NavigableMap b = newDefaultCtor();
+      b.add(0L);   // upper 32 bits = 0x00000000
+      b.add(1L);
+
+      Roaring64NavigableMap dst = newDefaultCtor();
+      dst.or(a);
+      dst.or(b);
+
+      Assertions.assertEquals(dst.getLongCardinality(), 3);
+  }
+
+
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap_concurrentReads.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap_concurrentReads.java
@@ -1,0 +1,100 @@
+package org.roaringbitmap.longlong;
+
+import com.google.common.io.ByteStreams;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.roaringbitmap.BitmapDataProvider;
+import org.roaringbitmap.RoaringBitmap;
+import org.roaringbitmap.RoaringBitmapSupplier;
+import org.roaringbitmap.TestAdversarialInputs;
+import org.roaringbitmap.Util;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmapSupplier;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.NoSuchElementException;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.roaringbitmap.longlong.TestRoaring64Bitmap.getSourceForAllKindsOfNodeTypes;
+
+public class TestRoaring64NavigableMap_concurrentReads {
+  // number of threads
+  int concurrency = 1024;
+  // number of tasks per threads
+  long taskMultiplicator = 128;
+  // This should be increased to a large value, as each run has one change to trigger a race-condition
+  long nbRuns = 1;
+  @Test
+  public void testConcurrencyIsEmpty_manyRuns() throws InterruptedException {
+    for (int i = 0; i < nbRuns; i++) {
+      System.out.println("Run #" + i);
+      oneRunConcurrencyIsEmpty();
+    }
+  }
+
+  private void oneRunConcurrencyIsEmpty() throws InterruptedException {
+    Roaring64NavigableMap bitmap = new Roaring64NavigableMap();
+    ExecutorService executor = Executors.newFixedThreadPool(concurrency);
+
+    // Write values for multiple highs, so that the cache array has size > 1
+    bitmap.add(170L);
+    for (int i = 0; i < 500; i++) {
+      bitmap.add(170L + i * (long) Integer.MAX_VALUE);
+    }
+
+    List<Callable<Object>> tasks = new ArrayList<>();
+    for (int i = 0; i < taskMultiplicator * concurrency; i++) {
+      tasks.add(() -> {
+        unsafeMethod(bitmap);
+        return null;
+      });
+    }
+
+    List<? extends Future<?>> futures = executor.invokeAll(tasks);
+
+    for (Future<?> future : futures) {
+      try {
+        future.get();
+      } catch (InterruptedException | ExecutionException e) {
+        throw new IllegalArgumentException(e);
+      }
+    }
+
+    executor.shutdown();
+  }
+
+  private void unsafeMethod(Roaring64NavigableMap bitmap) {
+    bitmap.isEmpty();
+    bitmap.getLongCardinality();
+    bitmap.rankLong(2L * (long) Integer.MAX_VALUE);
+  }
+}

--- a/roaringbitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap_concurrentReads.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64NavigableMap_concurrentReads.java
@@ -50,9 +50,9 @@ public class TestRoaring64NavigableMap_concurrentReads {
   // number of threads
   int concurrency = 1024;
   // number of tasks per threads
-  long taskMultiplicator = 128;
+  int taskMultiplicator = 128;
   // This should be increased to a large value, as each run has one change to trigger a race-condition
-  long nbRuns = 1;
+  int nbRuns = 1;
   @Test
   public void testConcurrencyIsEmpty_manyRuns() throws InterruptedException {
     for (int i = 0; i < nbRuns; i++) {


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/RoaringBitmap/RoaringBitmap/issues/828
Improves https://github.com/RoaringBitmap/RoaringBitmap/issues/773 (though the fix is not 100% clean, it *just* much improve the situation).

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
