### PR TITLE
Fix reverse advanceIfNeeded: cursor can stay above the bound or return a value not in the bitmap

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ArrayContainer.java
@@ -1597,7 +1597,10 @@ final class ReverseArrayContainerCharIterator implements PeekableCharIterator {
 
   @Override
   public void advanceIfNeeded(char maxval) {
-    pos = Util.reverseUntil(parent.content, pos + 1, maxval);
+    // reverseUntil returns 0 both when index 0 is the answer and when nothing qualifies, so
+    // index 0 has to be re-checked: if it is still above maxval, this container is exhausted.
+    int candidate = Util.reverseUntil(parent.content, pos + 1, maxval);
+    pos = (candidate == 0 && parent.content[0] > maxval) ? -1 : candidate;
   }
 
   @Override

--- a/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/BitmapContainer.java
@@ -1918,16 +1918,15 @@ final class ReverseBitmapContainerCharIterator implements PeekableCharIterator {
       }
       long currentWord = bitmap[position];
       currentWord &= ~0L >>> (63 - (maxval & 63));
-      if (position > 0) {
-        while (currentWord == 0) {
-          position--;
-          if (position == 0) {
-            break;
-          }
-          currentWord = bitmap[position];
-        }
+      while (currentWord == 0 && position > 0) {
+        position--;
+        currentWord = bitmap[position];
       }
       word = currentWord;
+      if (currentWord == 0) {
+        // no value at or below maxval in this container
+        position = -1;
+      }
     }
   }
 

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableArrayContainer.java
@@ -1925,7 +1925,10 @@ final class RawReverseArrayContainerCharIterator implements PeekableCharIterator
 
   @Override
   public void advanceIfNeeded(char maxval) {
-    pos = Util.reverseUntil(content, pos + 1, maxval);
+    // reverseUntil returns 0 both when index 0 is the answer and when nothing qualifies, so
+    // index 0 has to be re-checked: if it is still above maxval, this container is exhausted.
+    int candidate = Util.reverseUntil(content, pos + 1, maxval);
+    pos = (candidate == 0 && content[0] > maxval) ? -1 : candidate;
   }
 
   @Override
@@ -1978,7 +1981,10 @@ final class ReverseMappeableArrayContainerCharIterator implements PeekableCharIt
 
   @Override
   public void advanceIfNeeded(char maxval) {
-    pos = BufferUtil.reverseUntil(parent.content, pos + 1, maxval);
+    // reverseUntil returns 0 both when index 0 is the answer and when nothing qualifies, so
+    // index 0 has to be re-checked: if it is still above maxval, this container is exhausted.
+    int candidate = BufferUtil.reverseUntil(parent.content, pos + 1, maxval);
+    pos = (candidate == 0 && parent.content.get(0) > maxval) ? -1 : candidate;
   }
 
   @Override

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/MappeableBitmapContainer.java
@@ -2311,16 +2311,15 @@ final class ReverseMappeableBitmapContainerCharIterator implements PeekableCharI
       }
       long currentWord = parent.bitmap.get(x);
       currentWord &= ~0L >>> (63 - (maxval & 63));
-      if (x > 0) {
-        while (currentWord == 0) {
-          x--;
-          if (x == 0) {
-            break;
-          }
-          currentWord = parent.bitmap.get(x);
-        }
+      while (currentWord == 0 && x > 0) {
+        x--;
+        currentWord = parent.bitmap.get(x);
       }
       w = currentWord;
+      if (currentWord == 0) {
+        // no value at or below maxval in this container
+        x = -1;
+      }
     }
   }
 

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestIterators.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestIterators.java
@@ -361,6 +361,35 @@ public class TestIterators {
   }
 
   @Test
