### PR TITLE
Avoid O(N^2) operations in some cases

### DIFF
--- a/jmh/src/jmh/java/org/roaringbitmap/InPlaceMergeBenchmark.java
+++ b/jmh/src/jmh/java/org/roaringbitmap/InPlaceMergeBenchmark.java
@@ -1,0 +1,80 @@
+package org.roaringbitmap;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks the in-place union/xor/lazy-union merge paths of {@link RoaringBitmap}.
+ *
+ * <p>The {@code interleaved} pattern (left holds the even high-keys, right the odd ones) forces a
+ * source-only container to be inserted between every pair of receiver containers -- the quadratic
+ * case a single bulk merge pass should win. The {@code append} pattern (right's keys all follow
+ * left's) is a control: it never inserts in the interior, so both strategies take the tail path.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+public class InPlaceMergeBenchmark {
+
+  @Param({"64", "1024", "4096", "16384"})
+  public int containers;
+
+  @Param({"interleaved", "append"})
+  public String pattern;
+
+  // Templates: cloned per invocation because or/xor mutate the receiver. Clone cost is identical
+  // for every merge strategy, so it does not bias the comparison.
+  private RoaringBitmap leftTemplate;
+  private RoaringBitmap right;
+
+  private static RoaringBitmap withKeys(int start, int count, int step, int low) {
+    RoaringBitmap b = new RoaringBitmap();
+    for (int i = 0; i < count; i++) {
+      int key = start + i * step;
+      b.add((key << 16) | low);
+    }
+    return b;
+  }
+
+  @Setup
+  public void setup() {
+    if ("interleaved".equals(pattern)) {
+      // left: 0,2,4,...   right: 1,3,5,...  -> one interior insert per source container
+      leftTemplate = withKeys(0, containers, 2, 5);
+      right = withKeys(1, containers, 2, 7);
+    } else { // append: right's keys all follow left's -> pure tail append, no interior work
+      leftTemplate = withKeys(0, containers, 1, 5);
+      right = withKeys(containers, containers, 1, 7);
+    }
+  }
+
+  @Benchmark
+  public int or() {
+    RoaringBitmap receiver = leftTemplate.clone();
+    receiver.or(right);
+    return receiver.getCardinality();
+  }
+
+  @Benchmark
+  public int xor() {
+    RoaringBitmap receiver = leftTemplate.clone();
+    receiver.xor(right);
+    return receiver.getCardinality();
+  }
+
+  @Benchmark
+  public int naivelazyor() {
+    RoaringBitmap receiver = leftTemplate.clone();
+    receiver.naivelazyor(right);
+    receiver.repairAfterLazy();
+    return receiver.getCardinality();
+  }
+}

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringArray.java
@@ -822,6 +822,98 @@ public final class RoaringArray implements Cloneable, Externalizable, Appendable
     size--;
   }
 
