### PR TITLE
Size limit() result container to the requested cardinality

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -98,8 +98,16 @@ public final class MappeableArrayContainer extends MappeableContainer implements
   private MappeableArrayContainer(int newCard, CharBuffer newContent) {
     this.cardinality = newCard;
     CharBuffer tmp = newContent.duplicate(); // for thread-safety
-    this.content = CharBuffer.allocate(Math.max(newCard, tmp.limit()));
+    this.content = CharBuffer.allocate(newCard);
     tmp.rewind();
+    // Only the first newCard entries are retained. Callers such as limit() pass a
+    // target cardinality smaller than the source, so copy just those entries
+    // instead of allocating a buffer the size of the whole source and copying it
+    // all (which the cardinality then masks). When newCard >= the source length
+    // (e.g. range insertion) this copies the whole source, as before.
+    if (tmp.limit() > newCard) {
+      tmp.limit(newCard);
+    }
     this.content.put(tmp);
   }
 


### PR DESCRIPTION
### Problem

`MappeableArrayContainer(int newCard, CharBuffer newContent)` — the constructor used by
`MappeableArrayContainer.limit()` and hence `(Immutable|Mutable)RoaringBitmap.limit()` — allocates
`CharBuffer.allocate(Math.max(newCard, source.limit()))` and copies the **entire** source buffer,
even though only the first `newCard` entries are retained (`cardinality == newCard`). The non-buffer
`ArrayContainer` analog already sizes the result correctly: `Arrays.copyOf(newContent, newCard)`.

### Change

Allocate `newCard` and copy only the first `newCard` entries. Behaviour is unchanged for every caller:

- `limit(maxcardinality)` with `maxcardinality < cardinality` → smaller result buffer (the win);
- the clone-like path where `newCard == source length` → identical;
- range insertion (`iadd`) where `newCard >= source length` → identical, since
  `max(newCard, source) == newCard` there.

### Result

`MutableRoaringBitmap.limit(200)` on a 10k-entry bitmap, measured with
`ThreadMXBean.getThreadAllocatedBytes` over 200k ops:

```
before: 1662.3 B/op
after:   623.1 B/op   (-62%)
```

`SelectTopValuesBenchmark.limit` exercises this path.

### Testing

Full `:roaringbitmap:test` passes, including the existing `testLimit`, `limitTest`, `limitBug2`,
and `testLimitBitInts` correctness tests for the buffer `limit()` path.
