### PR TITLE
`ReverseIntIteratorFlyweight` uses a `short` container index — reverse iteration silently yields nothing past 32768 containers

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/ReverseIntIteratorFlyweight.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ReverseIntIteratorFlyweight.java
@@ -24,7 +24,7 @@ public class ReverseIntIteratorFlyweight implements IntIterator {
 
   private ReverseRunContainerCharIterator runIter = new ReverseRunContainerCharIterator();
 
-  private short pos;
+  private int pos;
 
   private RoaringBitmap roaringBitmap = null;
 
@@ -98,7 +98,7 @@ public class ReverseIntIteratorFlyweight implements IntIterator {
   public void wrap(RoaringBitmap r) {
     this.roaringBitmap = r;
     this.hs = 0;
-    this.pos = (short) (this.roaringBitmap.highLowContainer.size() - 1);
+    this.pos = this.roaringBitmap.highLowContainer.size() - 1;
     this.nextContainer();
   }
 }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/BufferReverseIntIteratorFlyweight.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/BufferReverseIntIteratorFlyweight.java
@@ -30,7 +30,7 @@ public class BufferReverseIntIteratorFlyweight implements IntIterator {
   private ReverseMappeableRunContainerCharIterator runIter =
       new ReverseMappeableRunContainerCharIterator();
 
-  private short pos;
+  private int pos;
 
   private ImmutableRoaringBitmap roaringBitmap = null;
 
@@ -106,7 +106,7 @@ public class BufferReverseIntIteratorFlyweight implements IntIterator {
   public void wrap(ImmutableRoaringBitmap r) {
     this.roaringBitmap = r;
     this.hs = 0;
-    this.pos = (short) (this.roaringBitmap.highLowContainer.size() - 1);
+    this.pos = this.roaringBitmap.highLowContainer.size() - 1;
     this.nextContainer();
   }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/ReverseIntIteratorFlyweightManyContainersTest.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/ReverseIntIteratorFlyweightManyContainersTest.java
@@ -1,0 +1,35 @@
+package org.roaringbitmap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class ReverseIntIteratorFlyweightManyContainersTest {
+
+  @Test
+  public void reverseIterationYieldsEveryValueWithMoreThanShortMaxContainers() {
+    // One value per distinct high-16-bit key => one container per value, so the
+    // container count lands just past the largest index a signed short can hold.
+    final int containerCount = Short.MAX_VALUE + 2; // 32769
+    final int[] data = new int[containerCount];
+    for (int i = 0; i < containerCount; i++) {
+      data[i] = i << 16; // low 16 bits zero, high 16 bits = i => a distinct container each
+    }
+
+    final RoaringBitmap bitmap = RoaringBitmap.bitmapOf(data);
+    assertEquals(containerCount, bitmap.getCardinality());
+
+    final ReverseIntIteratorFlyweight it = new ReverseIntIteratorFlyweight(bitmap);
+
+    assertTrue(it.hasNext());
+    assertEquals((containerCount - 1) << 16, it.next()); // highest value first
+
+    int seen = 1;
+    while (it.hasNext()) {
+      it.next();
+      seen++;
+    }
+    assertEquals(containerCount, seen);
+  }
+}


### PR DESCRIPTION
### Summary
`ReverseIntIteratorFlyweight` stores its container index in `private short pos;` and narrows it in `wrap()`: `this.pos = (short)(size() - 1);`. A bitmap can hold up to 65536 containers; once the count exceeds `Short.MAX_VALUE + 1` (32768), the cast overflows to **negative**, `hasNext()` (`pos >= 0`) returns false immediately, and reverse iteration silently produces nothing. The forward `IntIteratorFlyweight` correctly uses `int pos` with no cast.

### Reproduction
```java
@Test
void reverseIterationYieldsEveryValueWithMoreThanShortMaxContainers() {
  int containerCount = Short.MAX_VALUE + 2;          // 32769
  int[] data = new int[containerCount];
  for (int i = 0; i < containerCount; i++) data[i] = i << 16;   // one value per container
  RoaringBitmap bitmap = RoaringBitmap.bitmapOf(data);
  ReverseIntIteratorFlyweight it = new ReverseIntIteratorFlyweight(bitmap);
  assertTrue(it.hasNext());                          // actual: false (silent empty)
  int seen = 0;
  while (it.hasNext()) { it.next(); seen++; }
  assertEquals(containerCount, seen);                // actual: 0
}
```

### Suggested fix (zero runtime cost — widens one field to match the forward counterpart)
```diff
-  private short pos;                                           // ReverseIntIteratorFlyweight.java
+  private int pos;
-  this.pos = (short) (this.roaringBitmap.highLowContainer.size() - 1);
+  this.pos = this.roaringBitmap.highLowContainer.size() - 1;
```
Same change in the buffer twin `BufferReverseIntIteratorFlyweight` (field ~L33, `wrap` ~L109).

### Related prior art
#110 — an overflow in the *forward* `RoaringIntIterator.advanceIfNeeded`; same family of bug, different class. No prior report exists for the reverse flyweight.

### Automated Checks

- [X] I have run `./gradlew test` and made sure that my PR does not break any unit test.