+  static final int MERGE_OR = 0;
+  static final int MERGE_XOR = 1;
+  static final int MERGE_LAZY_OR = 2;
+
+  /**
+   * Finishes an in-place union/xor/lazy-union ({@code op}) once the receiver's structure must
+   * change, merging both suffixes into fresh arrays in one pass. Avoids the per-key insert/remove
+   * shift, which is quadratic when keys are interleaved.
+   *
+   * <p>{@code [0, dst)} is already final and copied over. {@code left}/{@code right} are the
+   * receiver/source scan positions. For a union {@code dst == left}; xor may pass
+   * {@code dst < left} to drop an emptied container. Source-only containers are cloned.
+   */
+  void mergeBulk(RoaringArray other, int dst, int left, int right, int op) {
+    final int length1 = this.size;
+    final int length2 = other.size;
+
+    // exact result size for union, tight upper bound for xor
+    int distinct = 0;
+    int l = left;
+    int r = right;
+    while (l < length1 && r < length2) {
+      char k1 = this.keys[l];
+      char k2 = other.keys[r];
+      if (k1 < k2) {
+        l++;
+      } else if (k1 > k2) {
+        r++;
+      } else {
+        l++;
+        r++;
+      }
+      distinct++;
+    }
+    distinct += (length1 - l) + (length2 - r);
+    final int total = dst + distinct;
+
+    char[] newKeys = new char[total];
+    Container[] newValues = new Container[total];
+    System.arraycopy(this.keys, 0, newKeys, 0, dst);
+    System.arraycopy(this.values, 0, newValues, 0, dst);
+    int pos = dst;
+
+    while (left < length1 && right < length2) {
+      char k1 = this.keys[left];
+      char k2 = other.keys[right];
+      if (k1 < k2) {
+        newKeys[pos] = k1;
+        newValues[pos] = this.values[left];
+        pos++;
+        left++;
+      } else if (k1 > k2) {
+        newKeys[pos] = k2;
+        newValues[pos] = other.values[right].clone();
+        pos++;
+        right++;
+      } else {
+        Container c;
+        if (op == MERGE_XOR) {
+          c = this.values[left].ixor(other.values[right]);
+        } else if (op == MERGE_LAZY_OR) {
+          c = this.values[left].toBitmapContainer().lazyIOR(other.values[right]);
+        } else {
+          c = this.values[left].ior(other.values[right]);
+        }
+        if (op != MERGE_XOR || !c.isEmpty()) {
+          newKeys[pos] = k1;
+          newValues[pos] = c;
+          pos++;
+        }
+        left++;
+        right++;
+      }
+    }
+    while (left < length1) {
+      newKeys[pos] = this.keys[left];
+      newValues[pos] = this.values[left];
+      pos++;
+      left++;
+    }
+    while (right < length2) {
+      newKeys[pos] = other.keys[right];
+      newValues[pos] = other.values[right].clone();
+      pos++;
+      right++;
+    }
+
+    this.keys = newKeys;
+    this.values = newValues;
+    this.size = pos;
+  }
+
   void removeIndexRange(int begin, int end) {
     if (end <= begin) {
       return;

--- a/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java
@@ -2494,15 +2494,10 @@ public class RoaringBitmap
           }
           s1 = highLowContainer.getKeyAtIndex(pos1);
         } else {
-          highLowContainer.insertNewKeyValueAt(
-              pos1, s2, x2.highLowContainer.getContainerAtIndex(pos2).clone());
-          pos1++;
-          length1++;
-          pos2++;
-          if (pos2 == length2) {
-            break main;
-          }
-          s2 = x2.highLowContainer.getKeyAtIndex(pos2);
+          // source-only insert: bulk-merge the rest (insert per key would be quadratic)
+          highLowContainer.mergeBulk(
+              x2.highLowContainer, pos1, pos1, pos2, RoaringArray.MERGE_LAZY_OR);
+          return;
         }
       }
     }
@@ -2576,15 +2571,9 @@ public class RoaringBitmap
           }
           s1 = highLowContainer.getKeyAtIndex(pos1);
         } else {
-          highLowContainer.insertNewKeyValueAt(
-              pos1, s2, x2.highLowContainer.getContainerAtIndex(pos2).clone());
-          pos1++;
-          length1++;
-          pos2++;
-          if (pos2 == length2) {
-            break main;
-          }
-          s2 = x2.highLowContainer.getKeyAtIndex(pos2);
+          // source-only insert: bulk-merge the rest (insert per key would be quadratic)
+          highLowContainer.mergeBulk(x2.highLowContainer, pos1, pos1, pos2, RoaringArray.MERGE_OR);
+          return;
         }
       }
     }