+  public void testSkipReverseBelowEveryValueOfAnArrayContainer() {
+    // the second container is array-backed and every value it holds is above the bound
+    RoaringBitmap bitset = RoaringBitmap.bitmapOf(500, 65536 + 1000, 65536 + 2000);
+
+    PeekableIntIterator bitIt = bitset.getReverseIntIterator();
+    bitIt.advanceIfNeeded(65536 + 700);
+
+    assertEquals(500, bitIt.peekNext());
+    assertEquals(500, bitIt.next());
+  }
+
+  @Test
+  public void testSkipReverseBelowEveryValueOfABitmapContainer() {
+    // a single container, bitmap-backed, whose only value at or below the bound sits in word 0
+    RoaringBitmap bitset = new RoaringBitmap();
+    bitset.add(5);
+    for (int value = 5000; value <= 9200; value++) { // past the array/bitmap threshold
+      bitset.add(value);
+    }
+
+    PeekableIntIterator bitIt = bitset.getReverseIntIterator();
+    bitIt.advanceIfNeeded(4000);
+
+    assertTrue(bitset.contains(bitIt.peekNext()));
+    assertEquals(5, bitIt.peekNext());
+    assertEquals(5, bitIt.next());
+  }
+
+  @Test
   public void testSkipIntoGapsReverse() {
     RoaringBitmap bitset = new RoaringBitmap();
 

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestIterators.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestIterators.java
@@ -6,6 +6,7 @@ package org.roaringbitmap.buffer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.roaringbitmap.CharIterator;
 import org.roaringbitmap.IntIterator;
@@ -268,6 +269,66 @@ public class TestIterators {
       assertEquals(data[i], pii.peekNext());
     }
     bitmap.getReverseIntIterator().advanceIfNeeded(-1); // should not crash
+  }
+
+  @Test
+  public void testSkipReverseBelowEveryValueOfAnArrayContainer() {
+    // the second container is array-backed and every value it holds is above the bound
+    MutableRoaringBitmap bitmap = MutableRoaringBitmap.bitmapOf(500, 65536 + 1000, 65536 + 2000);
+
+    PeekableIntIterator pii = bitmap.getReverseIntIterator();
+    pii.advanceIfNeeded(65536 + 700);
+
+    assertEquals(500, pii.peekNext());
+    assertEquals(500, pii.next());
+  }
+
+  @Test
+  public void testSkipReverseBelowEveryValueOfABitmapContainer() {
+    // a single container, bitmap-backed, whose only value at or below the bound sits in word 0
+    MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+    bitmap.add(5);
+    for (int value = 5000; value <= 9200; value++) { // past the array/bitmap threshold
+      bitmap.add(value);
+    }
+
+    PeekableIntIterator pii = bitmap.getReverseIntIterator();
+    pii.advanceIfNeeded(4000);
+
+    assertTrue(bitmap.contains(pii.peekNext()));
+    assertEquals(5, pii.peekNext());
+    assertEquals(5, pii.next());
+  }
+
+  @Test
+  public void testSkipReverseBelowEveryValueOnDirectBuffer() throws IOException {
+    MutableRoaringBitmap mutable = new MutableRoaringBitmap();
+    mutable.add(5); // container 0, bitmap-backed once past the threshold
+    for (int value = 5000; value <= 9200; value++) {
+      mutable.add(value);
+    }
+    mutable.add(65536 + 1000); // container 1, array-backed
+    mutable.add(65536 + 2000);
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    mutable.serialize(dos);
+    dos.close();
+    byte[] serialized = bos.toByteArray();
+    // a direct buffer is not array-backed, so the Mappeable cursors are used
+    ByteBuffer direct = ByteBuffer.allocateDirect(serialized.length);
+    direct.put(serialized);
+    direct.position(0);
+    ImmutableRoaringBitmap bitmap = new ImmutableRoaringBitmap(direct);
+
+    PeekableIntIterator pii = bitmap.getReverseIntIterator();
+
+    pii.advanceIfNeeded(65536 + 700); // inside container 1, below every value it holds
+    assertEquals(9200, pii.peekNext());
+
+    pii.advanceIfNeeded(4000); // inside container 0, the only match sits in word 0
+    assertTrue(bitmap.contains(pii.peekNext()));
+    assertEquals(5, pii.peekNext());
   }
 
   @Test

--- a/roaringbitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/longlong/TestRoaring64Bitmap.java
@@ -1927,6 +1927,18 @@ public class TestRoaring64Bitmap {
   }
 
   @Test
