### PR TITLE
Reuse ART shuttle stack entries instead of allocating per node

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/art/AbstractShuttle.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/art/AbstractShuttle.java
@@ -87,10 +87,8 @@ public abstract class AbstractShuttle implements Shuttle {
       if (nextPos != BranchNode.ILLEGAL_IDX) {
         stack[depth].position = nextPos;
         depth++;
-        // add a fresh entry on the top of the visiting stack
-        NodeEntry freshEntry = new NodeEntry();
-        freshEntry.node = currentBranchNode.getChild(nextPos);
-        stack[depth] = freshEntry;
+        // reuse the stack slot at this depth instead of allocating a fresh entry
+        useEntry(depth, currentBranchNode.getChild(nextPos));
       } else {
         // current internal node doesn't have anymore unvisited child,move to a top node
         depth--;
@@ -136,10 +134,8 @@ public abstract class AbstractShuttle implements Shuttle {
       return;
     }
     if (node == art.getRoot()) {
-      NodeEntry nodeEntry = new NodeEntry();
-      nodeEntry.node = node;
       this.depth = 0;
-      stack[depth] = nodeEntry;
+      useEntry(depth, node);
     }
     if (node instanceof LeafNode) {
       // leaf node's corresponding NodeEntry will not have the position member set.
@@ -157,10 +153,8 @@ public abstract class AbstractShuttle implements Shuttle {
     stack[depth].position = pos;
     stack[depth].visited = true;
     Node child = branchNode.getChild(pos);
-    NodeEntry childNodeEntry = new NodeEntry();
-    childNodeEntry.node = child;
     this.depth++;
-    stack[depth] = childNodeEntry;
+    useEntry(depth, child);
     visitToLeaf(child, inRunDirection);
   }
 
@@ -169,10 +163,8 @@ public abstract class AbstractShuttle implements Shuttle {
       return;
     }
     if (node == art.getRoot()) {
-      NodeEntry nodeEntry = new NodeEntry();
-      nodeEntry.node = node;
       this.depth = 0;
-      stack[depth] = nodeEntry;
+      useEntry(depth, node);
     }
     if (node instanceof LeafNode) {
       // leaf node's corresponding NodeEntry will not have the position member set.
@@ -225,10 +217,8 @@ public abstract class AbstractShuttle implements Shuttle {
     stack[depth].position = pos;
     stack[depth].visited = true;
     Node child = branchNode.getChild(pos);
-    NodeEntry childNodeEntry = new NodeEntry();
-    childNodeEntry.node = child;
     this.depth++;
-    stack[depth] = childNodeEntry;
+    useEntry(depth, child);
     if (continueAtBoundary) {
       // once we miss a single match, there's no point comparing parts of the key anymore
       // we just descend as far in run direction as possible
@@ -251,6 +241,24 @@ public abstract class AbstractShuttle implements Shuttle {
       byte nextSiblingKey = parentNode.getChildKey(nextSiblingPos);
       stack[depth - 1].leafNodeNextSiblingKey = nextSiblingKey;
     }
+  }
+
+  // Reuse the NodeEntry already parked in the stack slot at depth d (allocating one only
+  // the first time a given depth is reached) and reset it to the same defaults a fresh
+  // NodeEntry would have. This avoids allocating a NodeEntry on every push while the
+  // shuttle traverses the tree (select/rank/iteration).
+  private NodeEntry useEntry(int d, Node node) {
+    NodeEntry entry = stack[d];
+    if (entry == null) {
+      entry = new NodeEntry();
+      stack[d] = entry;
+    }
+    entry.node = node;
+    entry.position = BranchNode.ILLEGAL_IDX;
+    entry.visited = false;
+    entry.startFromNextSiblingPosition = false;
+    entry.leafNodeNextSiblingKey = 0;
+    return entry;
   }
 
   class NodeEntry {


### PR DESCRIPTION
### Problem

`AbstractShuttle` (the ART tree cursor used by `Roaring64Bitmap.select`, `rankLong`'s leaf
iteration, and ordered iteration) keeps a fixed-depth `NodeEntry[MAX_DEPTH]` stack, but allocated
a **new `NodeEntry` on every push**. Traversing the tree therefore allocates a `NodeEntry` per node
visited — e.g. `select` of a middle element walks many leaves — even though at most `MAX_DEPTH`
entries are ever live at once.

### Change

Park a reusable `NodeEntry` in each stack slot (allocated the first time a given depth is reached)
and reset it to defaults on each push. The reset values match the previous `new NodeEntry()`
defaults exactly (`position = ILLEGAL_IDX`, `visited = false`, `startFromNextSiblingPosition =
false`, `leafNodeNextSiblingKey = 0`), so behaviour is unchanged.

### Result

`Roaring64Bitmap` with 200k entries, allocation per op (`ThreadMXBean.getThreadAllocatedBytes`):

| op | before | after | delta |
|---|---:|---:|---:|
| `select` | 590.9 | 206.1 | **−65%** |
| iterator (full) | 3920 | 2512 | **−36%** |
| `contains` | 24.0 | 7.2 | −70% |
| `rankLong` | 321.4 | 282.3 | −12% |

### Testing

Full `:roaringbitmap:test` passes, including the `org.roaringbitmap.longlong.*` (select / rank /
iteration) and `org.roaringbitmap.art.*` suites.
