### PR TITLE
Fix RoaringBitSet.previousSetBit(-1) to return -1

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitSet.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitSet.java
@@ -89,6 +89,9 @@ public class RoaringBitSet extends BitSet {
 
   @Override
   public int previousSetBit(int fromIndex) {
+    if (fromIndex == -1) {
+      return -1;
+    }
     return (int) roaringBitmap.previousValue(fromIndex);
   }
 

--- a/roaringbitmap/src/test/java/org/roaringbitmap/RoaringBitSetTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/RoaringBitSetTest.java
@@ -521,6 +521,26 @@ public class RoaringBitSetTest {
   }
 
   @Test
+  public void testPreviousSetBit() {
+    RoaringBitSet rb = new RoaringBitSet();
+    java.util.BitSet jb = new java.util.BitSet();
+    for (int b : new int[] {5, 100, 200}) {
+      rb.set(b);
+      jb.set(b);
+    }
+
+    // java.util.BitSet contract: previousSetBit(-1) returns -1
+    Assertions.assertEquals(-1, rb.previousSetBit(-1));
+
+    for (int i = -1; i <= 260; i++) {
+      Assertions.assertEquals(
+          jb.previousSetBit(i), rb.previousSetBit(i), "mismatch at fromIndex=" + i);
+    }
+
+    Assertions.assertEquals(-1, new RoaringBitSet().previousSetBit(-1));
+  }
+
+  @Test
   public void testNextClearBit() {
     int failCount = 0;
 


### PR DESCRIPTION
`RoaringBitSet.previousSetBit(-1)` returned the largest set bit instead of `-1`. `RoaringBitSet` extends `java.util.BitSet`, whose contract specifies that `previousSetBit(-1)` returns `-1`; the argument was passed straight to `RoaringBitmap.previousValue`, which treats `-1` as unsigned and returns the maximum value. This breaks the standard backward-iteration idiom that terminates on `previousSetBit(i - 1) == -1`.

Guards the `-1` case and adds a test that cross-checks against `java.util.BitSet` across a range.