### PR TITLE
Declare  as a dependency of

### DIFF
--- a/roaringbitmap/build.gradle.kts
+++ b/roaringbitmap/build.gradle.kts
@@ -87,6 +87,10 @@ tasks.named<Jar>("sourcesJar") {
     dependsOn(tasks.named("compileModuleInfoJava"))
 }
 
+tasks.named<Jar>("javadocJar") {
+    dependsOn(tasks.named("compileModuleInfoJava"))
+}
+
 tasks.test {
     systemProperty("kryo.unsafe", "false")
     useJUnitPlatform()


### PR DESCRIPTION
### SUMMARY
`javadocJar` consumes the module-info classes generated by `compileModuleInfoJava`, but the dependency was not declared. Newer Gradle task validation therefore rejects the build because the execution order is not guaranteed.

This change adds the missing `dependsOn` relationship, matching the existing `sourcesJar` configuration:

```kotlin
tasks.named<Jar>("javadocJar") {
    dependsOn(tasks.named("compileModuleInfoJava"))
}
```

The change only updates task ordering and does not modify the generated classes or JAR contents. With this fix applied, the OSS-Fuzz JVM build completes and `check_build` passes for the configured `libFuzzer`, AddressSanitizer, and `x86_64` build.


### Automated Checks
 I have run `./gradlew test` and made sure that my PR does not break any unit test.