@@ -3396,8 +3385,11 @@ public class RoaringBitmap
             this.highLowContainer.setContainerAtIndex(pos1, c);
             pos1++;
           } else {
-            highLowContainer.removeAtIndex(pos1);
-            --length1;
+            // cancelled pair: bulk-merge the rest, dropping this empty container (removeAtIndex
+            // per key would be quadratic)
+            highLowContainer.mergeBulk(
+                x2.highLowContainer, pos1, pos1 + 1, pos2 + 1, RoaringArray.MERGE_XOR);
+            return;
           }
           pos2++;
           if ((pos1 == length1) || (pos2 == length2)) {
@@ -3412,15 +3404,9 @@ public class RoaringBitmap
           }
           s1 = highLowContainer.getKeyAtIndex(pos1);
         } else {
-          highLowContainer.insertNewKeyValueAt(
-              pos1, s2, x2.highLowContainer.getContainerAtIndex(pos2).clone());
-          pos1++;
-          length1++;
-          pos2++;
-          if (pos2 == length2) {
-            break main;
-          }
-          s2 = x2.highLowContainer.getKeyAtIndex(pos2);
+          // source-only insert: bulk-merge the rest (insert per key would be quadratic)
+          highLowContainer.mergeBulk(x2.highLowContainer, pos1, pos1, pos2, RoaringArray.MERGE_XOR);
+          return;
         }
       }
     }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringArray.java
@@ -668,6 +668,99 @@ public final class MutableRoaringArray
     size--;
   }
 
+  static final int MERGE_OR = 0;
+  static final int MERGE_XOR = 1;
+  static final int MERGE_LAZY_OR = 2;
+
+  /**
+   * Finishes an in-place union/xor/lazy-union ({@code op}) once the receiver's structure must
+   * change, merging both suffixes into fresh arrays in one pass. Avoids the per-key insert/remove
+   * shift, which is quadratic when keys are interleaved.
+   *
+   * <p>{@code [0, dst)} is already final and copied over. {@code left}/{@code right} are the
+   * receiver/source scan positions. For a union {@code dst == left}; xor may pass
+   * {@code dst < left} to drop an emptied container. Source-only containers are cloned; the source
+   * is read through {@link PointableRoaringArray} as it may be memory-mapped.
+   */
+  void mergeBulk(PointableRoaringArray other, int dst, int left, int right, int op) {
+    final int length1 = this.size;
+    final int length2 = other.size();
+
+    // exact result size for union, tight upper bound for xor
+    int distinct = 0;
+    int l = left;
+    int r = right;
+    while (l < length1 && r < length2) {
+      char k1 = this.keys[l];
+      char k2 = other.getKeyAtIndex(r);
+      if (k1 < k2) {
+        l++;
+      } else if (k1 > k2) {
+        r++;
+      } else {
+        l++;
+        r++;
+      }
+      distinct++;
+    }
+    distinct += (length1 - l) + (length2 - r);
+    final int total = dst + distinct;
+
+    char[] newKeys = new char[total];
+    MappeableContainer[] newValues = new MappeableContainer[total];
+    System.arraycopy(this.keys, 0, newKeys, 0, dst);
+    System.arraycopy(this.values, 0, newValues, 0, dst);
+    int pos = dst;
+
+    while (left < length1 && right < length2) {
+      char k1 = this.keys[left];
+      char k2 = other.getKeyAtIndex(right);
+      if (k1 < k2) {
+        newKeys[pos] = k1;
+        newValues[pos] = this.values[left];
+        pos++;
+        left++;
+      } else if (k1 > k2) {
+        newKeys[pos] = k2;
+        newValues[pos] = other.getContainerAtIndex(right).clone();
+        pos++;
+        right++;
+      } else {
+        MappeableContainer c;
+        if (op == MERGE_XOR) {
+          c = this.values[left].ixor(other.getContainerAtIndex(right));
+        } else if (op == MERGE_LAZY_OR) {
+          c = this.values[left].toBitmapContainer().lazyIOR(other.getContainerAtIndex(right));
+        } else {
+          c = this.values[left].ior(other.getContainerAtIndex(right));
+        }
+        if (op != MERGE_XOR || !c.isEmpty()) {
+          newKeys[pos] = k1;
+          newValues[pos] = c;
+          pos++;
+        }
+        left++;
+        right++;
+      }
+    }
+    while (left < length1) {
+      newKeys[pos] = this.keys[left];
+      newValues[pos] = this.values[left];
+      pos++;
+      left++;
+    }
+    while (right < length2) {
+      newKeys[pos] = other.getKeyAtIndex(right);
+      newValues[pos] = other.getContainerAtIndex(right).clone();
+      pos++;
+      right++;
+    }
+
+    this.keys = newKeys;
+    this.values = newValues;
+    this.size = pos;
+  }
+
   protected void removeIndexRange(int begin, int end) {
     if (end <= begin) {
       return;

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MutableRoaringBitmap.java
@@ -1462,15 +1462,10 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
           }
           s1 = highLowContainer.getKeyAtIndex(pos1);
         } else { // s1 > s2
+          // source-only insert: bulk-merge the rest (insert per key would be quadratic)
           getMappeableRoaringArray()
-              .insertNewKeyValueAt(pos1, s2, x2.highLowContainer.getContainerAtIndex(pos2).clone());
-          pos1++;
-          length1++;
-          pos2++;
-          if (pos2 == length2) {
-            break main;
-          }
-          s2 = x2.highLowContainer.getKeyAtIndex(pos2);
+              .mergeBulk(x2.highLowContainer, pos1, pos1, pos2, MutableRoaringArray.MERGE_LAZY_OR);
+          return;
         }
       }
     }
