### PR TITLE
`RoaringBitmap.orNot(x1, x2, rangeEnd)` mutates its input `x1` (violates its own Javadoc)

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -1591,7 +1591,7 @@ public class RoaringBitmap
             key == maxKey
                 ? x1.highLowContainer
                     .getContainerAtIndex(pos1)
-                    .ior(RunContainer.rangeOfOnes(0, lastRun))
+                    .or(RunContainer.rangeOfOnes(0, lastRun))
                 : RunContainer.full();
         ++pos1;
         s1 = pos1 < length1 ? x1.highLowContainer.getKeyAtIndex(pos1) : maxKey + 1;

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -550,7 +550,7 @@ public class ImmutableRoaringBitmap
             key == maxKey
                 ? x1.highLowContainer
                     .getContainerAtIndex(pos1)
-                    .ior(MappeableRunContainer.rangeOfOnes(0, lastRun))
+                    .or(MappeableRunContainer.rangeOfOnes(0, lastRun))
                 : MappeableRunContainer.full();
         ++pos1;
         s1 = pos1 < length1 ? x1.highLowContainer.getKeyAtIndex(pos1) : maxKey + 1;

--- a/roaringbitmap/src/test/java/org/roaringbitmap/OrNotMutatesInputTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/OrNotMutatesInputTest.java
@@ -1,0 +1,25 @@
+package org.roaringbitmap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class OrNotMutatesInputTest {
+
+  @Test
+  public void staticOrNotMustNotModifyInputX1() {
+    // Dense key 0 -> BitmapContainer whose ior() mutates in place.
+    // rangeEnd 0x10000 makes key 0 the last in-range key (maxKey == 0),
+    // present in x1 but absent in x2 => the ".ior()" branch is taken.
+    final RoaringBitmap x1 = new RoaringBitmap();
+    for (int i = 0; i < 5000; i++) {
+      x1.add(i);
+    }
+    final RoaringBitmap x2 = new RoaringBitmap();
+    final RoaringBitmap x1Before = x1.clone();
+
+    RoaringBitmap.orNot(x1, x2, 0x10000L);
+
+    assertEquals(x1Before, x1, "static orNot must not modify input x1");
+  }
+}


### PR DESCRIPTION
### Summary
The static factory `RoaringBitmap.orNot(x1, x2, rangeEnd)` is documented as pure — *"The provided bitmaps are *not* modified."* In the `key == maxKey && key == s1` ("or in a hole") branch it calls **`.ior(...)`** directly on `x1`'s own container, mutating `x1` in place. Every sibling branch uses the non-mutating form (`.orNot`, `.not`, `RunContainer.full()`, `rangeOfOnes`).

### Reproduction
```java
@Test
void staticOrNotMustNotModifyInputX1() {
  RoaringBitmap x1 = new RoaringBitmap();
  for (int i = 0; i < 5000; i++) x1.add(i);   // dense key 0 -> BitmapContainer (ior mutates in place)
  RoaringBitmap x2 = new RoaringBitmap();      // key 0 absent
  RoaringBitmap x1Before = x1.clone();
  RoaringBitmap.orNot(x1, x2, 0x10000L);       // maxKey==0 -> the .ior() branch
  assertEquals(x1Before, x1, "static orNot must not modify input x1");
}
```
**Expected:** `x1` unchanged `{0..4999}`. **Actual:** `x1` corrupted to `{0..65535}` (`expected: <{0,1,2,...,4999}> but was: <{...,65535}>`). The buffer twin `ImmutableRoaringBitmap.orNot` has the identical bug.

### Suggested fix (allocation-neutral — `ior` allocates anyway when it grows)
```diff
-                    .ior(RunContainer.rangeOfOnes(0, lastRun))          // RoaringBitmap.java:~1594
+                    .or(RunContainer.rangeOfOnes(0, lastRun))
-                    .ior(MappeableRunContainer.rangeOfOnes(0, lastRun)) // buffer/ImmutableRoaringBitmap.java:~553
+                    .or(MappeableRunContainer.rangeOfOnes(0, lastRun))
```
(The in-place instance method `orNot(other, rangeEnd)` is intentionally left untouched.)

### Related (different, already-fixed) prior art
#352, #376, #394 — other orNot defects; this purity violation is separate.

### Automated Checks

- [X] I have run `./gradlew test` and made sure that my PR does not break any unit test.
