### PR TITLE
Reverse `BitmapContainer` iterator drops word-0 values and emits a phantom `65535` from `advanceIfNeeded`

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -1918,16 +1918,14 @@ final class ReverseBitmapContainerCharIterator implements PeekableCharIterator {
       }
       long currentWord = bitmap[position];
       currentWord &= ~0L >>> (63 - (maxval & 63));
-      if (position > 0) {
-        while (currentWord == 0) {
-          position--;
-          if (position == 0) {
-            break;
-          }
-          currentWord = bitmap[position];
-        }
+      while (currentWord == 0 && position > 0) {
+        position--;
+        currentWord = bitmap[position];
       }
       word = currentWord;
+      if (currentWord == 0) {
+        position = -1;
+      }
     }
   }
 

--- a/roaringbitmap/src/test/java/org/roaringbitmap/ReverseBitmapIteratorWordZeroTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/ReverseBitmapIteratorWordZeroTest.java
@@ -1,0 +1,27 @@
+package org.roaringbitmap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class ReverseBitmapIteratorWordZeroTest {
+
+  @Test
+  public void reverseAdvanceKeepsWordZeroValueAcrossEmptyWords() {
+    final long[] words = new long[1024]; // 1024 * 64 = 65536 bits
+    words[2] = 1L << 2;   // value 2 * 64 + 2 = 130 (word 2)
+    words[0] = 1L << 40;  // value 40           (word 0)
+    final BitmapContainer bc = new BitmapContainer(words, 2);
+
+    final PeekableCharIterator it = bc.getReverseCharIterator();
+    // 130 > 128 must be skipped; 40 <= 128 is the highest remaining value.
+    it.advanceIfNeeded((char) 128);
+
+    assertTrue(it.hasNext());
+    assertEquals(40, it.peekNext());
+    assertEquals(40, it.next());
+    assertFalse(it.hasNext());
+  }
+}


### PR DESCRIPTION
### Summary
`ReverseBitmapContainerCharIterator.advanceIfNeeded(maxval)` descends across empty words. Its loop breaks *before* loading `bitmap[0]`, so a value in word 0 is skipped. The iterator is never marked exhausted, so `peekNext()`/`next()` compute `(0+1)*64 - (numberOfLeadingZeros(0)+1)` = `64 - 65` = **`65535`** (a phantom). `hasNext()` is `position >= 0`, so `position = -1` correctly signals exhaustion.

### Reproduction
```java
@Test
void reverseAdvanceKeepsWordZeroValueAcrossEmptyWords() {
  long[] words = new long[1024];
  words[2] = 1L << 2;   // value 130
  words[0] = 1L << 40;  // value 40 (word 0)
  BitmapContainer bc = new BitmapContainer(words, 2);
  PeekableCharIterator it = bc.getReverseCharIterator();
  it.advanceIfNeeded((char) 128);          // 130 skipped; 40 is the highest remaining
  assertTrue(it.hasNext());
  assertEquals(40, it.peekNext());         // actual: 65535
  assertEquals(40, it.next());
  assertFalse(it.hasNext());
}
```

### Suggested fix (hot path stays operation-for-operation identical)
```diff
-      if (position > 0) {
-        while (currentWord == 0) {
-          position--;
-          if (position == 0) { break; }
-          currentWord = bitmap[position];
-        }
-      }
-      word = currentWord;
+      while (currentWord == 0 && position > 0) {
+        position--;
+        currentWord = bitmap[position];
+      }
+      word = currentWord;
+      if (currentWord == 0) { position = -1; }   // true exhaustion
```
`BitmapContainer.java`, `ReverseBitmapContainerCharIterator.advanceIfNeeded` (~L1910). Buffer package not affected (its reverse iterator is a plain `CharIterator` with no `advanceIfNeeded`).

### Related prior art
#665 optimized the *forward* advanceIfNeeded — the reverse one was never covered.

### Automated Checks

- [x] I have run `./gradlew test` and made sure that my PR does not break any unit test.