+  public void testSkipReverseBelowEveryValueOfAnArrayContainer() {
+    // the second container is array-backed and every value it holds is above the bound
+    Roaring64Bitmap bitmap = Roaring64Bitmap.bitmapOf(500L, 65536L + 1000L, 65536L + 2000L);
+
+    PeekableLongIterator pii = bitmap.getReverseLongIterator();
+    pii.advanceIfNeeded(65536L + 700L);
+
+    assertEquals(500L, pii.peekNext());
+    assertEquals(500L, pii.next());
+  }
+
+  @Test
   public void testSkipsDenseReverse() {
     Roaring64Bitmap bitmap = new Roaring64Bitmap();
     int n = 100000;


### PR DESCRIPTION
### Summary

On a reverse iterator, `advanceIfNeeded(bound)` can leave the cursor on a value **greater** than `bound`, and on a bitmap-backed container it can hand back a value that was never added. Reproduced on current master (`ba92f497`).

```java
@Test
void reverseSeekReturnsValueNotInTheBitmap() {
  RoaringBitmap bitmap = new RoaringBitmap();
  bitmap.add(5);
  for (int v = 5000; v <= 9200; v++) { bitmap.add(v); }  // bitmap-backed container

  PeekableIntIterator it = bitmap.getReverseIntIterator();
  it.advanceIfNeeded(4000);

  assertEquals(5, it.peekNext());  // actual: 65535, and bitmap.contains(65535) == false
}

@Test
void reverseSeekStaysAboveTheBound() {
  RoaringBitmap bitmap = RoaringBitmap.bitmapOf(500, 65536 + 1000, 65536 + 2000);

  PeekableIntIterator it = bitmap.getReverseIntIterator();
  it.advanceIfNeeded(65536 + 700);  // inside container 1, below every value it holds

  assertEquals(500, it.peekNext());  // actual: 66536
}
```

Both reproduce identically through `MutableRoaringBitmap` / `ImmutableRoaringBitmap` and through `Roaring64Bitmap.getReverseLongIterator()`.

### Root cause

The bitmap-level seek moves on to the next container only when the container cursor reports itself exhausted. The array and bitmap reverse cursors never do:

- `ReverseArrayContainerCharIterator` delegates to `Util.reverseUntil`, which returns `0` both when index `0` is the answer and when nothing qualifies, so the cursor parks on `content[0]` with `hasNext() == true`.
- `ReverseBitmapContainerCharIterator` leaves its descent loop at `position == 0` *before* reading `bitmap[0]`, and leaves `word == 0` with `position >= 0`. `peekNext()` then computes `(0 + 1) * 64 - (numberOfLeadingZeros(0) + 1)` = `-1`, which narrows to `65535`.

`ReverseRunContainerCharIterator` already walks `pos` down to `-1`, which is why run containers are unaffected.

### Impact

`PeekableCharIterator.advanceIfNeeded` documents that in reverse it "will advance as long as the next value is larger than val". A monotonic reverse seek — the intersection idiom this API exists for — therefore either silently skips values it should have returned, or matches on a value that is in neither bitmap.

### Fix

The five affected cursors, in `ArrayContainer`, `BitmapContainer`, `MappeableArrayContainer` (both the mapped and the array-backed variant) and `MappeableBitmapContainer`. `MappeableBitmapContainer` needs only one because its array-backed path delegates to `BitmapContainer.getReverseShortIterator`. `Util.reverseUntil` / `BufferUtil.reverseUntil` are left alone — their saturating return is asserted by `TestUtil.testReverseUntil` — so the miss is detected at the call site instead.

Regression tests sit next to `testSkipIntoGapsReverse` in `TestIterators`, `buffer/TestIterators` and `TestRoaring64Bitmap`; the direct-buffer one covers the memory-mapped cursors, which the heap-backed path never reaches.

### Automated Checks

- [X] I have run `./gradlew test` and made sure that my PR does not break any unit test.

---

*Disclosure: this change was produced with an agent-assisted workflow, and reviewed by a human before submission. The reproduction was run against current `master`, and each new test was confirmed to fail without the specific fix it covers.*