@@ -1518,15 +1513,10 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
           }
           s1 = highLowContainer.getKeyAtIndex(pos1);
         } else { // s1 > s2
+          // source-only insert: bulk-merge the rest (insert per key would be quadratic)
           getMappeableRoaringArray()
-              .insertNewKeyValueAt(pos1, s2, x2.highLowContainer.getContainerAtIndex(pos2).clone());
-          pos1++;
-          length1++;
-          pos2++;
-          if (pos2 == length2) {
-            break main;
-          }
-          s2 = x2.highLowContainer.getKeyAtIndex(pos2);
+              .mergeBulk(x2.highLowContainer, pos1, pos1, pos2, MutableRoaringArray.MERGE_OR);
+          return;
         }
       }
     }
@@ -1772,8 +1762,12 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
             this.getMappeableRoaringArray().setContainerAtIndex(pos1, c);
             pos1++;
           } else {
-            getMappeableRoaringArray().removeAtIndex(pos1);
-            --length1;
+            // cancelled pair: bulk-merge the rest, dropping this empty container (removeAtIndex
+            // per key would be quadratic)
+            getMappeableRoaringArray()
+                .mergeBulk(
+                    x2.highLowContainer, pos1, pos1 + 1, pos2 + 1, MutableRoaringArray.MERGE_XOR);
+            return;
           }
           pos2++;
           if ((pos1 == length1) || (pos2 == length2)) {
@@ -1788,15 +1782,10 @@ public class MutableRoaringBitmap extends ImmutableRoaringBitmap
           }
           s1 = highLowContainer.getKeyAtIndex(pos1);
         } else { // s1 > s2
+          // source-only insert: bulk-merge the rest (insert per key would be quadratic)
           getMappeableRoaringArray()
-              .insertNewKeyValueAt(pos1, s2, x2.highLowContainer.getContainerAtIndex(pos2).clone());
-          pos1++;
-          length1++;
-          pos2++;
-          if (pos2 == length2) {
-            break main;
-          }
-          s2 = x2.highLowContainer.getKeyAtIndex(pos2);
+              .mergeBulk(x2.highLowContainer, pos1, pos1, pos2, MutableRoaringArray.MERGE_XOR);
+          return;
         }
       }
     }


### PR DESCRIPTION
In some cases, an in-place OR or XOR could trigger a O(N^2) path. We optimize this away.