### PR TITLE
`ArrayContainer.nextValue(char)` throws `ArrayIndexOutOfBoundsException` on an empty container

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -1177,6 +1177,9 @@ public final class ArrayContainer extends Container implements Cloneable {
 
   @Override
   public int nextValue(char fromValue) {
+    if (cardinality == 0) {
+      return -1;
+    }
     int index = Util.advanceUntil(content, -1, cardinality, fromValue);
     if (index == cardinality) {
       return fromValue == content[cardinality - 1] ? (fromValue) : -1;

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -1468,6 +1468,9 @@ public final class MappeableArrayContainer extends MappeableContainer implements
 
   @Override
   public int nextValue(char fromValue) {
+    if (cardinality == 0) {
+      return -1;
+    }
     int index = BufferUtil.advanceUntil(content, -1, cardinality, fromValue);
     if (index == cardinality) {
       return fromValue == content.get(cardinality - 1) ? (fromValue) : -1;

--- a/roaringbitmap/src/test/java/org/roaringbitmap/ArrayContainerNextValueEmptyTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/ArrayContainerNextValueEmptyTest.java
@@ -1,0 +1,17 @@
+package org.roaringbitmap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class ArrayContainerNextValueEmptyTest {
+
+  @Test
+  public void nextValueOnEmptyArrayContainerMustReturnMinusOne() {
+    final ArrayContainer empty = new ArrayContainer();
+    assertEquals(0, empty.getCardinality());
+    // Contract: "first stored value >= fromValue, or -1 if none".
+    // BitmapContainer.nextValue already returns -1 here; ArrayContainer throws.
+    assertEquals(-1, empty.nextValue((char) 5));
+  }
+}


### PR DESCRIPTION
### Summary
`ArrayContainer.nextValue` does `return fromValue == content[cardinality - 1] ? ... : -1;`. For `cardinality == 0` that's `content[-1]` → AIOOBE. `Util.advanceUntil(...,-1, 0, ...)` returns `0`, so the `index == cardinality` branch is taken. Siblings already handle empty (`BitmapContainer.nextValue` → `-1`; `ArrayContainer.previousValue` → empty-safe).

### Reproduction
```java
@Test
void nextValueOnEmptyArrayContainerMustReturnMinusOne() {
  ArrayContainer empty = new ArrayContainer();
  assertEquals(-1, empty.nextValue((char) 5));   // actual: AIOOBE Index -1
}
```

### Suggested fix (one early-return guard, non-hot path)
```diff
  public int nextValue(char fromValue) {
+   if (cardinality == 0) { return -1; }
    int index = Util.advanceUntil(content, -1, cardinality, fromValue);
```
Same guard applies to the buffer twin `MappeableArrayContainer.nextValue` (~L1470).

### Related prior art
#313 fixed the *non-empty* off-the-end case but left `cardinality == 0` unguarded — this is the residual edge case.

### Automated Checks

- [X] I have run `./gradlew test` and made sure that my PR does not break any unit test.
