### PR TITLE
Fix flyweight iterator clone(): shared cursors make it return values not in the bitmap

### DIFF
--- a/roaringbitmap/src/main/java/org/roaringbitmap/IntIteratorFlyweight.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/IntIteratorFlyweight.java
@@ -47,6 +47,11 @@ public class IntIteratorFlyweight implements PeekableIntIterator {
   public PeekableIntIterator clone() {
     try {
       IntIteratorFlyweight x = (IntIteratorFlyweight) super.clone();
+      // nextContainer() re-wraps the cached cursors in place, so the clone needs its own:
+      // sharing them lets whichever iterator crosses a container first clobber the other.
+      x.arrIter = new ArrayContainerCharIterator();
+      x.bitmapIter = new BitmapContainerCharIterator();
+      x.runIter = new RunContainerCharIterator();
       if (this.iter != null) {
         x.iter = this.iter.clone();
       }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/ReverseIntIteratorFlyweight.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/ReverseIntIteratorFlyweight.java
@@ -47,6 +47,11 @@ public class ReverseIntIteratorFlyweight implements PeekableIntIterator {
   public PeekableIntIterator clone() {
     try {
       ReverseIntIteratorFlyweight x = (ReverseIntIteratorFlyweight) super.clone();
+      // nextContainer() re-wraps the cached cursors in place, so the clone needs its own:
+      // sharing them lets whichever iterator crosses a container first clobber the other.
+      x.arrIter = new ReverseArrayContainerCharIterator();
+      x.bitmapIter = new ReverseBitmapContainerCharIterator();
+      x.runIter = new ReverseRunContainerCharIterator();
       if (this.iter != null) {
         x.iter = this.iter.clone();
       }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/BufferIntIteratorFlyweight.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/BufferIntIteratorFlyweight.java
@@ -51,6 +51,11 @@ public class BufferIntIteratorFlyweight implements PeekableIntIterator {
   public PeekableIntIterator clone() {
     try {
       BufferIntIteratorFlyweight x = (BufferIntIteratorFlyweight) super.clone();
+      // nextContainer() re-wraps the cached cursors in place, so the clone needs its own:
+      // sharing them lets whichever iterator crosses a container first clobber the other.
+      x.arrIter = new MappeableArrayContainerCharIterator();
+      x.bitmapIter = new MappeableBitmapContainerCharIterator();
+      x.runIter = new MappeableRunContainerCharIterator();
       if (this.iter != null) {
         x.iter = this.iter.clone();
       }

--- a/roaringbitmap/src/main/java/org/roaringbitmap/buffer/BufferReverseIntIteratorFlyweight.java
+++ b/roaringbitmap/src/main/java/org/roaringbitmap/buffer/BufferReverseIntIteratorFlyweight.java
@@ -53,6 +53,11 @@ public class BufferReverseIntIteratorFlyweight implements PeekableIntIterator {
   public PeekableIntIterator clone() {
     try {
       BufferReverseIntIteratorFlyweight x = (BufferReverseIntIteratorFlyweight) super.clone();
+      // nextContainer() re-wraps the cached cursors in place, so the clone needs its own:
+      // sharing them lets whichever iterator crosses a container first clobber the other.
+      x.arrIter = new ReverseMappeableArrayContainerCharIterator();
+      x.bitmapIter = new ReverseMappeableBitmapContainerCharIterator();
+      x.runIter = new ReverseMappeableRunContainerCharIterator();
       if (this.iter != null) {
         x.iter = this.iter.clone();
       }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/TestIntIteratorFlyweight.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/TestIntIteratorFlyweight.java
@@ -6,6 +6,7 @@ package org.roaringbitmap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -250,5 +251,38 @@ public class TestIntIteratorFlyweight {
     final List<Integer> iterList = asList(iter);
     final List<Integer> iterCloneList = asList(iterClone);
     assertEquals(iterList.toString(), iterCloneList.toString());
+  }
+
+  /** Two array-backed containers holding different low bits, so both use the same cached cursor. */
+  private static RoaringBitmap twoArrayContainers() {
+    return RoaringBitmap.bitmapOf(10, 20, 30, 65536 + 40, 65536 + 50, 65536 + 60);
+  }
+
+  @Test
+  public void testCloneIsIndependentAcrossContainers() {
+    RoaringBitmap bitmap = twoArrayContainers();
+    IntIteratorFlyweight origin = new IntIteratorFlyweight(bitmap);
+
+    PeekableIntIterator fork = origin.clone();
+    fork.next();
+    fork.next();
+    fork.next(); // the fork moves on to the second container
+
+    assertTrue(bitmap.contains(origin.peekNext()));
+    assertEquals(10, origin.next());
+  }
+
+  @Test
+  public void testReverseCloneIsIndependentAcrossContainers() {
+    RoaringBitmap bitmap = twoArrayContainers();
+    ReverseIntIteratorFlyweight origin = new ReverseIntIteratorFlyweight(bitmap);
+
+    PeekableIntIterator fork = origin.clone();
+    fork.next();
+    fork.next();
+    fork.next(); // the fork moves on to the first container
+
+    assertTrue(bitmap.contains(origin.peekNext()));
+    assertEquals(65536 + 60, origin.next());
   }
 }

--- a/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestIntIteratorFlyweight.java
+++ b/roaringbitmap/src/test/java/org/roaringbitmap/buffer/TestIntIteratorFlyweight.java
@@ -6,6 +6,7 @@ package org.roaringbitmap.buffer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.roaringbitmap.IntIterator;
 import org.roaringbitmap.PeekableIntIterator;
@@ -235,5 +236,38 @@ public class TestIntIteratorFlyweight {
     final List<Integer> reverseIntIteratorCopy = asList(reverseIter);
     assertEquals(ImmutableList.of(1, 2, 3), intIteratorCopy);
     assertEquals(ImmutableList.of(3, 2, 1), reverseIntIteratorCopy);
+  }
+
+  /** Two array-backed containers holding different low bits, so both use the same cached cursor. */
+  private static MutableRoaringBitmap twoArrayContainers() {
+    return MutableRoaringBitmap.bitmapOf(10, 20, 30, 65536 + 40, 65536 + 50, 65536 + 60);
+  }
+
+  @Test
+  public void testCloneIsIndependentAcrossContainers() {
+    MutableRoaringBitmap bitmap = twoArrayContainers();
+    BufferIntIteratorFlyweight origin = new BufferIntIteratorFlyweight(bitmap);
+
+    PeekableIntIterator fork = origin.clone();
+    fork.next();
+    fork.next();
+    fork.next(); // the fork moves on to the second container
+
+    assertTrue(bitmap.contains(origin.peekNext()));
+    assertEquals(10, origin.next());
+  }
+
+  @Test
+  public void testReverseCloneIsIndependentAcrossContainers() {
+    MutableRoaringBitmap bitmap = twoArrayContainers();
+    BufferReverseIntIteratorFlyweight origin = new BufferReverseIntIteratorFlyweight(bitmap);
+
+    PeekableIntIterator fork = origin.clone();
+    fork.next();
+    fork.next();
+    fork.next(); // the fork moves on to the first container
+
+    assertTrue(bitmap.contains(origin.peekNext()));
+    assertEquals(65536 + 60, origin.next());
   }
 }


### PR DESCRIPTION
### Summary

`clone()` on the flyweight iterators returns a cursor that shares mutable state with its origin. Once either side crosses a container boundary it re-wraps a cached cursor the other side is still reading from, and the victim then produces values that were never added to the bitmap. Reproduced on current master (`ba92f497`).

```java
@Test
void cloneIsIndependent() {
  // two array-backed containers with different low bits, so both use the same cached cursor
  RoaringBitmap bitmap = RoaringBitmap.bitmapOf(10, 20, 30, 65536 + 40, 65536 + 50, 65536 + 60);

  IntIteratorFlyweight origin = new IntIteratorFlyweight(bitmap);
  PeekableIntIterator fork = origin.clone();
  fork.next();
  fork.next();
  fork.next();  // the fork moves on to the second container

  assertEquals(10, origin.next());  // actual: 40, and bitmap.contains(40) == false
}
```

The reverse flyweight fails the same way, returning `65566` (`contains(65566) == false`). Both reproduce identically for `BufferIntIteratorFlyweight` / `BufferReverseIntIteratorFlyweight`.

### Root cause

Each flyweight caches one reusable cursor per container shape as an instance field — that is the point of the class. `clone()` delegates to `Object.clone()`, which copies those three *references*, so origin and fork share the cursor objects. The existing `x.iter = this.iter.clone()` repairs only the currently active one, so the defect stays hidden until `nextContainer()` re-wraps a cached cursor in place:

```java
arrIter.wrap((ArrayContainer) container);  // may be the object the other iterator is reading
iter = arrIter;
```

The origin then reads the second container's low bits while `hs` still holds the first container's high bits, and manufactures a value from two different containers.

### Prior art in this codebase

`RoaringBatchIterator.clone()` already handles exactly this, by giving the clone its own cached iterators:

```java
it.arrayBatchIterator = null;
it.bitmapBatchIterator = null;
it.runBatchIterator = null;
```

The flyweights simply never got the same treatment. `RoaringBitmap.getIntIterator().clone()` is also unaffected, because it allocates a fresh cursor per container rather than caching.

### Why the existing tests pass

`testClone` uses `bitmapOf(1, 2, 3, 4, 5)` — a single container, so no boundary is ever crossed and no cached cursor is ever re-wrapped. `testIterationFromBitmapClone` clones and then discards the origin, only ever consuming the clone. Interleaved use of origin and fork across a boundary — the thing a clone is for — is untested.

### Fix

The four flyweights each give the clone its own cached cursors, mirroring `RoaringBatchIterator`. `next()` is untouched, so the allocation-free iteration the class exists for is unaffected; the three extra allocations happen only on `clone()`.

### Automated Checks

- [X] I have run `./gradlew test` and made sure that my PR does not break any unit test.

---

*Disclosure: this change was produced with an agent-assisted workflow, and reviewed by a human before submission. The reproduction was run against current `master`, and each new test was confirmed to fail without the fix.*
